### PR TITLE
refactor(module: statistic): simplify format string for countdown

### DIFF
--- a/components/statistic/CountDown.razor
+++ b/components/statistic/CountDown.razor
@@ -1,5 +1,4 @@
 ﻿@namespace AntDesign
-@using AntDesign.Helpers
 @inherits StatisticComponentBase<DateTime>
 
 <div class="ant-statistic" style="@Style" @ref="Ref" id="@Id">

--- a/components/statistic/CountDown.razor
+++ b/components/statistic/CountDown.razor
@@ -1,5 +1,5 @@
 ﻿@namespace AntDesign
-@using System.Globalization
+@using AntDesign.Helpers
 @inherits StatisticComponentBase<DateTime>
 
 <div class="ant-statistic" style="@Style" @ref="Ref" id="@Id">
@@ -14,7 +14,7 @@
             </span>
         }
         <span class="ant-statistic-content-value">
-            @_countDown.ToString(_format, CultureInfo.InvariantCulture)
+            @(_countDown.ToString(_format))
         </span>
         @if (@Suffix.IsT0 && !string.IsNullOrEmpty(@Suffix.AsT0) || @Suffix.IsT1 && @Suffix.AsT1 != null)
         {

--- a/components/statistic/CountDown.razor.cs
+++ b/components/statistic/CountDown.razor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text.RegularExpressions;
 using System.Threading;
 using Microsoft.AspNetCore.Components;
 
@@ -6,9 +7,11 @@ namespace AntDesign
 {
     public partial class CountDown : StatisticComponentBase<DateTime>
     {
-        [Parameter] public string Format { get; set; } = @"hh\:mm\:ss";
+        [Parameter]
+        public string Format { get; set; } = "hh:mm:ss";
 
-        [Parameter] public EventCallback OnFinish { get; set; }
+        [Parameter]
+        public EventCallback OnFinish { get; set; }
 
         private Timer _timer;
 
@@ -17,9 +20,24 @@ namespace AntDesign
         private TimeSpan _countDown = TimeSpan.Zero;
         private string _format = "";
 
+        /// <summary>
+        /// parse other characters in format string.
+        /// </summary>
+        /// <remarks>refer to https://docs.microsoft.com/en-us/dotnet/standard/base-types/custom-timespan-format-strings#other-characters</remarks>
+        /// <param name="format"></param>
+        /// <returns></returns>
+        private static string ParseSpanTimeFormatString(string format)
+        {
+            if (string.IsNullOrWhiteSpace(format))
+            {
+                return format;
+            }
+            return Regex.Replace(format, "[^d|^h|^m|^s|^f|^F]+", "'$0'");
+        }
+
         protected override void OnInitialized()
         {
-            _format = Format;
+            _format = ParseSpanTimeFormatString(Format);
             _countDown = Value - DateTime.Now;
             _timer = new Timer(StartCountDownForTimeSpan);
             _timer.Change(0, REFRESH_INTERVAL);
@@ -32,7 +50,10 @@ namespace AntDesign
             {
                 _countDown = TimeSpan.Zero;
                 _timer.Dispose();
-                OnFinish.InvokeAsync(o);
+                if (OnFinish.HasDelegate)
+                {
+                    OnFinish.InvokeAsync(o);
+                }
             }
 
             InvokeStateHasChanged();

--- a/site/AntBlazor.Docs/Demos/Statistic/demo/Countdown.razor
+++ b/site/AntBlazor.Docs/Demos/Statistic/demo/Countdown.razor
@@ -4,10 +4,10 @@
         <CountDown Title="@("Countdown")" Value="@deadline" OnFinish="OnFinish" />
     </Col>
     <Col Span="12">
-        <CountDown Title="@("Million")" Value="@deadline" Format="hh\:mm\:ss\:fff" />
+        <CountDown Title="@("Million")" Value="@deadline" Format="hh:mm:ss:fff" />
     </Col>
     <Col Span="24">
-        <CountDown Title="@("Day Level")" Value="@deadline" Format="dd\ \天\ h\ \小\时\ m\ \分\钟\ s\ \秒" />
+        <CountDown Title="@("Day Level")" Value="@deadline" Format="dd 天  h 小时 m 分钟 s 秒" />
     </Col>
 </Row>
 


### PR DESCRIPTION
Let users does not need to handle any other unescaped character in a format string any more.

https://docs.microsoft.com/en-us/dotnet/standard/base-types/custom-timespan-format-strings#other-characters