### PR TITLE
fix: children components dispose

### DIFF
--- a/components/anchor/Anchor.razor.cs
+++ b/components/anchor/Anchor.razor.cs
@@ -165,6 +165,11 @@ namespace AntDesign
             }
         }
 
+        public void Remove(AnchorLink anchorLink)
+        {
+            _links.Remove(anchorLink);
+        }
+
         public void Add(AnchorLink anchorLink)
         {
             if (!_links.Where(l => !string.IsNullOrEmpty(l.Href))
@@ -280,5 +285,6 @@ namespace AntDesign
             // forced to render when user click on another link that is at the same height with the previously activated dom
             StateHasChanged();
         }
+
     }
 }

--- a/components/anchor/Anchor.razor.cs
+++ b/components/anchor/Anchor.razor.cs
@@ -113,19 +113,17 @@ namespace AntDesign
 
         #endregion Parameters
 
-        protected override void OnInitialized()
-        {
-            base.OnInitialized();
-
-            if (GetCurrentAnchor is null)
-            {
-                DomEventService.AddEventListener("window", "scroll", OnScroll);
-            }
-        }
-
-        protected async override Task OnAfterRenderAsync(bool firstRender)
+        protected override async Task OnAfterRenderAsync(bool firstRender)
         {
             await base.OnAfterRenderAsync(firstRender);
+
+            if (firstRender)
+            {
+                if (GetCurrentAnchor is null)
+                {
+                    DomEventService.AddEventListener("window", "scroll", OnScroll);
+                }
+            }
 
             if (firstRender || _linksChanged)
             {
@@ -285,6 +283,5 @@ namespace AntDesign
             // forced to render when user click on another link that is at the same height with the previously activated dom
             StateHasChanged();
         }
-
     }
 }

--- a/components/anchor/AnchorLink.razor.cs
+++ b/components/anchor/AnchorLink.razor.cs
@@ -68,6 +68,12 @@ namespace AntDesign
 
         internal string _hash = string.Empty;
 
+        protected override void Dispose(bool disposing)
+        {
+            _parent?.Remove(this);
+            base.Dispose(disposing);
+        }
+
         protected override void OnInitialized()
         {
             base.OnInitialized();
@@ -92,6 +98,11 @@ namespace AntDesign
                 _hrefDomExist = true;
             }
             catch { }
+        }
+
+        public void Remove(AnchorLink anchorLink)
+        {
+            _links.Remove(anchorLink);
         }
 
         public void Add(AnchorLink anchorLink)

--- a/components/anchor/IAnchor.cs
+++ b/components/anchor/IAnchor.cs
@@ -10,6 +10,7 @@ namespace AntDesign
     {
         //List<AnchorLink> Links { get; }
         void Add(AnchorLink anchorLink);
+        void Remove(AnchorLink anchorLink);
 
         void Clear();
 

--- a/components/carousel/Carousel.razor.cs
+++ b/components/carousel/Carousel.razor.cs
@@ -123,6 +123,11 @@ namespace AntDesign
             }
         }
 
+        internal void RemoveSlick(CarouselSlick slick)
+        {
+            _slicks.Remove(slick);
+        }
+
         internal void AddSlick(CarouselSlick slick)
         {
             _slicks.Add(slick);

--- a/components/carousel/Carousel.razor.cs
+++ b/components/carousel/Carousel.razor.cs
@@ -156,19 +156,22 @@ namespace AntDesign
                 index = 0;
             }
 
-            CarouselSlick slick = _slicks[index];
-            _slicks.ForEach(s =>
+            if (_slicks.Count > 0)
             {
-                if (s == slick)
+                CarouselSlick slick = _slicks[index];
+                _slicks.ForEach(s =>
                 {
-                    _activeSlick = s;
-                    s.Activate();
-                }
-                else
-                {
-                    s.Deactivate();
-                }
-            });
+                    if (s == slick)
+                    {
+                        _activeSlick = s;
+                        s.Activate();
+                    }
+                    else
+                    {
+                        s.Deactivate();
+                    }
+                });
+            }
 
             return index;
         }

--- a/components/carousel/CarouselSlick.cs
+++ b/components/carousel/CarouselSlick.cs
@@ -45,6 +45,12 @@ namespace AntDesign
 
         #endregion Parameters
 
+        protected override void Dispose(bool disposing)
+        {
+            Parent.RemoveSlick(this);
+            base.Dispose(disposing);
+        }
+
         private void OnParentSet()
         {
             Parent.AddSlick(this);

--- a/components/checkbox/Checkbox.razor.cs
+++ b/components/checkbox/Checkbox.razor.cs
@@ -56,6 +56,16 @@ namespace AntDesign
             Value = Checked;
         }
 
+        protected override void Dispose(bool disposing)
+        {
+            if (this is Checkbox checkbox)
+            {
+                CheckboxGroup?.CheckboxItems.Remove(checkbox);
+            }
+
+            base.Dispose(disposing);
+        }
+
         protected void SetClass()
         {
             string prefixName = "ant-checkbox";

--- a/components/descriptions/DescriptionsItem.razor.cs
+++ b/components/descriptions/DescriptionsItem.razor.cs
@@ -21,6 +21,12 @@ namespace AntDesign
         [CascadingParameter]
         public Descriptions Descriptions { get; set; }
 
+        protected override void Dispose(bool disposing)
+        {
+            this.Descriptions?.Items.Remove(this);
+            base.Dispose(disposing);
+        }
+
         protected override void OnInitialized()
         {
             this.Descriptions?.Items.Add(this);

--- a/components/icon/Icon.razor.cs
+++ b/components/icon/Icon.razor.cs
@@ -58,6 +58,15 @@ namespace AntDesign
 
         protected string IconStyle => Rotate == 0 ? "" : $"transform: rotate({Rotate}deg);";
 
+        protected override void Dispose(bool disposing)
+        {
+            if (this is Icon icon)
+            {
+                Button?.Icons.Remove(icon);
+            }
+            base.Dispose(disposing);
+        }
+
         protected override async Task OnInitializedAsync()
         {
             if (Type == "loading")

--- a/components/mentions/Mentions.razor.cs
+++ b/components/mentions/Mentions.razor.cs
@@ -209,6 +209,11 @@ namespace AntDesign
             return lst;
         }
 
+        public void RemoveOption(MentionsOption option)
+        {
+            LstOriginalOptions.Remove(option);
+        }
+
         public void AddOption(MentionsOption option)
         {
             if (option == null) return;

--- a/components/mentions/MentionsOption.razor.cs
+++ b/components/mentions/MentionsOption.razor.cs
@@ -18,6 +18,12 @@ namespace AntDesign
 
         public bool Active { get; set; }
 
+        protected override void Dispose(bool disposing)
+        {
+            Mentions?.RemoveOption(this);
+            base.Dispose(disposing);
+        }
+
         protected override void OnInitialized()
         {
             Mentions?.AddOption(this);

--- a/components/menu/MenuItem.razor.cs
+++ b/components/menu/MenuItem.razor.cs
@@ -51,6 +51,12 @@ namespace AntDesign
                 .If($"{prefixCls}-disabled", () => Disabled);
         }
 
+        protected override void Dispose(bool disposing)
+        {
+            RootMenu.MenuItems.Remove(this);
+            base.Dispose(disposing);
+        }
+
         protected override void OnInitialized()
         {
             base.OnInitialized();

--- a/components/radio/Radio.razor.cs
+++ b/components/radio/Radio.razor.cs
@@ -82,6 +82,12 @@ namespace AntDesign
             base.OnInitialized();
         }
 
+        protected override void Dispose(bool disposing)
+        {
+            RadioGroup?.RadioItems?.Remove(this);
+            base.Dispose(disposing);
+        }
+
         protected override async Task OnFirstAfterRenderAsync()
         {
             if (this.AutoFocus)

--- a/components/radio/RadioGroup.razor.cs
+++ b/components/radio/RadioGroup.razor.cs
@@ -51,6 +51,7 @@ namespace AntDesign
             StateHasChanged();
         }
 
+
         protected override async Task OnParametersSetAsync()
         {
             foreach (var radio in RadioItems)

--- a/components/select/Select.razor.cs
+++ b/components/select/Select.razor.cs
@@ -640,6 +640,11 @@ namespace AntDesign
             await OnSelectOpenClick(null);
         }
 
+        public void RemoveOption(SelectOption selectOption)
+        {
+            SelectOptions.Remove(selectOption);
+        }
+
         public void AddOption(SelectOption selectOption)
         {
             if (selectOption.IsSearch)

--- a/components/select/SelectOptGroup.razor.cs
+++ b/components/select/SelectOptGroup.razor.cs
@@ -62,6 +62,12 @@ namespace AntDesign
             Parent.AddOption(option);
         }
 
+        public void RemoveOption(SelectOption option)
+        {
+            SelectOptions.Remove(option);
+            Parent.RemoveOption(option);
+        }
+
         #endregion Methods
 
         #endregion Public

--- a/components/select/SelectOption.razor.cs
+++ b/components/select/SelectOption.razor.cs
@@ -53,6 +53,13 @@ namespace AntDesign
         #endregion
 
         #region Events
+        protected override void Dispose(bool disposing)
+        {
+            SelectParent?.RemoveOption(this);
+            SelectOptGroupParent?.RemoveOption(this);
+            base.Dispose(disposing);
+        }
+
         protected override void OnInitialized()
         {
             SetClassMap();

--- a/components/table/ColumnBase.cs
+++ b/components/table/ColumnBase.cs
@@ -61,5 +61,14 @@ namespace AntDesign
 
             SetClass();
         }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (Context != null)
+            {
+                Context.Columns.Remove(this);
+            }
+            base.Dispose(disposing);
+        }
     }
 }

--- a/components/tabs/TabPane.razor.cs
+++ b/components/tabs/TabPane.razor.cs
@@ -76,5 +76,14 @@ namespace AntDesign
                 .If($"{PrefixCls}-with-remove", () => Closable)
                 .If($"{PrefixCls}-disabled", () => Disabled);
         }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (_parent != null)
+            {
+                _parent._panes.Remove(this);
+            }
+            base.Dispose(disposing);
+        }
     }
 }

--- a/components/timeline/Timeline.razor.cs
+++ b/components/timeline/Timeline.razor.cs
@@ -43,7 +43,7 @@ namespace AntDesign
         [Parameter]
         public RenderFragment ChildContent { get; set; }
 
-        private IList<TimelineItem> _items = new List<TimelineItem>();
+        internal IList<TimelineItem> _items = new List<TimelineItem>();
 
         protected IList<TimelineItem> DisplayItems
         {

--- a/components/timeline/TimelineItem.cs
+++ b/components/timeline/TimelineItem.cs
@@ -29,11 +29,6 @@ namespace AntDesign
 
         private readonly string[] _defaultColors = new[] { "blue", "red", "green", "gray" };
 
-        public TimelineItem()
-        {
-
-        }
-
         internal TimelineItem(RenderFragment childContent, RenderFragment dot, string @class)
         {
             this.ChildContent = childContent;
@@ -43,13 +38,13 @@ namespace AntDesign
 
         protected override void Dispose(bool disposing)
         {
-            ParentTimeline._items.Remove(this);
+            ParentTimeline?._items.Remove(this);
             base.Dispose(disposing);
         }
 
         protected override void OnInitialized()
         {
-            ParentTimeline.AddItem(this);
+            ParentTimeline?.AddItem(this);
             this.TryUpdateCustomColor();
             base.OnInitialized();
         }

--- a/components/timeline/TimelineItem.cs
+++ b/components/timeline/TimelineItem.cs
@@ -41,6 +41,12 @@ namespace AntDesign
             this.Class = @class;
         }
 
+        protected override void Dispose(bool disposing)
+        {
+            ParentTimeline._items.Remove(this);
+            base.Dispose(disposing);
+        }
+
         protected override void OnInitialized()
         {
             ParentTimeline.AddItem(this);


### PR DESCRIPTION
Children components using CascadingParameter add itself to parent component.However, when children components disposed, they are not remove from parent component. For example, when items in checkgroup have changed , it may causes Index was outside the bounds of the array at AntDesign.CheckboxGroup.OnCheckboxChange.To fix these bug, Adding remove function in dispose process is the solution of this commit.
子组件释放时候，并没有从父组件中的list中移除。
1导致timeline内容发生变化时，子内容显示不正确。
2.导致子组件会不断积累在父组件中。
3.radiogroup会发生System.IndexOutOfRangeException异常。