### PR TITLE
fix(module: modal): dom cannot be destroyed when the page changed on DestroyOnClose is false

### DIFF
--- a/components/core/JsInterop/JSInteropConstants.cs
+++ b/components/core/JsInterop/JSInteropConstants.cs
@@ -65,6 +65,8 @@ namespace AntDesign
 
         public static string EnableBodyScroll => $"{FUNC_PREFIX}enableBodyScroll";
 
+        public static string DestroyAllDialog => $"{FUNC_PREFIX}destroyAllDialog";
+
         public static string CreateIconFromfontCN => $"{FUNC_PREFIX}createIconFromfontCN";
 
         public static string GetScroll => $"{FUNC_PREFIX}getScroll";

--- a/components/core/JsInterop/interop.ts
+++ b/components/core/JsInterop/interop.ts
@@ -424,6 +424,12 @@ export function enableBodyScroll() {
   removeCls(document.body, "ant-scrolling-effect");
 }
 
+export function destroyAllDialog() {
+    console.log(document.querySelectorAll('.ant-modal-root').length);
+    document.querySelectorAll('.ant-modal-root')
+        .forEach(e => document.body.removeChild(e.parentNode));
+}
+
 export function createIconFromfontCN(scriptUrl) {
   if (document.querySelector(`[data-namespace="${scriptUrl}"]`)) {
     return;

--- a/components/core/JsInterop/interop.ts
+++ b/components/core/JsInterop/interop.ts
@@ -425,7 +425,6 @@ export function enableBodyScroll() {
 }
 
 export function destroyAllDialog() {
-    console.log(document.querySelectorAll('.ant-modal-root').length);
     document.querySelectorAll('.ant-modal-root')
         .forEach(e => document.body.removeChild(e.parentNode));
 }

--- a/components/modal/Modal.razor.cs
+++ b/components/modal/Modal.razor.cs
@@ -15,6 +15,8 @@ namespace AntDesign
     {
         private const string PrefixCls = "ant-modal";
 
+        internal static HashSet<Modal> ReusedModals = new HashSet<Modal>(); 
+
         #region Parameter
 
         [Parameter] public Func<Task> AfterClose { get; set; }
@@ -199,6 +201,12 @@ namespace AntDesign
             {
                 _hasAdd = true;
             }
+
+            if (!DestroyOnClose && !ReusedModals.Contains(this))
+            {
+                ReusedModals.Add(this);
+            }
+
             await base.OnParametersSetAsync();
         }
 

--- a/components/modal/ModalServiceForModal.cs
+++ b/components/modal/ModalServiceForModal.cs
@@ -3,17 +3,45 @@ using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
 
 namespace AntDesign
 {
-    public partial class ModalService
+    public partial class ModalService : IDisposable
     {
         internal event Func<ModalRef, Task> OnModalOpenEvent;
 
         internal event Func<ModalRef, Task> OnModalCloseEvent;
 
+        private readonly NavigationManager _navigationManager;
+        private readonly IJSRuntime _jsRuntime;
         /// <summary>
-        /// Create and open a Moal
+        /// constructor
+        /// </summary>
+        public ModalService(NavigationManager navigationManager, IJSRuntime jsRuntime)
+        {
+            _navigationManager = navigationManager;
+            _navigationManager.LocationChanged += NavigationManager_LocationChanged;
+            _jsRuntime = jsRuntime;
+        }
+
+        /// <summary>
+        /// Destroy all reused Modal
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private async void NavigationManager_LocationChanged(object sender, Microsoft.AspNetCore.Components.Routing.LocationChangedEventArgs e)
+        {
+            if (Modal.ReusedModals.Count > 0)
+            {
+                // Since Modal cannot be captured, it can only be removed through JS
+                await _jsRuntime.InvokeVoidAsync(JSInteropConstants.DestroyAllDialog);
+                Modal.ReusedModals.Clear();
+            }
+        }
+
+        /// <summary>
+        /// Create and open a Modal
         /// </summary>
         /// <returns></returns>
         public Task<ModalRef> CreateModalAsync(ModalOptions config)
@@ -68,6 +96,15 @@ namespace AntDesign
                 return OnModalCloseEvent.Invoke(modalRef);
             }
             return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Implement the interface IDisposable
+        /// </summary>
+        public void Dispose()
+        {
+            _navigationManager.LocationChanged -= NavigationManager_LocationChanged;
+            GC.SuppressFinalize(this);
         }
     }
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
#757 

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | When the page changes, the dom of the modal component whose destroyonclose is false is automatically deleted |
| 🇨🇳 Chinese | 当页面发生变化时自动删除DestroyOnClose为false的Modal组件的DOM |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
