### PR TITLE
fix(module: modal): throw error when using ModalService if not set ModalOptions.AfterClose (#807)

### DIFF
--- a/components/modal/ModalContainer.razor
+++ b/components/modal/ModalContainer.razor
@@ -6,7 +6,7 @@
 {
     var options = modalRef.Config;
     <Modal @key="@options"
-           AfterClose="@options.AfterClose"
+           AfterClose="@options.GetAfterClose()"
            BodyStyle="@options.BodyStyle"
            CancelText="@options.CancelText"
            Centered="@options.Centered"

--- a/components/modal/ModalContainer.razor
+++ b/components/modal/ModalContainer.razor
@@ -6,7 +6,7 @@
 {
     var options = modalRef.Config;
     <Modal @key="@options"
-           AfterClose="@options.GetAfterClose()"
+           AfterClose="@options.AfterClose"
            BodyStyle="@options.BodyStyle"
            CancelText="@options.CancelText"
            Centered="@options.Centered"
@@ -30,8 +30,8 @@
            Width="@options.Width"
            WrapClassName="@options.WrapClassName"
            ZIndex="@options.ZIndex"
-           OnCancel="@options.GetOnCancel()"
-           OnOk="@options.GetOnOk()"
+           OnCancel="@options.OnCancel"
+           OnOk="@options.OnOk"
            OkButtonProps="@options.OkButtonProps"
            CancelButtonProps="@options.CancelButtonProps"
            >

--- a/components/modal/config/ModalOptions.cs
+++ b/components/modal/config/ModalOptions.cs
@@ -31,6 +31,12 @@ namespace AntDesign
 
         public Func<Task> AfterClose { get; set; }
 
+        internal Func<Task> GetAfterClose()
+        {
+            return AfterClose ?? (() => Task.CompletedTask);
+        }
+
+
         public string BodyStyle { get; set; }
 
         public OneOf<string, RenderFragment> CancelText { get; set; } = "Cancel";
@@ -77,7 +83,7 @@ namespace AntDesign
 
         public int ZIndex { get; set; } = 1000;
 
-        public Func<MouseEventArgs, Task> OnCancel { get; set; }
+        public Func<MouseEventArgs, Task> OnCancel { get; set; } = null;
 
         internal Func<MouseEventArgs, Task> GetOnCancel()
         {

--- a/components/modal/config/ModalOptions.cs
+++ b/components/modal/config/ModalOptions.cs
@@ -29,13 +29,7 @@ namespace AntDesign
             builder.CloseComponent();
         };
 
-        public Func<Task> AfterClose { get; set; }
-
-        internal Func<Task> GetAfterClose()
-        {
-            return AfterClose ?? (() => Task.CompletedTask);
-        }
-
+        public Func<Task> AfterClose { get; set; } = () => Task.CompletedTask;
 
         public string BodyStyle { get; set; }
 
@@ -59,7 +53,7 @@ namespace AntDesign
 
         public bool ForceRender { get; set; }
 
-        public ElementReference? GetContainer { get; set; } = null;
+        public ElementReference? GetContainer { get; set; }
 
         public bool Keyboard { get; set; } = true;
 
@@ -83,26 +77,42 @@ namespace AntDesign
 
         public int ZIndex { get; set; } = 1000;
 
-        public Func<MouseEventArgs, Task> OnCancel { get; set; } = null;
+        private Func<MouseEventArgs, Task> _onCancel;
 
-        internal Func<MouseEventArgs, Task> GetOnCancel()
+        public Func<MouseEventArgs, Task> OnCancel
         {
-            if (OnCancel != null) return OnCancel;
-            return async (e) =>
+            get
             {
-                await (ModalRef?.CloseAsync() ?? Task.CompletedTask);
-            };
+                return _onCancel ??= DefaultOnCancelOrOk;
+            }
+            set
+            {
+                _onCancel = value;
+            }
         }
 
-        public Func<MouseEventArgs, Task> OnOk { get; set; }
+        private Func<MouseEventArgs, Task> _onOk;
 
-        internal Func<MouseEventArgs, Task> GetOnOk()
+        public ModalOptions()
         {
-            if (OnOk != null) return OnOk;
-            return async (e) =>
+            Rtl = false;
+        }
+
+        public Func<MouseEventArgs, Task> OnOk
+        {
+            get
             {
-                await (ModalRef?.CloseAsync() ?? Task.CompletedTask);
-            };
+                return _onOk ??= DefaultOnCancelOrOk;
+            }
+            set
+            {
+                _onOk = value;
+            }
+        }
+
+        internal async Task DefaultOnCancelOrOk(MouseEventArgs e)
+        {
+            await (ModalRef?.CloseAsync() ?? Task.CompletedTask);
         }
 
         public ButtonProps OkButtonProps { get; set; }
@@ -111,6 +121,6 @@ namespace AntDesign
 
         public RenderFragment Content { get; set; }
 
-        public bool Rtl { get; set; } = false;
+        public bool Rtl { get; set; }
     }
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
#807 

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Inspection before use ModalOptions.AfterClose Is it null |
| 🇨🇳 Chinese | 使用前检查ModalOptions.AfterClose是否为null |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
