### PR TITLE
feat: clearall method to clear all items in the list

### DIFF
--- a/components/select/Select.razor.cs
+++ b/components/select/Select.razor.cs
@@ -244,6 +244,15 @@ namespace AntDesign
                 _ => SelectMode == SelectMode.Default ? OneOf<string, RenderFragment>.FromT1((option?.ChildContent)) : option?.Label ?? option.Value,
             };
         }
+
+        protected async Task ResetState()
+        {
+            Value = null;
+            SelectedOptions.Clear();
+            OnChange?.Invoke(default, default(SelectOption));
+
+            await InvokeAsync(StateHasChanged);
+        }
         #endregion
 
         #region  Events
@@ -377,11 +386,7 @@ namespace AntDesign
 
         protected async Task OnClearClick(MouseEventArgs _)
         {
-            Value = null;
-            SelectedOptions.Clear();
-            OnChange?.Invoke(default, default(SelectOption));
-
-            await InvokeAsync(StateHasChanged);
+            await ResetState();
         }
 
         protected async void OnInput(ChangeEventArgs e)
@@ -863,6 +868,11 @@ namespace AntDesign
                 }
             }
             return true;
+        }
+
+        public async Task ClearAll()
+        {
+            await ResetState();
         }
         #endregion
         #endregion

--- a/site/AntBlazor.Docs/Demos/Select/demo/ClearValues.razor
+++ b/site/AntBlazor.Docs/Demos/Select/demo/ClearValues.razor
@@ -1,0 +1,42 @@
+﻿<Select @ref="select" Mode="tags"
+        Style="width: 100%"
+        Placeholder="Tags Mode" Value="@selectedItems" AllowClear=true>
+    @foreach (var item in _items)
+    {
+        <SelectOption Value="@item">@item</SelectOption>
+    }
+</Select>
+
+<Button OnClick="Reset">
+    Reset
+</Button>
+
+@using OneOf;
+@code
+{
+    Select select;
+    private string[] _items;
+    private OneOf<string, IEnumerable<string>, LabeledValue, IEnumerable<LabeledValue>> selectedItems = new List<string>();
+
+    protected override void OnInitialized()
+    {
+        var min = 10;
+        var max = 36;
+        _items = new string[max - min];
+        for (var i = min; max > i; i++)
+        {
+            _items[i - min] = Convert.ToString(i, 16).PadLeft(2, '0') + i.ToString();
+        }
+    }
+
+    private async Task Reset(MouseEventArgs args)
+    {
+        var values = selectedItems.AsT1.ToList();
+        Console.WriteLine("Before delete count: " + values.Count());
+        values.Clear();
+        selectedItems = values;
+
+        await select.ClearAll();
+        Console.WriteLine("After delete count: " + selectedItems.AsT1.Count());
+    }
+}

--- a/site/AntBlazor.Docs/Demos/Select/demo/clear-values.md
+++ b/site/AntBlazor.Docs/Demos/Select/demo/clear-values.md
@@ -1,34 +1,15 @@
 ---
 order: 55
 title:
-  zh-CN: 无边框
-  en-US: Clear-values
+  zh-CN: 清空已选项
+  en-US: Clear Values
 ---
 
 ## zh-CN
 
-无边框样式。
+调用 `ClearAll()` 方法来清空已选项。
 
 ## en-US
 
-Clear-values style component.
+Call the `ClearAll()` method to clear values.
 
-```jsx
-import { Select } from 'antd';
-
-const { Option } = Select;
-
-ReactDOM.render(
-  <>
-    <Select defaultValue="lucy" style={{ width: 120 }} bordered={false}>
-      <Option value="jack">Jack</Option>
-      <Option value="lucy">Lucy</Option>
-      <Option value="Yiminghe">yiminghe</Option>
-    </Select>
-    <Select defaultValue="lucy" style={{ width: 120 }} disabled bordered={false}>
-      <Option value="lucy">Lucy</Option>
-    </Select>
-  </>,
-  mountNode,
-);
-```

--- a/site/AntBlazor.Docs/Demos/Select/demo/clear-values.md
+++ b/site/AntBlazor.Docs/Demos/Select/demo/clear-values.md
@@ -1,0 +1,34 @@
+---
+order: 55
+title:
+  zh-CN: 无边框
+  en-US: Clear-values
+---
+
+## zh-CN
+
+无边框样式。
+
+## en-US
+
+Clear-values style component.
+
+```jsx
+import { Select } from 'antd';
+
+const { Option } = Select;
+
+ReactDOM.render(
+  <>
+    <Select defaultValue="lucy" style={{ width: 120 }} bordered={false}>
+      <Option value="jack">Jack</Option>
+      <Option value="lucy">Lucy</Option>
+      <Option value="Yiminghe">yiminghe</Option>
+    </Select>
+    <Select defaultValue="lucy" style={{ width: 120 }} disabled bordered={false}>
+      <Option value="lucy">Lucy</Option>
+    </Select>
+  </>,
+  mountNode,
+);
+```


### PR DESCRIPTION
I have to clear all selected tag values in the input filed of a select component in the form. So, I made a couple of changes in the base code of the Select component. Here are the explanations of changes.

1. ClearAll() method
    Exposed method to a parent component.
2. ResetState() method
    I made this method to avoid code duplicate of OnClearClick and ClearAll methods. It is always a better approach to have one main method for two or more same actions.
3. Removed all code of OnClearClick() method and called ResetState() method.

Please, notice that the md Select/demo/clear-values.md file should be rewritten based on the appropriate documentation. I just copied it from the bordered.md, but you know better than me what should be in there.

I am open to any kinds of suggestions. :) 

Kind regards,
Ratomir

