### PR TITLE
fix(module:alert): Change span to div when applicable for better responsive experience

### DIFF
--- a/components/alert/Alert.razor
+++ b/components/alert/Alert.razor
@@ -6,7 +6,7 @@
     <div data-show="@(!_isClosing||_isClosed?"true":"false")" class="@ClassMapper.Class" style="@_innerStyle @Style " Id="@Id" @ref="Ref">
         @if (ShowIcon)
         {
-            @if (Icon!=null)
+            @if (Icon != null)
             {
                 <div class="ant-alert-icon">
                     @Icon
@@ -17,18 +17,20 @@
                 <Icon Type="@IconType" Theme="@(string.IsNullOrWhiteSpace(Description)?"fill":"outline")" Class="ant-alert-icon" />
             }
         }
-        @if (!string.IsNullOrEmpty(Message))
-        {
-            <span class="ant-alert-message">@Message</span>
-        }
-        @if (!string.IsNullOrEmpty(Description))
-        {
-            <span class="ant-alert-description">@Description</span>
-        }
-        @if (ChildContent != null)
-        {
-            <span class="ant-alert-description">@ChildContent</span>
-        }
+        <div class="ant-alert-content">
+            @if (!string.IsNullOrEmpty(Message))
+            {
+                <div class="ant-alert-message">@Message</div>
+            }
+            @if (!string.IsNullOrEmpty(Description))
+            {
+                <div class="ant-alert-description">@Description</div>
+            }
+            @if (ChildContent != null)
+            {
+                <div class="ant-alert-description">@ChildContent</div>
+            }
+        </div>
         @if (Closable)
         {
             <button type="button" class="ant-alert-close-icon" tabindex="0" @onclick="@OnCloseHandler">
@@ -38,7 +40,7 @@
                 }
                 else
                 {
-                    <Icon Type="close"/>
+                    <Icon Type="close" />
                 }
             </button>
         }


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 💡 Background and solution
`<Alert>` in react ant-design is based on `<div>` elements while in ant-design-blazor is based on `<span>` elements, what causes this type of behaviour when resized:
![image](https://user-images.githubusercontent.com/6518006/104823041-df7b6a00-584f-11eb-8c56-947229d15d84.png)
Notice that also close button is not visible for closable alert.
Also gif demo:
![alert-resize-bug](https://user-images.githubusercontent.com/6518006/104823110-4d279600-5850-11eb-91d6-c924ff2e106e.gif)


The fix proposed by this PR is bringing the design directly in line with react ant-design:
1. Wrap all previous `<span>` elements with extra `<div class="ant-alert-content">` element
2. Replace all `<span>` with `<div>` elements.
New behaviour after changes:
![alert-resize-fixed](https://user-images.githubusercontent.com/6518006/104823149-9aa40300-5850-11eb-9df8-71c40843a6fd.gif)


### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
