### PR TITLE
使用HashCode.Combine重构CssSizeLength的GetHashCode()方法

### DIFF
--- a/components/core/CssSizeLength.cs
+++ b/components/core/CssSizeLength.cs
@@ -81,7 +81,7 @@ namespace AntDesign
 
         public override bool Equals(object obj) => obj is CssSizeLength other && Equals(other);
 
-        public override int GetHashCode() => unchecked(_value.GetHashCode() + _unit.GetHashCode());
+        public override int GetHashCode() => HashCode.Combine(_value, _unit);
 
         public static bool operator ==(CssSizeLength left, CssSizeLength right) => left.Equals(right);
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在一个维护者审核通过后合并。
请确保填写以下 pull request 的信息，谢谢！~

[[English Template / 英文模板](?expand=1)]
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式改进
- [ ] 包体积优化
- [ ] 性能优化
- [x] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
一般的，在实现GetHashCode上，我们倾向于使用异或两值，这个得到的值不会溢出。现在，我们还可以使用基础库提供的HashCode.Combine()方法来实现。

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志怎么写？

<!--
> 从用户角度描述具体变化，以及可能的 breaking change 和其他风险？
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |          |
| 🇨🇳 中文 |          |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] Changelog 已提供或无须提供