### PR TITLE
Make github main language as C#

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -62,5 +62,4 @@
 #*.rtf   diff=astextplain
 #*.RTF   diff=astextplain
 
-*.less linguist-language=C#
-*.css linguist-language=C#
+*.razor linguist-language=C#

--- a/.gitattributes
+++ b/.gitattributes
@@ -61,3 +61,6 @@
 #*.PDF   diff=astextplain
 #*.rtf   diff=astextplain
 #*.RTF   diff=astextplain
+
+*.less linguist-language=C#
+*.css linguist-language=C#


### PR DESCRIPTION
Hi Team:
I found this project is marked as `CSS` project in github. So I create this pr to make github use `C#` as main language.

This pr will make `.css` and `.less` file list as C#, after apply these changes, the github display will as below:
![image](https://user-images.githubusercontent.com/10071911/82790802-41412b00-9e9f-11ea-8ece-abf24cea8b7c.png)
