### PR TITLE
fix(docs): handles fallback to en-US if resources are not available

### DIFF
--- a/site/AntBlazor.Docs/Localization/InAssemblyLanguageService.cs
+++ b/site/AntBlazor.Docs/Localization/InAssemblyLanguageService.cs
@@ -3,6 +3,8 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text.Json;
+using System.Text.RegularExpressions;
 
 namespace AntDesign.Docs.Localization
 {
@@ -30,25 +32,25 @@ namespace AntDesign.Docs.Localization
 
         private void SetDefaultLanguage(CultureInfo culture)
         {
-            CurrentCulture = culture;
-            CultureInfo.CurrentCulture = culture;
+            var availableResources = _resourcesAssembly
+                .GetManifestResourceNames()
+                .Select(x => Regex.Match(x, @"^.*Resources\.(.+)\.yml$"))
+                .Where(x => x.Success)
+                .Select(x => (CultureName: x.Groups[1].Value, ResourceName: x.Value))
+                .ToList();
 
-            string[] languageFileNames = _resourcesAssembly.GetManifestResourceNames().Where(s => s.Contains("Resources") && s.Contains(".yml") && s.Contains("-")).ToArray();
+            var (_, resourceName) = availableResources.FirstOrDefault(x => x.CultureName.Equals(culture.Name, StringComparison.OrdinalIgnoreCase));
 
-            Resources = GetKeysFromCulture(culture.Name, languageFileNames.SingleOrDefault(n => n.Contains($"{culture.Name}.yml")));
-
-            if (Resources == null)
+            if (resourceName == null)
             {
-                string language = culture.Name.Split('-')[0];
-                Resources = GetKeysFromCulture(culture.Name, languageFileNames.FirstOrDefault(n => n.Contains(language)));
+                (_, resourceName) = availableResources.FirstOrDefault(x => x.CultureName.Equals("en-US", StringComparison.OrdinalIgnoreCase));
+                culture = CultureInfo.GetCultureInfo("en-US");
             }
 
-            if (Resources == null && culture.Name != "en-US")
-                Resources = GetKeysFromCulture("en-US", languageFileNames.SingleOrDefault(n => n.Contains($"en-US.yml")));
-
-            if (Resources == null)
-                Resources = GetKeysFromCulture("en-US", languageFileNames.FirstOrDefault());
-
+            CultureInfo.CurrentCulture = culture;
+            CurrentCulture = culture;
+            Resources = GetKeysFromCulture(culture.Name, resourceName);
+            
             if (Resources == null)
                 throw new FileNotFoundException($"There is no language files existing in the Resource folder within '{_resourcesAssembly.GetName().Name}' assembly");
         }


### PR DESCRIPTION

### 🤔 This is a ...

- [ ] New feature
- [X] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

The website is completely broken when accessing from a computer with a culture different from either en-US or zn-CH. This PR fixes the LanguageService to fallback to en-US when needed.


### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] Changelog is provided or not needed
