### PR TITLE
Modify the method to judge the existence of the folder

### DIFF
--- a/site/AntBlazor.Docs.Build.CLI/Command/GenerateMenuJsonCommand.cs
+++ b/site/AntBlazor.Docs.Build.CLI/Command/GenerateMenuJsonCommand.cs
@@ -64,14 +64,14 @@ namespace AntBlazor.Docs.Build.CLI.Command
         private void GenerateFiles(string demoDirectory, string docsDirectory, string output)
         {
             DirectoryInfo demoDirectoryInfo = new DirectoryInfo(demoDirectory);
-            if (demoDirectoryInfo.Attributes != FileAttributes.Directory)
+            if (!demoDirectoryInfo.Exists)
             {
                 Console.WriteLine("{0} is not a directory", demoDirectory);
                 return;
             }
 
             DirectoryInfo docsDirectoryInfo = new DirectoryInfo(docsDirectory);
-            if (docsDirectoryInfo.Attributes != FileAttributes.Directory)
+            if (!docsDirectoryInfo.Exists)
             {
                 Console.WriteLine("{0} is not a directory", docsDirectory);
                 return;


### PR DESCRIPTION
如果使用 Attributes  判断的时候，需要使用 HasFlag 的方法判断，因为这个值可能是多个值合并的

但是使用 HasFlag 的方法判断不够直观，于是就修改为 Exist 方法