### PR TITLE
fix(module: AntInputComponentBase ): always triggers statehaschanged

### DIFF
--- a/components/core/Base/AntInputComponentBase.cs
+++ b/components/core/Base/AntInputComponentBase.cs
@@ -66,8 +66,27 @@ namespace AntDesign
             get { return _value; }
             set
             {
-                _value = value;
+                if (Value == null && value == null)
+                {
+                    return;
+                }
 
+                if (Value is string valStr)
+                {
+                    if (value != null && value is string newValStr && newValStr == valStr)
+                    {
+                        return;
+                    }
+                }
+                else if (Value is ValueType val1 && value is ValueType val2)
+                {
+                    if (val1.Equals(val2))
+                    {
+                        return;
+                    }
+                }
+
+                _value = value;
                 OnValueChange(value);
             }
         }

--- a/components/core/Base/AntInputComponentBase.cs
+++ b/components/core/Base/AntInputComponentBase.cs
@@ -71,13 +71,6 @@ namespace AntDesign
                 {
                     _value = value;
                     OnValueChange(value);
-
-                    ValueChanged.InvokeAsync(value);
-
-                    if (_isNotifyFieldChanged)
-                    {
-                        EditContext?.NotifyFieldChanged(FieldIdentifier);
-                    }
                 }
             }
         }
@@ -115,7 +108,18 @@ namespace AntDesign
             get => Value;
             set
             {
-                Value = value;
+                var hasChanged = !EqualityComparer<TValue>.Default.Equals(value, Value);
+                if (hasChanged)
+                {
+                    Value = value;
+
+                    ValueChanged.InvokeAsync(value);
+
+                    if (_isNotifyFieldChanged)
+                    {
+                        EditContext?.NotifyFieldChanged(FieldIdentifier);
+                    }
+                }
             }
         }
 

--- a/components/core/Base/AntInputComponentBase.cs
+++ b/components/core/Base/AntInputComponentBase.cs
@@ -66,28 +66,19 @@ namespace AntDesign
             get { return _value; }
             set
             {
-                if (Value == null && value == null)
+                var hasChanged = !EqualityComparer<TValue>.Default.Equals(value, Value);
+                if (hasChanged)
                 {
-                    return;
-                }
+                    _value = value;
+                    OnValueChange(value);
 
-                if (Value is string valStr)
-                {
-                    if (value != null && value is string newValStr && newValStr == valStr)
+                    ValueChanged.InvokeAsync(value);
+
+                    if (_isNotifyFieldChanged)
                     {
-                        return;
+                        EditContext?.NotifyFieldChanged(FieldIdentifier);
                     }
                 }
-                else if (Value is ValueType val1 && value is ValueType val2)
-                {
-                    if (val1.Equals(val2))
-                    {
-                        return;
-                    }
-                }
-
-                _value = value;
-                OnValueChange(value);
             }
         }
 
@@ -124,18 +115,7 @@ namespace AntDesign
             get => Value;
             set
             {
-                var hasChanged = !EqualityComparer<TValue>.Default.Equals(value, Value);
-                if (hasChanged)
-                {
-                    Value = value;
-
-                    ValueChanged.InvokeAsync(value);
-
-                    if (_isNotifyFieldChanged)
-                    {
-                        EditContext?.NotifyFieldChanged(FieldIdentifier);
-                    }
-                }
+                Value = value;
             }
         }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
fix #350 

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    fixed AntInputComponentBase always triggers statehaschanged |
| 🇨🇳 Chinese |  修复 AntInputComponentBase 总是触发 StateHasChanged  |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
