### PR TITLE
fix: remove non auto destroyed Modal DOM created by ModalService (#926)

### DIFF
--- a/components/modal/modalDialog/Modal.razor.cs
+++ b/components/modal/modalDialog/Modal.razor.cs
@@ -13,8 +13,6 @@ namespace AntDesign
     /// </summary>
     public partial class Modal
     {
-        internal static HashSet<Modal> ReusedModals = new HashSet<Modal>();
-
         #region Parameter
 
         /// <summary>
@@ -284,19 +282,5 @@ namespace AntDesign
         }
 
         #endregion
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <returns></returns>
-        protected override async Task OnParametersSetAsync()
-        {
-            if (!DestroyOnClose && !ReusedModals.Contains(this))
-            {
-                ReusedModals.Add(this);
-            }
-
-            await base.OnParametersSetAsync();
-        }
     }
 }

--- a/components/modal/modalDialog/ModalServiceForModal.cs
+++ b/components/modal/modalDialog/ModalServiceForModal.cs
@@ -36,11 +36,11 @@ namespace AntDesign
         /// <param name="e"></param>
         private async void NavigationManager_LocationChanged(object sender, Microsoft.AspNetCore.Components.Routing.LocationChangedEventArgs e)
         {
-            if (Modal.ReusedModals.Count > 0)
+            if (ReusedModals.Count > 0)
             {
                 // Since Modal cannot be captured, it can only be removed through JS
                 await _jsRuntime.InvokeVoidAsync(JSInteropConstants.DestroyAllDialog);
-                Modal.ReusedModals.Clear();
+                ReusedModals.Clear();
             }
         }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
#926 
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  fix the Blazor error caused by using modal component directly: Cannot read property 'removeChild' of null  |
| 🇨🇳 Chinese | 修复直接使用Modal组件可能引起Blazor报错: Cannot read property 'removeChild' of null |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed