### PR TITLE
fix(module: AutoComplete): overlay couldn't close

### DIFF
--- a/components/auto-complete/AutoComplete.razor
+++ b/components/auto-complete/AutoComplete.razor
@@ -5,8 +5,8 @@
 
 <div @ref="@_divRef" style="@Style" id="@Id">
     <CascadingValue Value='$"ant-select-dropdown"' Name="PrefixCls">
-        <OverlayTrigger Style="display: inline"
-                        Visible="@(ShowPanel && !_isOptionsZero)"
+        <OverlayTrigger @ref="_overlayTrigger"
+                        Style="display: inline"
                         IsButton="@true"
                         Disabled="false"
                         Trigger="new TriggerType[] { TriggerType.Click }"
@@ -17,9 +17,8 @@
                         OverlayStyle="@OverlayStyle"
                         OnVisibleChange="@OnOverlayTriggerVisibleChange">
             <Overlay>
-
                 <CascadingValue Value="this">
-                    @if (ShowPanel)
+                    @if (ShowPanel && !_isOptionsZero)
                     {
                         <div style="max-height: 256px; overflow-y: auto; overflow-anchor: none; @_minWidth">
                             <div style="display: flex;flex-direction: column;">

--- a/components/auto-complete/AutoComplete.razor.cs
+++ b/components/auto-complete/AutoComplete.razor.cs
@@ -1,10 +1,9 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Data;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
+using AntDesign.Internal;
 using AntDesign.JsInterop;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
@@ -136,6 +135,7 @@ namespace AntDesign
         #endregion Parameters
 
         private ElementReference _divRef;
+        private OverlayTrigger _overlayTrigger;
 
         public object SelectedValue { get; set; }
         /// <summary>
@@ -165,7 +165,10 @@ namespace AntDesign
         #region 子控件触发事件
         public async Task InputFocus(FocusEventArgs e)
         {
-            this.OpenPanel();
+            if (!_isOptionsZero)
+            {
+                this.OpenPanel();
+            }
         }
 
         public async Task InputInput(ChangeEventArgs args)
@@ -190,7 +193,7 @@ namespace AntDesign
                     await SetSelectedItem(GetActiveItem());
                 }
             }
-            else
+            else if (!_isOptionsZero)
             {
                 this.OpenPanel();
             }
@@ -255,6 +258,9 @@ namespace AntDesign
             if (this.ShowPanel == false)
             {
                 this.ShowPanel = true;
+
+                _overlayTrigger.Show();
+
                 ResetActiveItem();
                 StateHasChanged();
             }
@@ -268,6 +274,9 @@ namespace AntDesign
             if (this.ShowPanel == true)
             {
                 this.ShowPanel = false;
+
+                _overlayTrigger.Close();
+
                 StateHasChanged();
             }
         }
@@ -318,7 +327,8 @@ namespace AntDesign
             var items = GetOptionItems();
             _isOptionsZero = items.Count == 0 && Options != null;
             if (items.Any(x => CompareWith(x.Value, this.ActiveValue)) == false)
-            {//如果当前激活项找在列表中不存在，那么我们需要做一些处理
+            {
+                // 如果当前激活项找在列表中不存在，那么我们需要做一些处理
                 if (items.Any(x => CompareWith(x.Value, this.SelectedValue)))
                 {
                     this.ActiveValue = this.SelectedValue;
@@ -330,6 +340,20 @@ namespace AntDesign
                 else
                 {
                     this.ActiveValue = null;
+                }
+            }
+
+            if (_overlayTrigger != null && ShowPanel)
+            {
+                // if options count == 0 then close overlay
+                if (_isOptionsZero && _overlayTrigger.IsOverlayShow())
+                {
+                    _overlayTrigger.Close();
+                }
+                // if options count > 0 then open overlay
+                else if (!_isOptionsZero && !_overlayTrigger.IsOverlayShow())
+                {
+                    _overlayTrigger.Show();
                 }
             }
         }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

当通过Visible参数控制OverlayTrigger时，Overlay组件无法自主关闭（参考：[pr743](https://github.com/ant-design-blazor/ant-design-blazor/pull/743)）

overlay cann't be close when it is controlled via visable param (see: [pr743](https://github.com/ant-design-blazor/ant-design-blazor/pull/743))

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       fix(module: AutoComplete): overlay couldn't close    |
| 🇨🇳 Chinese |       fix(module: AutoComplete): 下拉面板无法关闭   |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
