### PR TITLE
fix(module: button): allows type and shape to change

### DIFF
--- a/components/button/Button.razor.cs
+++ b/components/button/Button.razor.cs
@@ -86,13 +86,13 @@ namespace AntDesign
 
         protected void SetClassMap()
         {
-            string prefixName = "ant-btn";
+            const string prefixName = "ant-btn";
 
             ClassMapper.Clear()
                 .Add("ant-btn")
-                .If($"{prefixName}-{this.Type}", () => !string.IsNullOrEmpty(Type))
+                .GetIf(() => $"{prefixName}-{this.Type}", () => !string.IsNullOrEmpty(Type))
                 .If($"{prefixName}-dangerous", () => Danger)
-                .If($"{prefixName}-{Shape}", () => !string.IsNullOrEmpty(Shape))
+                .GetIf(() => $"{prefixName}-{Shape}", () => !string.IsNullOrEmpty(Shape))
                 .If($"{prefixName}-lg", () => Size == "large")
                 .If($"{prefixName}-sm", () => Size == "small")
                 .If($"{prefixName}-loading", () => Loading)

--- a/tests/button/ButtonTests.cs
+++ b/tests/button/ButtonTests.cs
@@ -1,4 +1,4 @@
-using Bunit;
+﻿using Bunit;
 using Xunit;
 
 namespace AntDesign.Tests.Button
@@ -13,7 +13,7 @@ namespace AntDesign.Tests.Button
                 <button class=""ant-btn ant-btn-default"" id:ignore type=""button"" ant-click-animating-without-extra-node=""false""></button>
             ");
         }
-        
+
         [Fact]
         public void Renders_a_button_with_contents()
         {
@@ -25,7 +25,7 @@ namespace AntDesign.Tests.Button
                 <button class=""ant-btn ant-btn-default"" id:ignore type=""button"" ant-click-animating-without-extra-node=""false"">Save</button>
             ");
         }
-        
+
         [Fact]
         public void Renders_a_disabled_the_button()
         {
@@ -37,7 +37,7 @@ namespace AntDesign.Tests.Button
                 <button class=""ant-btn ant-btn-default"" id:ignore type=""button"" ant-click-animating-without-extra-node=""false"" disabled></button>
             ");
         }
-        
+
         [Theory]
         [InlineData(ButtonType.Dashed)]
         [InlineData(ButtonType.Default)]
@@ -46,14 +46,14 @@ namespace AntDesign.Tests.Button
         public void Renders_buttons_of_different_types(string type)
         {
             var cut = Context.RenderComponent<AntDesign.Button>(p =>
-                p.Add(x => x.Type, type )
+                p.Add(x => x.Type, type)
             );
 
             cut.MarkupMatches($@"
                 <button class=""ant-btn ant-btn-{type.ToLower()}"" id:ignore type=""button"" ant-click-animating-without-extra-node=""false""></button>
             ");
         }
-        
+
         [Fact]
         public void Should_fire_OnClick_when_clicked()
         {
@@ -68,7 +68,7 @@ namespace AntDesign.Tests.Button
 
             Assert.True(clicked);
         }
-        
+
         [Fact]
         public void Renders_loading_icon()
         {
@@ -80,6 +80,23 @@ namespace AntDesign.Tests.Button
                 <button class=""ant-btn ant-btn-default ant-btn-loading"" id:ignore type=""button"" ant-click-animating-without-extra-node=""false"">
                   <span diff:ignore></span>
                 </button>
+            ");
+        }
+
+
+        [Fact]
+        public void Renders_when_type_is_changed()
+        {
+            var cut = Context.RenderComponent<AntDesign.Button>(p =>
+                p.Add(x => x.Type, ButtonType.Default)
+            );
+
+            cut.SetParametersAndRender(p =>
+                p.Add(x => x.Type, ButtonType.Dashed)
+            );
+
+            cut.MarkupMatches($@"
+                <button class=""ant-btn ant-btn-dashed"" id:ignore type=""button"" ant-click-animating-without-extra-node=""false""></button>
             ");
         }
     }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [X] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 💡 Background and solution

Once a button is rendered, changing Shape or Type has no effect. This change allows the Shape and Type to be changed after the initial render, just like other properties..

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] Changelog is provided or not needed
