### PR TITLE
Fix: Remove "Danger" from Button Type

### DIFF
--- a/components/button/AntButton.razor.cs
+++ b/components/button/AntButton.razor.cs
@@ -66,7 +66,7 @@ namespace AntBlazor
             ClassMapper.Clear()
                 .Add("ant-btn")
                 .If($"{prefixName}-{this.Type}", () => !string.IsNullOrEmpty(Type))
-                 .If($"{prefixName}-danger", () => Danger)
+                 .If($"{prefixName}-dangerous", () => Danger)
                 .If($"{prefixName}-{Shape}", () => !string.IsNullOrEmpty(Shape))
                 .If($"{prefixName}-{sizeMap[this.Size]}", () => sizeMap.ContainsKey(Size))
                 .If($"{prefixName}-loading", () => Loading)

--- a/components/button/AntButtonType.cs
+++ b/components/button/AntButtonType.cs
@@ -10,7 +10,6 @@ namespace AntBlazor
         public const string Default = "default";
         public const string Primary = "primary";
         public const string Dashed = "dashed";
-        public const string Danger = "danger";
         public const string Link = "link";
     }
 }

--- a/site/AntBlazor.Docs/Demos/Button/demo/Basic.razor
+++ b/site/AntBlazor.Docs/Demos/Button/demo/Basic.razor
@@ -2,6 +2,5 @@
     <AntButton Type="primary">Primary</AntButton>
     <AntButton>Default</AntButton>
     <AntButton Type="dashed">Dashed</AntButton>
-    <AntButton Type="danger">Danger</AntButton>
     <AntButton Type="link">Link</AntButton>
 </div>

--- a/site/AntBlazor.Docs/Pages/Button.razor
+++ b/site/AntBlazor.Docs/Pages/Button.razor
@@ -31,7 +31,6 @@
         <AntButton Type="@AntButtonType.Primary">Primary</AntButton>
         <AntButton>Default</AntButton>
         <AntButton Type="@AntButtonType.Dashed">Dashed</AntButton>
-        <AntButton Type="@AntButtonType.Danger">Danger</AntButton>
         <AntButton Type="@AntButtonType.Link">Link</AntButton>
     </Demo>
 </DemoCard>
@@ -78,7 +77,6 @@
             <AntButton Size="@size"> Default </AntButton>
             <AntButton Size="@size" Type="@AntButtonType.Primary">Primary</AntButton>
             <AntButton Size="@size" Type="@AntButtonType.Dashed">Dashed</AntButton>
-            <AntButton Size="@size" Type="@AntButtonType.Danger">Danger</AntButton>
             <AntButton Size="@size" Type="@AntButtonType.Link">Link</AntButton>
         </div>
     </Demo>


### PR DESCRIPTION
This is according to Ant Design latest documentation. Also fixed "danger link button" not in correct color. 