### PR TITLE
Make sider smarter

### DIFF
--- a/components/layout/Sider.razor
+++ b/components/layout/Sider.razor
@@ -1,7 +1,7 @@
 @namespace AntDesign
 @inherits AntDomComponentBase
 
-<aside class="@ClassMapper.Class" style="@SiderStyles @Style">
+<aside class="@ClassMapper.Class" style="@SiderStyles @Style" @onfocuslost="OnFocusLost" >
     @if (_isCollapsed && CollapsedWidth == 0)
     {
         <span class="ant-layout-sider-zero-width-trigger ant-layout-sider-zero-width-trigger-left"

--- a/components/layout/Sider.razor.cs
+++ b/components/layout/Sider.razor.cs
@@ -147,6 +147,17 @@ namespace AntDesign
             StateHasChanged();
         }
 
+        private void OnFocusLost()
+        {
+            if (_isCollapsed ||
+                CollapsedWidth != 0)
+            {
+                return;
+            }
+            
+            ToggleCollapsed();
+        }
+
         protected override void Dispose(bool disposing)
         {
             base.Dispose(disposing);


### PR DESCRIPTION
When the sider has a breakpoint for 0 width, ie:
![image](https://user-images.githubusercontent.com/10430890/105134882-d08c0480-5b3a-11eb-8e4c-f1c314e3412c.png)

When it is opened like:
![image](https://user-images.githubusercontent.com/10430890/105134948-ed283c80-5b3a-11eb-9fc4-7003b09d7157.png)

And the user clicks off the menu it will now hide, providing a much better user experience.