### PR TITLE
Make description element visible if passed in ChildContent

### DIFF
--- a/components/alert/Alert.razor.cs
+++ b/components/alert/Alert.razor.cs
@@ -113,7 +113,7 @@ namespace AntDesign
                 .If($"{prefixName}-no-icon", () => !ShowIcon)
                 .If($"{prefixName}-closable", () => Closable)
                 .If($"{prefixName}-banner", () => Banner)
-                .If($"{prefixName}-with-description", () => !string.IsNullOrEmpty(Description))
+                .If($"{prefixName}-with-description", () => !string.IsNullOrEmpty(Description) || ChildContent != null)
                 .If($"{prefixName}-motion", () => _isClosing)
                 .If($"{prefixName}-motion-leave", () => _isClosing)
                 .If($"{prefixName}-motion-leave-active", () => _isClosing && _motionStage == 1)

--- a/site/AntBlazor.Docs/Demos/Components/Alert/demo/Description.razor
+++ b/site/AntBlazor.Docs/Demos/Components/Alert/demo/Description.razor
@@ -3,8 +3,9 @@
           Type="@AlertType.Success" />
 
 <Alert Message="Info Text"
-          Description="Info Description Info Description Info Description Info Description"
-          Type="@AlertType.Info" />
+          Type="@AlertType.Info">
+    Info Description Info Description Info Description Info Description
+</Alert>
 
 <Alert Message="Warning Text"
           Description="Warning Description Warning Description Warning Description Warning Description"


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [x] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

#875 

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->
Fix is simple - modified conditions which are used to apply `ant-alert-description` to span with desciption (span was rendered but with default `display: none` style).
One thing to mention - the user can simultaneously pass the value in the `Description` parameter and define the content in `ChildContent`. In this case, two span tags with a description are inserted and render side by side instead of one below the other. I did not try to fix this because it is a rather rare case and I also feel average about CSS;]

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
