### PR TITLE
Fix: Search component wait time

### DIFF
--- a/components/input/Search.razor.cs
+++ b/components/input/Search.razor.cs
@@ -96,7 +96,6 @@ namespace AntDesign
             {
                 await OnSearch.InvokeAsync(EventArgs.Empty);
             }
-            await Task.Delay(TimeSpan.FromSeconds(10));
             _isSearching = false;
             StateHasChanged();
         }


### PR DESCRIPTION
已经使用await进行了等待，没有必要固定等待10秒，而且查询请求也无法固定成10秒。
I have used "await" to wait, there is no need to wait for 10 seconds, and the query request cannot be fixed to 10 seconds.