### PR TITLE
Fix multi thread unsafe use method

### DIFF
--- a/site/AntBlazor.Docs/Services/ConcurrentCache.cs
+++ b/site/AntBlazor.Docs/Services/ConcurrentCache.cs
@@ -51,8 +51,10 @@ namespace AntBlazor.Docs.Services
         {
             get
             {
-                if (dictionary.ContainsKey(key))
-                    return dictionary[key].Value;
+                if (dictionary.TryGetValue(key, out var lazy))
+                {
+                    return lazy.Value;
+                }
 
                 return default(TValue);
             }


### PR DESCRIPTION
When judging whether the value exists, the value still exists. But when getting the value, the value is killed by other threads


原先在 1 线程判断存在，在准备调用 dictionary[key].Value 返回的时候，在 2 线程更改删除了这个内容