### PR TITLE
'Upload' component change to use responseCode not a "error" string when upload failed

### DIFF
--- a/components/upload/Upload.razor.cs
+++ b/components/upload/Upload.razor.cs
@@ -222,7 +222,7 @@ namespace AntDesign
             file.State = UploadState.Fail;
             file.Progress = 100;
             _uploadInfo.File = file;
-            file.Response ??= "error";
+            file.Response ??= reponseCode;
             await UploadChanged(id, 100);
             await InvokeAsync(StateHasChanged);
             if (OnSingleCompleted.HasDelegate)


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 💡 Background and solution

1.Use Upload component,when upload failed,[OnSingleCompleted]File.Response only has a "error" string.
2.[OnSingleCompleted]File.Response should be responseCode.