### PR TITLE
fix(module: tabs): stops tabs buttons from flickering when icons are …

### DIFF
--- a/components/tabs/TabPane.cs
+++ b/components/tabs/TabPane.cs
@@ -2,7 +2,7 @@
 
 namespace AntDesign
 {
-    public partial class TabPane : AntDomComponentBase
+    public class TabPane : AntDomComponentBase
     {
         private const string PrefixCls = "ant-tabs-tab";
         private Tabs _parent;
@@ -11,6 +11,7 @@ namespace AntDesign
 
         internal bool IsActive { get; set; }
         internal bool HasRendered { get; set; }
+        internal ElementReference TabBar { get; set; }
 
         public TabPane()
         {

--- a/components/tabs/TabPane.razor
+++ b/components/tabs/TabPane.razor
@@ -1,2 +1,0 @@
-﻿@namespace AntDesign
-@inherits AntDomComponentBase

--- a/components/tabs/Tabs.razor
+++ b/components/tabs/Tabs.razor
@@ -11,51 +11,40 @@
             <div class="ant-tabs-nav-list" style="@_navStyle" @ref="@_scrollTabBar">
                 @foreach (var pane in _panes)
                 {
-                    if (pane.IsActive)
-                    {
-                        <button @ref="_activeTabBar" type="button" role="tab" aria-selected="@(pane.IsActive)" tabindex="0" class="@pane._classMapper.Class" id="@($"rc-tabs-{Id}-tab-{pane.Key}")" aria-controls="@($"rc-tabs-{Id}-tab-{pane.Key}")"
-                                draggable="@Draggable.ToString()"
-                                @ondragover:preventDefault
-                                ondragover="event.preventDefault();"
-                                @ondragstart="(e)=>HandleDragStart(e, pane)"
-                                @ondrop="(e)=>HandleDrop(pane)">
-                            @if (Type == TabType.EditableCard && pane.Closable)
-                            {
-                                @pane.Tab
-                                <span class="ant-tabs-tab-remove">
-                                    <Icon Type="close" @onclick="(e)=>RemoveTabPane(pane)" />
-                                </span>
-                            }
-                            else
-                            {
-                                @pane.Tab
-                            }
-                        </button>
-                    }
-                    else
-                    {
-                        <button type="button" role="tab" aria-selected="@(pane.IsActive)" tabindex="0" class="@pane._classMapper.Class" id="@($"rc-tabs-{Id}-tab-{pane.Key}")" aria-controls="@($"rc-tabs-{Id}-tab-{pane.Key}")"
-                                disabled="@(pane.Disabled)"
-                                @onclick="(e)=>HandleTabClick(pane,e)"
-                                @onclick:stopPropagation
-                                draggable="@Draggable.ToString()"
-                                ondragover="event.preventDefault();"
-                                @ondragstart="(e)=>HandleDragStart(e, pane)"
-                                @ondrop="(e)=>HandleDrop(pane)">
-                            @if (Type == TabType.EditableCard && pane.Closable)
-                            {
-                                @pane.Tab
-                                <span class="ant-tabs-tab-remove">
-                                    <Icon Type="close" @onclick="(e)=>RemoveTabPane(pane)" />
-                                </span>
-                            }
-                            else
-                            {
-                                @pane.Tab
-                            }
-                        </button>
-                    }
+                    var ondragoverPreventDefault = pane.IsActive;
+                    var onclickStopPropagation = !pane.IsActive;
+
+                    <button @key="pane.Key"
+                            @ref="pane.TabBar"
+                            @onclick:stopPropagation="@onclickStopPropagation"
+                            @onclick="@(e => HandleTabClick(pane,e))"
+                            @ondragover:preventDefault="@ondragoverPreventDefault"
+                            @ondragstart="@(e => HandleDragStart(e, pane))"
+                            @ondrop="@(_ => HandleDrop(pane))"
+                            aria-controls="@($"rc-tabs-{Id}-tab-{pane.Key}")"
+                            aria-selected="@(pane.IsActive)"
+                            class="@pane._classMapper.Class"
+                            draggable="@Draggable.ToString()"
+                            id="@($"rc-tabs-{Id}-tab-{pane.Key}")"
+                            ondragover="event.preventDefault();"
+                            role="tab"
+                            tabindex="0"
+                            type="button"
+                            >
+                        @if (Type == TabType.EditableCard && pane.Closable)
+                        {
+                            @pane.Tab
+                            <span class="ant-tabs-tab-remove">
+                                <Icon Type="close" @onclick="(e)=>RemoveTabPane(pane)" />
+                            </span>
+                        }
+                        else
+                        {
+                            @pane.Tab
+                        }
+                    </button>
                 }
+
                 @if (Type == TabType.EditableCard && !HideAdd)
                 {
                     <button type="button" class="ant-tabs-nav-add" aria-label="Add tab" @onclick="(e)=>AddTabPane(e)">

--- a/components/tabs/Tabs.razor.cs
+++ b/components/tabs/Tabs.razor.cs
@@ -20,7 +20,6 @@ namespace AntDesign
         private TabPane _activePane;
 
         private TabPane _renderedActivePane;
-        private ElementReference _activeTabBar;
 
         private ElementReference _scrollTabBar;
         private ElementReference _tabBars;
@@ -336,6 +335,9 @@ namespace AntDesign
 
         private void HandleTabClick(TabPane tabPane, MouseEventArgs args)
         {
+            if (tabPane.IsActive)
+                    return;
+
             if (OnTabClick.HasDelegate)
             {
                 OnTabClick.InvokeAsync(tabPane.Key);
@@ -420,9 +422,9 @@ namespace AntDesign
                 // TODO: slide to activated tab
                 // animate Active Ink
                 // ink bar
-                Element element = await JsInvokeAsync<Element>(JSInteropConstants.GetDomInfo, _activeTabBar);
-                Element navSection = await JsInvokeAsync<Element>(JSInteropConstants.GetDomInfo, _tabBars);
-                Element navScroll = await JsInvokeAsync<Element>(JSInteropConstants.GetDomInfo, _scrollTabBar);
+                var element = await JsInvokeAsync<Element>(JSInteropConstants.GetDomInfo, _activePane.TabBar);
+                var navSection = await JsInvokeAsync<Element>(JSInteropConstants.GetDomInfo, _tabBars);
+
                 if (IsHorizontal)
                 {
                     //_inkStyle = "left: 0px; width: 0px;";

--- a/site/AntBlazor.Docs/Demos/Components/Tabs/demo/Slide.razor
+++ b/site/AntBlazor.Docs/Demos/Components/Tabs/demo/Slide.razor
@@ -6,9 +6,10 @@
     <Tabs DefaultActiveKey="0" TabPosition="@mode" Style="height: 220px;">
         @for (int i = 0; i < 30; i++)
         {
-            <TabPane Key="@($"{i}")">
-                <Tab>Tab-@i</Tab>
-                <ChildContent>Content of tab Pane @i</ChildContent>
+            var myTab = i;
+            <TabPane Key="@($"{myTab}")">
+                <Tab>Tab-@myTab</Tab>
+                <ChildContent>Content of tab Pane @myTab</ChildContent>
             </TabPane>
         }
     </Tabs>

--- a/tests/tabs/TabsTests.cs
+++ b/tests/tabs/TabsTests.cs
@@ -32,8 +32,8 @@ namespace AntDesign.Tests.tabs
         {
             var tabPane1Builder = new ComponentParameterBuilder<TabPane>()
                 .Add(x => x.Key, key)
-                .Add(x => x.Tab, RenderFragmentHelper.ToRenderFragment($"Tab {key}"))
-                .Add(x => x.ChildContent, RenderFragmentHelper.ToRenderFragment($"Content {key}"));
+                .Add(x => x.Tab, $"Tab {key}".ToRenderFragment())
+                .Add(x => x.ChildContent, $"Content {key}".ToRenderFragment());
 
             configure?.Invoke(tabPane1Builder);
 
@@ -92,6 +92,25 @@ namespace AntDesign.Tests.tabs
             cut.SetParametersAndRender(p => p.Add(x => x.ActiveKey, "1"));
 
             Assert.Equal(2, renderedPanes.Count);
+        }
+
+        [Fact]
+        public void Clicking_on_an_inactive_tab_should_make_it_active()
+        {
+            var cut = CreateTabs(p =>
+            {
+                var tabPane1 = CreateTabPanel("1");
+                var tabPane2 = CreateTabPanel("2");
+
+                tabPane1(p);
+                tabPane2(p);
+            });
+
+            Assert.Equal("Content 2", cut.Find(".ant-tabs-tabpane").TextContent);
+
+            cut.Find("button.ant-tabs-tab").Click();
+
+            Assert.Equal("Content 1", cut.Find(".ant-tabs-tabpane").TextContent);
         }
     }
 }


### PR DESCRIPTION
### 🤔 This is a ...

- [X] Bug fix
- [X] Site / documentation update

### 🔗 Related issue link

Flicker issue: not raised.
Documentation issue: https://github.com/ant-design-blazor/ant-design-blazor/issues/619

### 💡 Background and solution

When changing switching between tabs, the tab bar will flicker if there are any icons present. This flicker also causes the tab ink to be calculated incorrectly as the icon width is not accounted for. This PR fixes the flicker and mitigates the ink offset and width calculation issue.

This PR fixes the flickering issue by adding @key to the tab nav list, which avoids re-rendering all tab buttons anytime a tab switch occurs.

Also, this PR fixes a problem with documentation referenced on issue #619.

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] Changelog is provided or not needed
