### PR TITLE
fix : badgeribbon with preset color

### DIFF
--- a/components/badge/BadgeRibbon.razor
+++ b/components/badge/BadgeRibbon.razor
@@ -7,7 +7,9 @@
         @ChildContent
     }
     <div class="@ClassMapper.Class" style="@_colorStyle">
-        @if (TextTemplate != null)@TextTemplate else @Text
+        <span class="ant-ribbon-text">
+            @if (TextTemplate != null)@TextTemplate else @Text
+        </span>
         <div class="ant-ribbon-corner" style="@_cornerColorStyle" />
     </div>
 </div>

--- a/components/badge/style/ribbon.less
+++ b/components/badge/style/ribbon.less
@@ -54,11 +54,9 @@
     @color: extract(@preset-colors, @i);
     @darkColor: '@{color}-6';
     &-color-@{color} {
-      background: @@darkColor;
-    }
-    .@{ribbon-prefix-cls}-corner {
       color: @@darkColor;
-    }
+      background: @@darkColor;
+    }    
   }
   .make-color-classes();
 

--- a/components/badge/style/ribbon.less
+++ b/components/badge/style/ribbon.less
@@ -54,8 +54,10 @@
     @color: extract(@preset-colors, @i);
     @darkColor: '@{color}-6';
     &-color-@{color} {
-      color: @@darkColor;
       background: @@darkColor;
+    }
+    .@{ribbon-prefix-cls}-corner {
+      color: @@darkColor;
     }
   }
   .make-color-classes();

--- a/components/badge/style/ribbon.less
+++ b/components/badge/style/ribbon.less
@@ -56,7 +56,7 @@
     &-color-@{color} {
       color: @@darkColor;
       background: @@darkColor;
-    }    
+    }
   }
   .make-color-classes();
 

--- a/site/AntBlazor.Docs/Demos/Components/Badge/demo/Ribbon.razor
+++ b/site/AntBlazor.Docs/Demos/Components/Badge/demo/Ribbon.razor
@@ -2,6 +2,14 @@
     <Card Bordered>And raises the spyglass.</Card>
 </BadgeRibbon>
 <br />
+<BadgeRibbon Text="Pushes open the window" Color="orange">
+    <Card Bordered>And raises the spyglass.</Card>
+</BadgeRibbon>
+<br />
+<BadgeRibbon Text="Pushes open the window" Color="#832">
+    <Card Bordered>And raises the spyglass.</Card>
+</BadgeRibbon>
+<br />
 <BadgeRibbon >
     <TextTemplate>
         <Icon Type="windows" Theme="outline" />Pushes open the window

--- a/tests/badge/RibbonTests.cs
+++ b/tests/badge/RibbonTests.cs
@@ -1,4 +1,4 @@
-﻿using Bunit;
+using Bunit;
 using Microsoft.AspNetCore.Components;
 using Xunit;
 
@@ -13,6 +13,7 @@ namespace AntDesign.Tests.Badge
             cut.MarkupMatches(@"
                 <div class=""ant-ribbon-wrapper""> 
                     <div class=""ant-ribbon ant-ribbon-placement-end"">
+                    <span class=""ant-ribbon-text""></span>
                         <div class=""ant-ribbon-corner""></div>
                     </div>
                 </div>
@@ -32,6 +33,7 @@ namespace AntDesign.Tests.Badge
                 <div class=""ant-ribbon-wrapper""> 
                     <div /> 
                     <div class=""ant-ribbon ant-ribbon-placement-start"">
+                    <span class=""ant-ribbon-text""></span>
                     <div class=""ant-ribbon-corner"">
                         </div>
                     </div>
@@ -48,6 +50,7 @@ namespace AntDesign.Tests.Badge
                 <div class=""ant-ribbon-wrapper""> 
                     <div /> 
                     <div class=""ant-ribbon ant-ribbon-placement-end"">
+                    <span class=""ant-ribbon-text""></span>
                     <div class=""ant-ribbon-corner"">
                         </div>
                     </div>
@@ -68,6 +71,7 @@ namespace AntDesign.Tests.Badge
                 <div class=""ant-ribbon-wrapper""> 
                     <div /> 
                     <div class=""ant-ribbon ant-ribbon-placement-end ant-ribbon-color-green"">
+                    <span class=""ant-ribbon-text""></span>
                     <div class=""ant-ribbon-corner"">
                         </div>
                     </div>
@@ -91,6 +95,7 @@ namespace AntDesign.Tests.Badge
                 <div class=""ant-ribbon-wrapper""> 
                     <div /> 
                     <div class=""ant-ribbon ant-ribbon-placement-end"" style=""background: {color}"">
+                    <span class=""ant-ribbon-text""></span>
                     <div class=""ant-ribbon-corner"" style=""color: {color}"">
                         </div>
                     </div>
@@ -112,7 +117,7 @@ namespace AntDesign.Tests.Badge
                 <div class=""ant-ribbon-wrapper""> 
                     <div /> 
                     <div class=""ant-ribbon ant-ribbon-placement-end"">
-                        unicorn
+                    <span class=""ant-ribbon-text"">unicorn</span>                        
                         <div class=""ant-ribbon-corner"">
                             </div>
                         </div>
@@ -142,7 +147,9 @@ namespace AntDesign.Tests.Badge
                 <div class=""ant-ribbon-wrapper""> 
                     <div /> 
                     <div class=""ant-ribbon ant-ribbon-placement-end"">
-                        <span class=""cool"">Hello</span>
+                        <span class=""ant-ribbon-text"">
+                            <span class=""cool"">Hello</span>
+                        </span>
                         <div class=""ant-ribbon-corner"">
                         </div>
                     </div>

--- a/tests/badge/RibbonTests.cs
+++ b/tests/badge/RibbonTests.cs
@@ -117,7 +117,7 @@ namespace AntDesign.Tests.Badge
                 <div class=""ant-ribbon-wrapper""> 
                     <div /> 
                     <div class=""ant-ribbon ant-ribbon-placement-end"">
-                    <span class=""ant-ribbon-text"">unicorn</span>                        
+                    <span class=""ant-ribbon-text"">unicorn</span>
                         <div class=""ant-ribbon-corner"">
                             </div>
                         </div>


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ x ] Bug fix
- [ ] Site / documentation update
- [ x ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

When using BadgeRibbon with a preset color, text color is the same as background color.

### 💡 Background and solution

Here is a snapshot of the bug
```
<BadgeRibbon Text="Pushes open the window" Color="orange">
    <Card Bordered>And raises the spyglass.</Card>
</BadgeRibbon>
<br />
<BadgeRibbon Text="Pushes open the window" Color="#832">
    <Card Bordered>And raises the spyglass.</Card>
</BadgeRibbon>
```
![image](https://user-images.githubusercontent.com/1549198/99258585-136aec80-2819-11eb-9225-564ea830cf83.png)

Solution : Fix less file.

### 📝 Changelog

Updated ribbon less file. 
Added two ribbon examples with color set (preset and custom)

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
