### PR TITLE
fix: modal box randomly closed when multiple mouse click performed within it (#696)

### DIFF
--- a/components/core/JsInterop/Element.cs
+++ b/components/core/JsInterop/Element.cs
@@ -18,9 +18,9 @@
 
         public int scrollWidth { get; set; }
 
-        public int scrollLeft { get; set; }
+        public double scrollLeft { get; set; }
 
-        public int scrollTop { get; set; }
+        public double scrollTop { get; set; }
 
         public int clientTop { get; set; }
 

--- a/components/modal/Dialog.razor
+++ b/components/modal/Dialog.razor
@@ -9,7 +9,6 @@
         }
     <div tabindex="-1" class="ant-modal-wrap @Config.GetWrapClassNameExtended()" role="dialog" aria-labelledby="rcDialogTitle0"
          @onclick="@OnMaskClick" 
-         @onmouseup="@OnMaskMouseUp"
          @onkeydown="@OnKeyDown"
          style="@_wrapStyle">
         <div  @ref="@_modal" role="document" class="ant-modal @GetModalClsName()"

--- a/components/modal/Dialog.razor.cs
+++ b/components/modal/Dialog.razor.cs
@@ -105,15 +105,6 @@ namespace AntDesign
             _dialogMouseDown = true;
         }
 
-        private async Task OnMaskMouseUp()
-        {
-            if (Config.MaskClosable && _dialogMouseDown)
-            {
-                await Task.Delay(50);
-                _dialogMouseDown = false;
-            }
-        }
-
         private async Task OnMaskClick(MouseEventArgs e)
         {
             if (Config.MaskClosable
@@ -121,6 +112,7 @@ namespace AntDesign
             {
                 await CloseAsync();
             }
+            _dialogMouseDown = false;
         }
 
         #endregion

--- a/components/radio/Radio.razor
+++ b/components/radio/Radio.razor
@@ -2,7 +2,7 @@
 @typeparam TValue
 @inherits AntDomComponentBase
 
-<label @onclick="_=>OnClick()" class="@ClassMapper.Class" style="@Style" id="@Id" @ref="Ref">
+<label @onclick="OnClick" @onclick:preventDefault="true" class="@ClassMapper.Class" style="@Style" id="@Id" @ref="Ref">
     <span class="@RadioClassMapper.Class">
         <input type="radio"
                autofocus="@AutoFocus"


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
#696 

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  1. Wrong type mapping between scrolltop and scrollleft in element; 2. Fix the problem that Radio triggers OnClick event twice; 3. Frequent click results in modal to close automatically. |
| 🇨🇳 Chinese | 1. Element中scrollTop与scrollLeft错误的类型映射; 2.修复Radio触发两次OnClick事件的问题; 3.快速点击下Modal自动关闭的问题. |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
