### PR TITLE
refactor: improve input and textarea

### DIFF
--- a/components/core/EventCallbackArgs/OnResizeEventArgs.cs
+++ b/components/core/EventCallbackArgs/OnResizeEventArgs.cs
@@ -1,0 +1,9 @@
+﻿
+namespace AntDesign
+{
+    public class OnResizeEventArgs
+    {
+        public int Width { get; set; }
+        public int Height { get; set; }
+    }
+}

--- a/components/input/TextArea.razor
+++ b/components/input/TextArea.razor
@@ -2,10 +2,40 @@
 @inherits Input<string>
 <!--TODO: minheight, maxheight, onResize-->
 
-<textarea class="@ClassMapper.Class" style="@Style" @attributes="Attributes" id="@Id" placeholder="@Placeholder" value="@CurrentValueAsString"
-          @ref="Ref"
-          @oninput="OnInputAsync"
-          @onkeypress="OnPressEnterAsync" />
+@{
+    Dictionary<string, object> attributes =
+        new Dictionary<string, object>()
+        {
+            { "onchange", CallbackFactory.Create(this, OnChangeAsync) },
+            { "onblur", CallbackFactory.Create(this, OnBlur) },
+            { "oninput", CallbackFactory.Create(this, OnInputAsync) },
+            { "onkeypress", CallbackFactory.Create(this, OnPressEnterAsync) },
+            { "onfocus", CallbackFactory.Create(this, OnFocus) },
+            { "onkeyup", CallbackFactory.Create(this, OnKeyUp) },
+            { "value", CurrentValueAsString },
+            { "placeholder", Placeholder },
+            { "id", Id },
+            { "style", Style },
+            { "class", ClassMapper.Class },
+                    };
+
+    if (Attributes != null)
+    {
+        Attributes.Keys.ForEach(key => { attributes[key] = Attributes[key]; });
+    }
+}
+
+@if (Suffix != null)
+{
+    <span class=@($"{PrefixCls}-affix-wrapper {PrefixCls}-affix-wrapper-textarea-with-clear-btn")>
+        <textarea @ref="Ref" @attributes="attributes" />
+        @Suffix
+    </span>
+}
+else
+{
+    <textarea @ref="Ref" @attributes="attributes" />
+}
 
 @if (AutoSize)
 {

--- a/components/input/TextArea.razor.cs
+++ b/components/input/TextArea.razor.cs
@@ -73,7 +73,7 @@ namespace AntDesign
         }
 
         [Parameter]
-        public EventCallback<object> OnResize { get; set; }
+        public EventCallback<OnResizeEventArgs> OnResize { get; set; }
 
         protected async override Task OnFirstAfterRenderAsync()
         {
@@ -87,13 +87,7 @@ namespace AntDesign
 
         protected override async void OnInputAsync(ChangeEventArgs args)
         {
-            // do not call base method to avoid lost focus
             base.OnInputAsync(args);
-
-            //if (OnChange.HasDelegate)
-            //{
-            //    await OnChange.InvokeAsync(CurrentValueAsString);
-            //}
 
             if (AutoSize)
             {
@@ -112,15 +106,22 @@ namespace AntDesign
             // do not use %mod in case _rowheight is not an integer
             uint rows = (uint)(element.scrollHeight / _rowHeight);
             rows = Math.Max((uint)MinRows, rows);
+
+            int height = 0;
             if (rows > MaxRows)
             {
                 rows = MaxRows;
-                Style = $"height: {rows * _rowHeight + _offsetHeight}px;";
+
+                height = (int)(rows * _rowHeight + _offsetHeight);
+                Style = $"height: {height}px;";
             }
             else
             {
-                Style = $"height: {rows * _rowHeight + _offsetHeight}px;overflow-y: hidden;";
+                height = (int)(rows * _rowHeight + _offsetHeight);
+                Style = $"height: {height}px;overflow-y: hidden;";
             }
+
+            await OnResize.InvokeAsync(new OnResizeEventArgs { Width = element.scrollWidth, Height = height });
         }
 
         private async Task CalculateRowHeightAsync()
@@ -151,6 +152,11 @@ namespace AntDesign
             Value = str;
             StateHasChanged();
             await ChangeSizeAsync();
+        }
+
+        protected override string GetClearIconCls()
+        {
+            return $"{PrefixCls}-textarea-clear-icon";
         }
     }
 }

--- a/site/AntBlazor.Docs/Demos/Input/demo/Area.razor
+++ b/site/AntBlazor.Docs/Demos/Input/demo/Area.razor
@@ -1,13 +1,20 @@
-﻿<div>
-    <TextArea Placeholder="Autosize height based on content lines" AutoSize="true" @bind-Value="@txtValue"/>
+﻿@using AntDesign;
+
+<div>
+    <TextArea Placeholder="Autosize height based on content lines" AutoSize="true" OnResize="OnResize" @bind-Value="@txtValue"/>
     <br />
     <br />
-    <TextArea Placeholder="Autosize height based on content lines" MinRows="2" MaxRows="6" @bind-Value="@txtValue"/>
+    <TextArea Placeholder="Autosize height based on content lines" MinRows="2" MaxRows="6" OnResize="OnResize" @bind-Value="@txtValue"/>
     <br />
     <br />
-    <TextArea Placeholder="Autosize height based on content lines" MinRows="3" MaxRows="5" @bind-Value="@txtValue"/>
+    <TextArea Placeholder="Autosize height based on content lines" MinRows="3" MaxRows="5" OnResize="OnResize" @bind-Value="@txtValue"/>
 </div>
 
 @code{
     string txtValue { get; set; }
+
+    private void OnResize(OnResizeEventArgs args)
+    {
+        Console.WriteLine($"OnResizeEvent width:{args.Width},height:{args.Height}");
+    }
 }


### PR DESCRIPTION
1. Input BuildRenderTree: hardcode the arguments for sequence numbers.
Using a calculation or counter to generate the sequence number can lead to poor performance. [see the doc](https://docs.microsoft.com/zh-cn/aspnet/core/blazor/advanced-scenarios?view=aspnetcore-3.1#manual-rendertreebuilder-logic)

2. TextArea feat: support AllowClear、OnResize
3. TextArea fix:  fix the bugs(which [pr308](https://github.com/ant-design-blazor/ant-design-blazor/pull/308) had fix) in a better way
