### PR TITLE
fix: input and textarea bug

### DIFF
--- a/components/input/Input.cs
+++ b/components/input/Input.cs
@@ -202,7 +202,6 @@ namespace AntDesign
             }
         }
 
-        protected string _preInputValue;
         /// <summary>
         /// Invoked when user add/remove content
         /// </summary>
@@ -212,7 +211,7 @@ namespace AntDesign
         {
             bool flag = !(!string.IsNullOrEmpty(Value?.ToString()) && args != null && !string.IsNullOrEmpty(args.Value.ToString()));
 
-            _preInputValue = args?.Value?.ToString();
+            CurrentValueAsString = args?.Value?.ToString();
 
             if (_allowClear && flag)
             {
@@ -223,20 +222,6 @@ namespace AntDesign
             {
                 await OnInput.InvokeAsync(args);
             }
-        }
-
-        private DateTime _preKeyUpTime = DateTime.Now;
-        protected virtual async void OnKeyUp(KeyboardEventArgs args)
-        {
-            _preKeyUpTime = DateTime.Now;
-
-            // Avoid frequent refreshes
-            while (DateTime.Now.Ticks - _preKeyUpTime.Ticks < 500000)
-            {
-                await Task.Delay(50);
-            }
-
-            CurrentValueAsString = _preInputValue;
         }
 
         protected override void BuildRenderTree(RenderTreeBuilder builder)
@@ -318,7 +303,6 @@ namespace AntDesign
                 builder.AddAttribute(i++, "oninput", CallbackFactory.Create(this, OnInputAsync));
                 builder.AddAttribute(i++, "onblur", CallbackFactory.Create(this, OnBlurAsync));
                 builder.AddAttribute(i++, "onfocus", CallbackFactory.Create(this, OnFocus));
-                builder.AddAttribute(i++, "onkeyup", CallbackFactory.Create(this, OnKeyUp));
                 builder.AddElementReferenceCapture(i++, r => Ref = r);
                 builder.CloseElement();
 

--- a/components/input/TextArea.razor.cs
+++ b/components/input/TextArea.razor.cs
@@ -88,14 +88,12 @@ namespace AntDesign
         protected override async void OnInputAsync(ChangeEventArgs args)
         {
             // do not call base method to avoid lost focus
-            //base.OnInputAsync(args);
+            base.OnInputAsync(args);
 
-            _preInputValue = args?.Value?.ToString();
-
-            if (OnChange.HasDelegate)
-            {
-                await OnChange.InvokeAsync(CurrentValueAsString);
-            }
+            //if (OnChange.HasDelegate)
+            //{
+            //    await OnChange.InvokeAsync(CurrentValueAsString);
+            //}
 
             if (AutoSize)
             {


### PR DESCRIPTION
1、Input的value延迟更新功能会导致Input的OnInput事件异常，TextArea数据绑定失效，所以我删除了此功能
2、我任务在TextArea的OnInputAsync函数中不应该触发OnChange事件
3、我测试没有发现TextArea中调用base.OnInputAsync(args)存在失去焦点问题。