### PR TITLE
fix(module:slider): drag, select, focus and rapid reposition fix

### DIFF
--- a/components/slider/Slider.razor
+++ b/components/slider/Slider.razor
@@ -2,7 +2,7 @@
 @typeparam TValue
 @inherits AntInputComponentBase<TValue>
 
-<div class="@ClassMapper.Class" style="@Style" id="@Id" @ref="_slider"
+<div class="@ClassMapper.Class" style="user-select:none;@Style" id="@Id" @ref="_slider"
      @onmousedown="(e)=>OnMouseDown(e)">
     <div class="ant-slider-rail">
     </div>

--- a/components/slider/Slider.razor.cs
+++ b/components/slider/Slider.razor.cs
@@ -28,6 +28,8 @@ namespace AntDesign
         private bool _mouseMove;
         private bool _right = true;
         private bool _initialized = false;
+        private double _initialLeftValue;
+        private double _initialRightValue;
 
         private string RightHandleStyleFormat
         {
@@ -465,11 +467,13 @@ namespace AntDesign
         private void OnMouseDownEdge(MouseEventArgs args, bool right)
         {
             _right = right;
+            _initialLeftValue = _leftValue;
+            _initialRightValue = _rightValue;
             _edgeClickArgs = args;
         }
 
         private bool IsMoveInEdgeBoundary(JsonElement jsonElement)
-        {
+        {            
             if (_edgeClicked == null)
             {
                 double clientX = jsonElement.GetProperty("clientX").GetDouble();
@@ -492,7 +496,7 @@ namespace AntDesign
 
         private async void OnMouseMove(JsonElement jsonElement)
         {
-            if (_mouseDown && !IsMoveInEdgeBoundary(jsonElement))
+            if (_mouseDown)
             {
                 _mouseMove = true;
                 await CalculateValueAsync(Vertical ? jsonElement.GetProperty("pageY").GetDouble() : jsonElement.GetProperty("pageX").GetDouble());
@@ -515,6 +519,8 @@ namespace AntDesign
             if (_edgeClicked != null)
             {
                 _edgeClicked = null;
+                _initialLeftValue = _leftValue;
+                _initialRightValue = _rightValue;
             }
         }
 
@@ -530,27 +536,26 @@ namespace AntDesign
                 {
                     _rightHandleDom = await JsInvokeAsync<Element>(JSInteropConstants.GetDomInfo, _rightHandle);
                 }
-                double handleLength = (double)(Vertical ? _rightHandleDom.clientHeight : _rightHandleDom.clientWidth);
                 if (Reverse)
                 {
                     if (Vertical)
                     {
-                        handleNewPosition = clickClient - sliderOffset + handleLength / 2;
+                        handleNewPosition = clickClient - sliderOffset;
                     }
                     else
                     {
-                        handleNewPosition = sliderLength - (clickClient - sliderOffset) + handleLength / 2;
+                        handleNewPosition = sliderLength - (clickClient - sliderOffset);
                     }
                 }
                 else
                 {
                     if (Vertical)
                     {
-                        handleNewPosition = sliderOffset + sliderLength - clickClient - handleLength / 2;
+                        handleNewPosition = sliderOffset + sliderLength - clickClient;
                     }
                     else
                     {
-                        handleNewPosition = clickClient - sliderOffset - handleLength / 2;
+                        handleNewPosition = clickClient - sliderOffset;
                     }
                 }
 
@@ -558,7 +563,10 @@ namespace AntDesign
                 if (rightV < LeftValue)
                 {
                     _right = false;
+                    if (_mouseDown)
+                        RightValue = _initialLeftValue;
                     LeftValue = rightV;
+                    await JsInvokeAsync(JSInteropConstants.Focus, _leftHandle);
                 }
                 else
                 {
@@ -575,27 +583,26 @@ namespace AntDesign
                 {
                     _rightHandleDom = await JsInvokeAsync<Element>(JSInteropConstants.GetDomInfo, _rightHandle);
                 }
-                double handleLength = (double)(Vertical ? _rightHandleDom.clientHeight : _rightHandleDom.clientWidth);
                 if (Reverse)
                 {
                     if (Vertical)
                     {
-                        handleNewPosition = clickClient - sliderOffset + handleLength / 2;
+                        handleNewPosition = clickClient - sliderOffset;
                     }
                     else
                     {
-                        handleNewPosition = sliderLength - (clickClient - sliderOffset) + handleLength / 2;
+                        handleNewPosition = sliderLength - (clickClient - sliderOffset);
                     }
                 }
                 else
                 {
                     if (Vertical)
                     {
-                        handleNewPosition = sliderOffset + sliderLength - clickClient - handleLength / 2;
+                        handleNewPosition = sliderOffset + sliderLength - clickClient;
                     }
                     else
                     {
-                        handleNewPosition = clickClient - sliderOffset - handleLength / 2;
+                        handleNewPosition = clickClient - sliderOffset;
                     }
                 }
 
@@ -603,7 +610,10 @@ namespace AntDesign
                 if (leftV > RightValue)
                 {
                     _right = true;
+                    if (_mouseDown)
+                        LeftValue = _initialRightValue;
                     RightValue = leftV;
+                    await JsInvokeAsync(JSInteropConstants.Focus, _rightHandle);
                 }
                 else
                 {

--- a/components/slider/Slider.razor.cs
+++ b/components/slider/Slider.razor.cs
@@ -170,6 +170,7 @@ namespace AntDesign
         /// </summary>
         //[Parameter]
         private bool? _range;
+
         public bool Range
         {
             get
@@ -206,7 +207,7 @@ namespace AntDesign
         public bool Reverse
         {
             get { return _reverse; }
-            set 
+            set
             {
                 if (_reverse != value)
                 {
@@ -300,7 +301,6 @@ namespace AntDesign
             }
             return GetNearestStep(value);
         }
-
 
         /// <summary>
         /// If true, the slider will be vertical.
@@ -464,6 +464,7 @@ namespace AntDesign
 
         private MouseEventArgs _edgeClickArgs;
         private bool? _edgeClicked;
+
         private void OnMouseDownEdge(MouseEventArgs args, bool right)
         {
             _right = right;
@@ -473,7 +474,7 @@ namespace AntDesign
         }
 
         private bool IsMoveInEdgeBoundary(JsonElement jsonElement)
-        {            
+        {
             if (_edgeClicked == null)
             {
                 double clientX = jsonElement.GetProperty("clientX").GetDouble();
@@ -527,7 +528,7 @@ namespace AntDesign
         private async Task CalculateValueAsync(double clickClient)
         {
             _sliderDom = await JsInvokeAsync<Element>(JSInteropConstants.GetDomInfo, _slider);
-            double sliderOffset = (double)(Vertical ? _sliderDom.absoluteTop: _sliderDom.absoluteLeft);
+            double sliderOffset = (double)(Vertical ? _sliderDom.absoluteTop : _sliderDom.absoluteLeft);
             double sliderLength = (double)(Vertical ? _sliderDom.clientHeight : _sliderDom.clientWidth);
             double handleNewPosition;
             if (_right)
@@ -697,7 +698,7 @@ namespace AntDesign
             return (typedValue.Item1 != LeftValue) && (typedValue.Item2 != RightValue);
         }
 
-        private TValue _value;        
+        private TValue _value;
 
         /// <summary>
         /// Gets or sets the value of the input. This should be used with two-way binding.

--- a/components/slider/style/index.less
+++ b/components/slider/style/index.less
@@ -12,6 +12,7 @@
   padding: 4px 0;
   cursor: pointer;
   touch-action: none;
+  user-select: none;
 
   .vertical();
 

--- a/components/slider/style/index.less
+++ b/components/slider/style/index.less
@@ -12,7 +12,6 @@
   padding: 4px 0;
   cursor: pointer;
   touch-action: none;
-  user-select: none;
 
   .vertical();
 


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
This addresses a number of small issues with slider:
1. When clicked and dragged to the left, often before first movement to the left a movement to the right was executed: 
![slider_goes_back_on_click](https://user-images.githubusercontent.com/6518006/102685803-d5803000-41eb-11eb-8df8-2113f841ba9d.gif)

2. When dragging, especially after page load, nothing was happening: 
![slider_drag_lag](https://user-images.githubusercontent.com/6518006/102685826-ecbf1d80-41eb-11eb-995e-c158cbedd40c.gif)

3. For ranged slider, when dragging one edge beyond the other range, the focus was not following (I am referring to transparent gradient border that is showing when edge gets focus) :
![slider_focus_fix](https://user-images.githubusercontent.com/6518006/102685854-22fc9d00-41ec-11eb-9417-859b444c2134.gif)

4. For ranged slider, when quickly dragging one edge beyond the other edge, the "not changed" edge also moves:
![slider_non_active_edge_not_locked](https://user-images.githubusercontent.com/6518006/102686188-8a1b5100-41ee-11eb-9fb2-1010b724d1c8.gif)

5. When dragging an edge, text selection should be inactive:
![slider_drag_and_select](https://user-images.githubusercontent.com/6518006/102686194-999a9a00-41ee-11eb-826e-913a730b478e.gif)



### 💡 Background and solution
1. Required changes to calculation method of the edge position.
2. Previously added method ```IsMoveInEdgeBoundary``` was removed from ```OnMouseMove``` event handler.
3. When side switch is discovered, a js focus method is called on appropriate edge.
4. When ranged slider is used, original values of each edge are stored when mouse down is registered. During side switch, the stored values are persisted, to ensure they do not change.
5. Added to class ```@{slider-prefix-cls}``` css ```user-select:none```

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
