### PR TITLE
为组件提供所有参数值的哈希计算方法，用于改善复杂组件的渲染卡顿问题。

### DIFF
--- a/components/core/HashCodes/HashCode.cs
+++ b/components/core/HashCodes/HashCode.cs
@@ -1,11 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
-
-namespace AntDesign.Core.HashCodes
+﻿namespace AntDesign.Core.HashCodes
 {
     /// <summary>
-    /// 提供两参数值哈希比较
+    /// Provides a hash comparison of two parameter values
     /// </summary>
     /// <typeparam name="TParameter"></typeparam>
     static class HashCode<TParameter>
@@ -13,10 +9,10 @@ namespace AntDesign.Core.HashCodes
         private static readonly HashCodeProvider _provider = HashCodeProvider.Create(typeof(TParameter));
 
         /// <summary>
-        /// 计算两参数值的哈希是否相等
+        /// Calculate whether the hash of two parameter values is equal
         /// </summary>
-        /// <param name="parameter1">参数值1</param>
-        /// <param name="parameter2">参数值2</param>
+        /// <param name="parameter1">Parameter 1</param>
+        /// <param name="parameter2">Parameter 2</param>
         /// <returns></returns>
         public static bool HashCodeEquals(TParameter parameter1, TParameter parameter2)
         {
@@ -24,9 +20,9 @@ namespace AntDesign.Core.HashCodes
         }
 
         /// <summary>
-        /// 计算参数的哈希值
+        /// Calculate the hash value of the parameter
         /// </summary>
-        /// <param name="parameter">参数值1</param>
+        /// <param name="parameter">Parameter</param>
         /// <returns></returns>
         public static int GetHashCode(TParameter parameter)
         {

--- a/components/core/HashCodes/HashCode.cs
+++ b/components/core/HashCodes/HashCode.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace AntDesign.Core.HashCodes
+{
+    /// <summary>
+    /// 提供两参数值哈希比较
+    /// </summary>
+    /// <typeparam name="TParameter"></typeparam>
+    static class HashCode<TParameter>
+    {
+        private static readonly HashCodeProvider _provider = HashCodeProvider.Create(typeof(TParameter));
+
+        /// <summary>
+        /// 计算两参数值的哈希是否相等
+        /// </summary>
+        /// <param name="parameter1">参数值1</param>
+        /// <param name="parameter2">参数值2</param>
+        /// <returns></returns>
+        public static bool HashCodeEquals(TParameter parameter1, TParameter parameter2)
+        {
+            return GetHashCode(parameter1) == GetHashCode(parameter2);
+        }
+
+        /// <summary>
+        /// 计算参数的哈希值
+        /// </summary>
+        /// <param name="parameter">参数值1</param>
+        /// <returns></returns>
+        public static int GetHashCode(TParameter parameter)
+        {
+            return _provider.GetHashCode(parameter);
+        }
+    }
+}

--- a/components/core/HashCodes/HashCodeExtensions.cs
+++ b/components/core/HashCodes/HashCodeExtensions.cs
@@ -1,21 +1,17 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
-
-using Microsoft.AspNetCore.Components;
+﻿using Microsoft.AspNetCore.Components;
 
 namespace AntDesign.Core.HashCodes
 {
     /// <summary>
-    /// 提供组件参数的HashCode计算等功能
+    /// Provide HashCode calculation of component parameters and other functions
     /// </summary>
     static class HashCodeExtensions
     {
         /// <summary>
-        /// 计算所有参数的HashCode
+        /// Compute the HashCode for all parameters
         /// </summary>
         /// <typeparam name="TComponent"></typeparam>
-        /// <param name="component">组件</param>
+        /// <param name="component">Component</param>
         /// <returns></returns>
         public static int GetParametersHashCode<TComponent>(this TComponent component) where TComponent : ComponentBase
         {

--- a/components/core/HashCodes/HashCodeExtensions.cs
+++ b/components/core/HashCodes/HashCodeExtensions.cs
@@ -1,0 +1,55 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using Microsoft.AspNetCore.Components;
+
+namespace AntDesign.Core.HashCodes
+{
+    /// <summary>
+    /// 提供组件参数的HashCode计算等功能
+    /// </summary>
+    static class HashCodeExtensions
+    {
+        /// <summary>
+        /// 计算所有参数的HashCode
+        /// </summary>
+        /// <typeparam name="TComponent"></typeparam>
+        /// <param name="component">组件</param>
+        /// <returns></returns>
+        public static int GetParametersHashCode<TComponent>(this TComponent component) where TComponent : ComponentBase
+        {
+            return Component<TComponent>.GetParametersHashCode(component);
+        }
+
+        /// <summary>
+        /// 提供组件参数哈希值计算
+        /// </summary>
+        /// <typeparam name="TComponent"></typeparam>
+        static class Component<TComponent>
+        {
+            private static readonly ParameterDescriptor<TComponent>[] _descriptors
+                = typeof(TComponent)
+                    .GetProperties()
+                    .Select(item => new ParameterDescriptor<TComponent>(item))
+                    .Where(item => item.IsParameter)
+                    .ToArray();
+
+            /// <summary>
+            /// 返回组件的参数的HashCode
+            /// </summary>
+            /// <param name="component"></param>
+            /// <returns></returns>
+            public static int GetParametersHashCode(TComponent component)
+            {
+                var hashCode = 0;
+                foreach (var descriptor in _descriptors)
+                {
+                    hashCode ^= descriptor.GetValueHashCode(component);
+                }
+                return hashCode;
+            }
+        }
+    }
+}

--- a/components/core/HashCodes/HashCodeExtensions.cs
+++ b/components/core/HashCodes/HashCodeExtensions.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Linq;
 using Microsoft.AspNetCore.Components;
 
 namespace AntDesign.Core.HashCodes
@@ -20,36 +19,13 @@ namespace AntDesign.Core.HashCodes
         /// <returns></returns>
         public static int GetParametersHashCode<TComponent>(this TComponent component) where TComponent : ComponentBase
         {
-            return Component<TComponent>.GetParametersHashCode(component);
-        }
-
-        /// <summary>
-        /// 提供组件参数哈希值计算
-        /// </summary>
-        /// <typeparam name="TComponent"></typeparam>
-        static class Component<TComponent>
-        {
-            private static readonly ParameterDescriptor<TComponent>[] _descriptors
-                = typeof(TComponent)
-                    .GetProperties()
-                    .Select(item => new ParameterDescriptor<TComponent>(item))
-                    .Where(item => item.IsParameter)
-                    .ToArray();
-
-            /// <summary>
-            /// 返回组件的参数的HashCode
-            /// </summary>
-            /// <param name="component"></param>
-            /// <returns></returns>
-            public static int GetParametersHashCode(TComponent component)
+            var hashCode = 0;
+            var descriptors = ParameterDescriptor<TComponent>.Descriptors;
+            foreach (var descriptor in descriptors)
             {
-                var hashCode = 0;
-                foreach (var descriptor in _descriptors)
-                {
-                    hashCode ^= descriptor.GetValueHashCode(component);
-                }
-                return hashCode;
+                hashCode ^= descriptor.GetValueHashCode(component);
             }
+            return hashCode;
         }
     }
 }

--- a/components/core/HashCodes/HashCodeProvider.cs
+++ b/components/core/HashCodes/HashCodeProvider.cs
@@ -1,0 +1,110 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace AntDesign.Core.HashCodes
+{
+    /// <summary>
+    /// 表示hashCode提供者抽象类
+    /// 用于计算参数值的HashCode
+    /// 集合类型则计算每个元素的HashCode
+    /// 其它类型则直接返回对象的默认GetHashCode方法所提值
+    /// 出于反射性能考虑，复杂模型不会进行拆解计算其各属性的HashCode，建议模型自己重写GetHashCode方法
+    /// </summary>
+    abstract class HashCodeProvider
+    {
+        /// <summary>
+        /// 获取参数值的哈希值
+        /// </summary>
+        /// <param name="parameter">参数值</param>
+        /// <returns></returns>
+        public abstract int GetHashCode(object parameter);
+
+        /// <summary>
+        /// 为参数创建合适的哈希提供者
+        /// </summary>
+        /// <param name="parameterType">参数类型</param>
+        /// <returns></returns>
+        public static HashCodeProvider Create(Type parameterType)
+        {
+            if (typeof(IDictionary<string, object>).IsAssignableFrom(parameterType))
+            {
+                return DictionaryHashCodeProvider.Instance;
+            }
+
+            if (typeof(IEnumerable).IsAssignableFrom(parameterType))
+            {
+                return EnumerableHashCodeProvider.Instance;
+            }
+
+            return OtherHashCodeProvider.Instance;
+        }
+
+        /// <summary>
+        /// IEnumerable类型的哈希提供者
+        /// </summary>
+        private class EnumerableHashCodeProvider : HashCodeProvider
+        {
+            public static HashCodeProvider Instance { get; } = new EnumerableHashCodeProvider();
+
+            public override int GetHashCode(object parameter)
+            {
+                if (!(parameter is IEnumerable enumerable))
+                {
+                    return 0;
+                }
+
+                var hashCode = 0;
+                var enumerator = enumerable.GetEnumerator();
+                while (enumerator.MoveNext())
+                {
+                    hashCode ^= OtherHashCodeProvider.Instance.GetHashCode(enumerator.Current);
+                }
+                return hashCode;
+            }
+        }
+
+
+        /// <summary>
+        /// 字典类型的哈希提供者
+        /// </summary>
+        private class DictionaryHashCodeProvider : HashCodeProvider
+        {
+            public static HashCodeProvider Instance { get; } = new DictionaryHashCodeProvider();
+
+            public override int GetHashCode(object parameter)
+            {
+                if (!(parameter is IDictionary<string, object> dic))
+                {
+                    return 0;
+                }
+
+                var hashCode = 0;
+                foreach (var item in dic)
+                {
+                    hashCode ^= OtherHashCodeProvider.Instance.GetHashCode(item.Key);
+                    hashCode ^= OtherHashCodeProvider.Instance.GetHashCode(item.Value);
+                }
+                return hashCode;
+            }
+        }
+
+
+        /// <summary>
+        /// 其它类型的哈希提供者
+        /// </summary>
+        private class OtherHashCodeProvider : HashCodeProvider
+        {
+            public static HashCodeProvider Instance { get; } = new OtherHashCodeProvider();
+
+            public override int GetHashCode(object parameter)
+            {
+                return parameter == null ? 0 : parameter.GetHashCode();
+            }
+        }
+    }
+}

--- a/components/core/HashCodes/HashCodeProvider.cs
+++ b/components/core/HashCodes/HashCodeProvider.cs
@@ -1,33 +1,30 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
-
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 
 namespace AntDesign.Core.HashCodes
 {
     /// <summary>
-    /// 表示hashCode提供者抽象类
-    /// 用于计算参数值的HashCode
-    /// 集合类型则计算每个元素的HashCode
-    /// 其它类型则直接返回对象的默认GetHashCode方法所提值
-    /// 出于反射性能考虑，复杂模型不会进行拆解计算其各属性的HashCode，建议模型自己重写GetHashCode方法
+    /// HashCode provider
+    /// <para>It is used to calculate the parameter value of HashCode</para>
+    /// <para>The collection type computes the HashCode for each element,
+    /// and the other types simply return the value raised by the default GetHashCode method of the object
+    /// </para>
+    /// <para>For the consideration of reflection performance, the complex model will not disassemble and calculate the HashCode of its attributes, so it is suggested that the model rewrite the GetHashCode method by itself</para>
     /// </summary>
-    abstract class HashCodeProvider
+    internal abstract class HashCodeProvider
     {
         /// <summary>
-        /// 获取参数值的哈希值
+        /// Gets the hash value of the parameter value
         /// </summary>
-        /// <param name="parameter">参数值</param>
+        /// <param name="parameter">Parameter type</param>
         /// <returns></returns>
         public abstract int GetHashCode(object parameter);
 
         /// <summary>
-        /// 为参数创建合适的哈希提供者
+        /// Create the appropriate hash provider for the parameter
         /// </summary>
-        /// <param name="parameterType">参数类型</param>
+        /// <param name="parameterType">Parameter type</param>
         /// <returns></returns>
         public static HashCodeProvider Create(Type parameterType)
         {
@@ -45,7 +42,7 @@ namespace AntDesign.Core.HashCodes
         }
 
         /// <summary>
-        /// IEnumerable类型的哈希提供者
+        /// The hash provider for the IEnumerable type
         /// </summary>
         private class EnumerableHashCodeProvider : HashCodeProvider
         {
@@ -70,7 +67,7 @@ namespace AntDesign.Core.HashCodes
 
 
         /// <summary>
-        /// 字典类型的哈希提供者
+        /// The hash providers for dictionary types
         /// </summary>
         private class DictionaryHashCodeProvider : HashCodeProvider
         {
@@ -95,7 +92,7 @@ namespace AntDesign.Core.HashCodes
 
 
         /// <summary>
-        /// 其它类型的哈希提供者
+        /// The hash providers for other types 
         /// </summary>
         private class OtherHashCodeProvider : HashCodeProvider
         {

--- a/components/core/HashCodes/ParameterDescriptor.cs
+++ b/components/core/HashCodes/ParameterDescriptor.cs
@@ -1,8 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
-
-using System;
+﻿using System;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -11,7 +7,7 @@ using Microsoft.AspNetCore.Components;
 namespace AntDesign.Core.HashCodes
 {
     /// <summary>
-    /// 表示组件的参数描述者
+    /// Represents a parameter descriptor for a component
     /// </summary>
     /// <typeparam name="TComponent"></typeparam>
     class ParameterDescriptor<TComponent>
@@ -23,7 +19,7 @@ namespace AntDesign.Core.HashCodes
         private readonly Func<TComponent, object> _getter;
 
         /// <summary>
-        /// 获取组件的所有参数描述
+        /// Gets a description of all the parameters of the component
         /// </summary>
         public static readonly ParameterDescriptor<TComponent>[] Descriptors
             = typeof(TComponent)
@@ -33,7 +29,7 @@ namespace AntDesign.Core.HashCodes
                 .ToArray();
 
         /// <summary>
-        /// 组件的参数描述者
+        /// A parameter descriptor for a component
         /// </summary>
         /// <param name="property">属性类型</param>
         private ParameterDescriptor(PropertyInfo property)
@@ -55,7 +51,7 @@ namespace AntDesign.Core.HashCodes
         }
 
         /// <summary>
-        /// 返回是否为EventCallback类型
+        /// Check whether it is of type EventCallback
         /// </summary>
         /// <param name="property"></param>
         /// <returns></returns>
@@ -76,9 +72,9 @@ namespace AntDesign.Core.HashCodes
         }
 
         /// <summary>
-        /// 创建属性的获取委托
+        /// Create the get delegate for the property
         /// </summary>
-        /// <param name="property">属性</param>
+        /// <param name="property">Property</param>
         /// <returns></returns>
         private static Func<TComponent, object> CreateGetFunc(PropertyInfo property)
         {
@@ -91,7 +87,7 @@ namespace AntDesign.Core.HashCodes
         }
 
         /// <summary>
-        /// 返回参数值的哈希
+        /// Returns the hash of the parameter value
         /// </summary>
         /// <param name="component">组件</param>
         /// <exception cref="NotSupportedException"></exception>

--- a/components/core/HashCodes/ParameterDescriptor.cs
+++ b/components/core/HashCodes/ParameterDescriptor.cs
@@ -1,0 +1,121 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Linq.Expressions;
+using System.Reflection;
+using Microsoft.AspNetCore.Components;
+
+namespace AntDesign.Core.HashCodes
+{
+    /// <summary>
+    /// 表示组件的参数描述者
+    /// </summary>
+    /// <typeparam name="TComponent"></typeparam>
+    class ParameterDescriptor<TComponent>
+    {
+        private readonly HashCodeProvider _hashCodeProvider;
+
+        private readonly Func<TComponent, object> _getter;
+
+        /// <summary>
+        /// 获取参数名
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// 获取是否为参数
+        /// </summary>
+        public bool IsParameter { get; }
+
+        /// <summary>
+        /// 组件的参数描述者
+        /// </summary>
+        /// <param name="property">属性类型</param>
+        public ParameterDescriptor(PropertyInfo property)
+        {
+            if (property == null)
+            {
+                throw new ArgumentNullException(nameof(property));
+            }
+
+            if (IsEventCallBack(property) == false)
+            {
+                var parameter = property.GetCustomAttribute<ParameterAttribute>();
+                if (parameter != null)
+                {
+                    this.IsParameter = true;
+                    this.Name = property.Name;
+                }
+                else
+                {
+                    var cascadingParameter = property.GetCustomAttribute<CascadingParameterAttribute>();
+                    if (cascadingParameter != null)
+                    {
+                        this.IsParameter = true;
+                        this.Name = cascadingParameter.Name ?? property.Name;
+                    }
+                }
+            }
+
+            if (this.IsParameter == true)
+            {
+                this._getter = CreateGetFunc(property);
+                this._hashCodeProvider = HashCodeProvider.Create(property.PropertyType);
+            }
+        }
+
+        /// <summary>
+        /// 返回是否为EventCallback类型
+        /// </summary>
+        /// <param name="property"></param>
+        /// <returns></returns>
+        private static bool IsEventCallBack(PropertyInfo property)
+        {
+            var type = property.PropertyType;
+            if (type == typeof(EventCallback))
+            {
+                return true;
+            }
+
+            if (type.IsGenericType == true)
+            {
+                return type.GetGenericTypeDefinition() == typeof(EventCallback<>);
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// 创建属性的获取委托
+        /// </summary>
+        /// <param name="property">属性</param>
+        /// <returns></returns>
+        private static Func<TComponent, object> CreateGetFunc(PropertyInfo property)
+        {
+            // (TComponent component) => (object)(component.Property)
+            var componentType = typeof(TComponent);
+            var parameter = Expression.Parameter(componentType);
+            var member = Expression.Property(parameter, property);
+            var body = Expression.Convert(member, typeof(object));
+            return Expression.Lambda<Func<TComponent, object>>(body, parameter).Compile();
+        }
+
+        /// <summary>
+        /// 返回参数值的哈希
+        /// </summary>
+        /// <param name="component">组件</param>
+        /// <exception cref="NotSupportedException"></exception>
+        /// <returns></returns>
+        public int GetValueHashCode(TComponent component)
+        {
+            if (this.IsParameter == false)
+            {
+                throw new NotSupportedException();
+            }
+            var value = this._getter(component);
+            return this._hashCodeProvider.GetHashCode(value);
+        }
+    }
+}

--- a/components/core/RenderMode.cs
+++ b/components/core/RenderMode.cs
@@ -1,21 +1,17 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
-
-namespace AntDesign
+﻿namespace AntDesign
 {
     /// <summary>
-    /// 渲染模式
+    /// Rendering mode
     /// </summary>
     public enum RenderMode
     {
         /// <summary>
-        /// 总是渲染
+        /// Always to render
         /// </summary>
         Always,
 
         /// <summary>
-        /// 当参数值的hashCode变化才渲染
+        /// Render when the hashCode of the parameter value changes
         /// </summary>
         ParametersHashCodeChanged,
     }

--- a/components/core/RenderMode.cs
+++ b/components/core/RenderMode.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace AntDesign
+{
+    /// <summary>
+    /// 渲染模式
+    /// </summary>
+    public enum RenderMode
+    {
+        /// <summary>
+        /// 总是渲染
+        /// </summary>
+        Always,
+
+        /// <summary>
+        /// 当参数值的hashCode变化才渲染
+        /// </summary>
+        ParametersHashCodeChanged,
+    }
+}

--- a/components/table/Table.razor.cs
+++ b/components/table/Table.razor.cs
@@ -1,10 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using AntDesign.Core.HashCodes;
 using AntDesign.TableModels;
 using Microsoft.AspNetCore.Components;
-using OneOf;
 
 namespace AntDesign
 {
@@ -12,15 +11,21 @@ namespace AntDesign
     {
         private static readonly TItem _fieldModel = (TItem)RuntimeHelpers.GetUninitializedObject(typeof(TItem));
 
+        private bool _shouldRender = true;
+        private int _parametersHashCode = 0;
+
+        [Parameter]
+        public RenderMode RenderMode { get; set; } = RenderMode.Always;
+
         [Parameter]
         public IEnumerable<TItem> DataSource
         {
             get => _dataSource;
             set
             {
+                _waitingReload = HashCode<IEnumerable<TItem>>.HashCodeEquals(_dataSource, value) == false;
                 _dataSourceCount = value?.Count() ?? 0;
                 _dataSource = value ?? Enumerable.Empty<TItem>();
-                _waitingReload = true;
             }
         }
 
@@ -181,6 +186,28 @@ namespace AntDesign
             {
                 this.FinishLoadPage();
             }
+        }
+
+
+        protected override void OnParametersSet()
+        {
+            base.OnParametersSet();
+
+            if (this.RenderMode == RenderMode.ParametersHashCodeChanged)
+            {
+                var hashCode = this.GetParametersHashCode();
+                this._shouldRender = this._parametersHashCode != hashCode;
+                this._parametersHashCode = hashCode;
+            }
+            else
+            {
+                this._shouldRender = true;
+            }
+        }
+
+        protected override bool ShouldRender()
+        {
+            return this._shouldRender;
         }
     }
 }


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在一个维护者审核通过后合并。
请确保填写以下 pull request 的信息，谢谢！~

[[English Template / 英文模板](?expand=1)]
-->

### 🤔 这个变动的性质是？

- [x] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式改进
- [ ] 包体积优化
- [x] 性能优化
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
* #707 
* #579
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
在Blazor的Page，输入框的每个键入事件，会触发一次整个Page所有组件的渲染过程。在数据管理系统中，最常用的设计是顶部是多个数据查询输入框，中间部分是Table显示数据，如果Table的内容比较丰富（比如10列10行），搜索框每键入一个字母，在老爷机里肉眼能感觉到0.5秒或以上的卡顿，当然这个卡顿不是Input组件的问题，而是Table组件的复杂度在渲染时造成的。

我们可以改进让组件不进行没有意义的渲染，从而加快整个Page的渲染速度，Page上的Input在输入时不再卡顿。判断组件的某次渲染是否为有意义，可以使用计算组件下所有参数的HashCode是否有变化的方法，比如Table组件，计算其参数的 HashCode ,耗时大概0.2ms，而渲染一次耗时约500ms，这个投资是划算的。

组件的参数类型，我们可以分为三大类
* IDictionary<string, object>
* IEnumerable
* 非集合的普通类型

对于IDictionary<string, object>和IEnumerable，我们需要读取里面的元素进行HashCode计算，普通类型则直接使用对象提供的GetHashCode()方法。最后，我们为组件提供一个GetParametersHashCode()的扩展方法，用于计算其所有参数值的HashCode。

同时，我们为Table组件增加一个RenderMode组件参数，用于选择总结是渲染，还是参数值的HashCode变化了才渲染，以适应不同的场景的需求。

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志怎么写？

<!--
> 从用户角度描述具体变化，以及可能的 breaking change 和其他风险？
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |          |
| 🇨🇳 中文 |          |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] Changelog 已提供或无须提供