### PR TITLE
Update docs path in debug build

### DIFF
--- a/site/AntBlazor.Docs/AntDesign.Docs.csproj
+++ b/site/AntBlazor.Docs/AntDesign.Docs.csproj
@@ -55,7 +55,7 @@
     <Exec WorkingDirectory="$(SolutionDir)" Command="dotnet build $(CLIProjectDir)" />
     <Exec WorkingDirectory="$(SolutionDir)" Command="dotnet $(CLIPath) demo2json $(ProjectDir)Demos $(ProjectDir)wwwroot/meta" />
     <Exec WorkingDirectory="$(SolutionDir)" Command="dotnet $(CLIPath) menu2json $(ProjectDir)Demos docs $(ProjectDir)wwwroot/meta" />
-    <Exec WorkingDirectory="$(SolutionDir)" Command="dotnet $(CLIPath) docs2html $(SolutionDir)docs $(ProjectDir)wwwroot/docs" />
+    <Exec WorkingDirectory="$(SolutionDir)" Command="dotnet $(CLIPath) docs2html docs $(ProjectDir)wwwroot/docs" />
   </Target>
 
   <Target Name="PublishRunGulp" AfterTargets="ComputeFilesToPublish">


### PR DESCRIPTION
The current WorkingDirectory is set to $(SolutionDir) whilst $(SolutionDir)docs results in ../../docs


Steps to reproduce issue this fixes:

```
git clone https://github.com/ant-design-blazor/ant-design-blazor
npm install
npm start
----
/home/kieran/ant-design-blazor/site/AntBlazor.Docs/AntDesign.Docs.csproj(58,5): error MSB3073: The command "dotnet site/AntDesign.Docs.Build.CLI/bin/Debug/netcoreapp3.1/AntDesign.Docs.Build.CLI.dll docs2html ../../docs /home/kieran/ant-design-blazor/site/AntBlazor.Docs/wwwroot/docs" exited with code 1.
```