### PR TITLE
修复HttpClientExtensions反序列化时没有判断内容是否为utf8编码的问题

### DIFF
--- a/components/core/Extensions/HttpClientExtensions.cs
+++ b/components/core/Extensions/HttpClientExtensions.cs
@@ -31,10 +31,10 @@ namespace AntDesign.core.Extensions
 
 
         /// <summary>
-        /// 读取为二进制数组并转换为指定的编码
+        /// Reads as a binary array and converts to the specified encoding
         /// </summary>
         /// <param name="httpContent"></param>
-        /// <param name="dstEncoding">目标编码</param>
+        /// <param name="dstEncoding">The target encoding</param>
         /// <exception cref="ArgumentException"></exception>
         /// <returns></returns>
         private static async Task<byte[]> ReadAsByteArrayAsync(this HttpContent httpContent, Encoding dstEncoding)
@@ -48,7 +48,7 @@ namespace AntDesign.core.Extensions
         }
 
         /// <summary>
-        /// 获取编码信息
+        /// Get encoding information from <see cref="HttpContent"/>
         /// </summary>
         /// <param name="httpContent"></param>
         /// <returns></returns>

--- a/components/core/Extensions/HttpClientExtensions.cs
+++ b/components/core/Extensions/HttpClientExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net.Http;
+using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -18,14 +19,54 @@ namespace AntDesign.core.Extensions
             var res = await client.GetAsync(requestUri, cancellationToken);
             if (res.IsSuccessStatusCode)
             {
-                var json = await res.Content.ReadAsStreamAsync();
-                return await JsonSerializer.DeserializeAsync<TValue>(json, new JsonSerializerOptions()
+                var utf8Json = await res.Content.ReadAsByteArrayAsync(Encoding.UTF8);
+                return JsonSerializer.Deserialize<TValue>(utf8Json, new JsonSerializerOptions()
                 {
                     PropertyNameCaseInsensitive = true,
-                }, cancellationToken);
+                });
             }
 
             return default;
+        }
+
+
+        /// <summary>
+        /// 读取为二进制数组并转换为指定的编码
+        /// </summary>
+        /// <param name="httpContent"></param>
+        /// <param name="dstEncoding">目标编码</param>
+        /// <exception cref="ArgumentException"></exception>
+        /// <returns></returns>
+        private static async Task<byte[]> ReadAsByteArrayAsync(this HttpContent httpContent, Encoding dstEncoding)
+        {
+            var encoding = httpContent.GetEncoding();
+            var byteArray = await httpContent.ReadAsByteArrayAsync().ConfigureAwait(false);
+
+            return encoding.Equals(dstEncoding)
+                ? byteArray
+                : Encoding.Convert(encoding, dstEncoding, byteArray);
+        }
+
+        /// <summary>
+        /// 获取编码信息
+        /// </summary>
+        /// <param name="httpContent"></param>
+        /// <returns></returns>
+        private static Encoding GetEncoding(this HttpContent httpContent)
+        {
+            var charSet = httpContent.Headers.ContentType?.CharSet;
+            if (string.IsNullOrEmpty(charSet) == true)
+            {
+                return Encoding.UTF8;
+            }
+
+            var span = charSet.AsSpan().TrimStart('"').TrimEnd('"');
+            if (span.Equals(Encoding.UTF8.WebName, StringComparison.OrdinalIgnoreCase))
+            {
+                return Encoding.UTF8;
+            }
+
+            return Encoding.GetEncoding(span.ToString());
         }
     }
 }


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在一个维护者审核通过后合并。
请确保填写以下 pull request 的信息，谢谢！~

[[English Template / 英文模板](?expand=1)]
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
System.Text.Json在反序列化时，要求输入的流或二进制数据必须为utf8编码，虽然utf8是web默认的编码，但http允许服务指定返回其它编码的响应内容，所以HttpClientExtensions.GetFromJsonAsync()方法应该增加检测响应内容编码是否为utf8的逻辑，如果不是utf8需要先转码为utf8再反序列化。

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志怎么写？

<!--
> 从用户角度描述具体变化，以及可能的 breaking change 和其他风险？
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |          |
| 🇨🇳 中文 |          |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] Changelog 已提供或无须提供