### PR TITLE
fix(module:calendar): critical exception for ChangePickerValue

### DIFF
--- a/components/calendar/internal/CalendarPanelChooser.razor
+++ b/components/calendar/internal/CalendarPanelChooser.razor
@@ -3,7 +3,7 @@
 
 @{
     Action ClosePanel = () => { };
-    Action<DateTime, int> ChangePickerValue = async (date, index) => { await Calendar.ChangeValue(date); };
+    Action<DateTime, int?> ChangePickerValue = async (date, index) => { await Calendar.ChangeValue(date); };
     Action<DateTime, int> ChangeValue = async (date, index) => { await Calendar.ChangeValue(date); };
     Action<string, int> ChangePickerType = (type, index) => { Calendar.ChangePickerType(type, index); };
     Func<int, DateTime> GetIndexPickerValue = (index) => Calendar.Value;


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 💡 Background and solution
This is a critical fix for `Calendar` component. When changes were done to `DatePicker` and `RangePicker` (my PR #933) a change was done to one of the parameters used by `Calendar` component. I missed that, because `Calendar` does not use the property directly. Without that fix, `Calendar` component does not render at all (it raises an exception). I am sorry to say, that current demo page is broken as well...

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
