### PR TITLE
fix(module:menu): fix loop on same route & performance & duplicate highlight

### DIFF
--- a/components/menu/Menu.razor
+++ b/components/menu/Menu.razor
@@ -1,7 +1,7 @@
 ﻿@namespace AntDesign
 @inherits AntDomComponentBase
 
-<CascadingValue Value="this" IsFixed="@true">
+<CascadingValue Value="this" IsFixed>
     <ul class="@ClassMapper.Class" style="@Style" id="@Id" direction="ltr" role="menu" @ref="Ref">
         @ChildContent
     </ul>

--- a/components/menu/Menu.razor.cs
+++ b/components/menu/Menu.razor.cs
@@ -122,16 +122,24 @@ namespace AntDesign
 
         public void SelectItem(MenuItem item)
         {
-            if (item == null)
+            if (item == null || item.IsSelected)
             {
                 return;
             }
-
+            var selectedKeys = new List<string>();
             if (!Multiple)
             {
                 foreach (MenuItem menuitem in MenuItems.Where(x => x != item))
                 {
-                    menuitem.Deselect();
+                    if (item.RouterLink != null && menuitem.RouterLink != null && menuitem.RouterLink.Equals(item.RouterLink) && !menuitem.IsSelected)
+                    {
+                        menuitem.Select();
+                        selectedKeys.Add(menuitem.Key);
+                    }
+                    else if (menuitem.IsSelected || menuitem.FirstRun)
+                    {
+                        menuitem.Deselect();
+                    }
                 }
             }
 
@@ -139,13 +147,14 @@ namespace AntDesign
             {
                 item.Select();
             }
+            selectedKeys.Add(item.Key);
+            _selectedKeys = selectedKeys.ToArray();
 
             StateHasChanged();
 
             if (OnMenuItemClicked.HasDelegate)
                 OnMenuItemClicked.InvokeAsync(item);
 
-            _selectedKeys = MenuItems.Where(x => x.IsSelected).Select(x => x.Key).ToArray();
             if (SelectedKeysChanged.HasDelegate)
                 SelectedKeysChanged.InvokeAsync(_selectedKeys);
 

--- a/components/menu/MenuItem.razor
+++ b/components/menu/MenuItem.razor
@@ -1,7 +1,7 @@
 ﻿@namespace AntDesign
 @inherits AntDomComponentBase
 
-<CascadingValue Value="this" IsFixed="@true">
+<CascadingValue Value="this" IsFixed>
     <li class="@ClassMapper.Class" role="menuitem" style=" @(PaddingLeft>0? $"padding-left:{PaddingLeft}px;":"") @Style" @onclick="HandleOnClick" @key="Key" @ref="Ref">
         @if (RouterLink == null)
         {

--- a/components/menu/MenuItem.razor.cs
+++ b/components/menu/MenuItem.razor.cs
@@ -1,9 +1,9 @@
-﻿using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Web;
-using System;
+﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Routing;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace AntDesign
 {
@@ -41,6 +41,7 @@ namespace AntDesign
         public string Title { get; set; }
 
         internal bool IsSelected { get; private set; }
+        internal bool FirstRun { get; set; } = true;
         private string _key;
 
         private int PaddingLeft => RootMenu.InternalMode == MenuMode.Inline ? ((ParentMenu?.Level ?? 0) + 1) * 24 : 0;
@@ -76,7 +77,7 @@ namespace AntDesign
         {
             base.OnParametersSet();
 
-            if (RootMenu.SelectedKeys.Contains(Key))
+            if (RootMenu.SelectedKeys.Contains(Key) && !IsSelected)
                 Select();
         }
 
@@ -112,12 +113,14 @@ namespace AntDesign
         public void Select()
         {
             IsSelected = true;
+            FirstRun = false;
             ParentMenu?.Select();
         }
 
         public void Deselect()
         {
             IsSelected = false;
+            FirstRun = false;
             ParentMenu?.Deselect();
         }
     }

--- a/components/menu/MenuLink.cs
+++ b/components/menu/MenuLink.cs
@@ -63,19 +63,22 @@ namespace AntDesign
         /// <inheritdoc />
         protected override void OnParametersSet()
         {
-            if (Href == "/" && Match != NavLinkMatch.All)
+            if (Match != NavLinkMatch.All && Href == "/")
             {
                 Match = NavLinkMatch.All;
             }
 
             // Update computed state
-            _hrefAbsolute = Href == null ? null : NavigationManger.ToAbsoluteUri(Href).AbsoluteUri;
-            _isActive = ShouldMatch(NavigationManger.Uri);
+            _hrefAbsolute = Href == null ? null : NavigationManger.ToAbsoluteUri(Href).AbsoluteUri;                        
 
-            if (MenuItem != null && _isActive && !MenuItem.IsSelected)
+            if (MenuItem.FirstRun)
             {
-                Menu?.SelectItem(MenuItem);
-                Menu?.SelectSubmenu(MenuItem.ParentMenu);
+                _isActive = ShouldMatch(NavigationManger.Uri);
+                if (MenuItem != null && _isActive && !MenuItem.IsSelected)
+                {
+                    Menu?.SelectItem(MenuItem);
+                    Menu?.SelectSubmenu(MenuItem.ParentMenu);
+                }
             }
         }
 
@@ -98,12 +101,12 @@ namespace AntDesign
 
                 if (MenuItem != null)
                 {
-                    if (_isActive)
+                    if (_isActive && !MenuItem.IsSelected)
                     {
                         MenuItem.Select();
                         Menu.SelectItem(MenuItem);
                     }
-                    else
+                    else if (MenuItem.IsSelected)
                     {
                         MenuItem.Deselect();
                     }
@@ -159,9 +162,10 @@ namespace AntDesign
                 builder.OpenElement(0, "a");
                 builder.AddAttribute(1, "href", Href);
                 builder.AddAttribute(2, "class", ClassMapper.Class);
-                builder.AddAttribute(2, "style", Style);
-                builder.AddMultipleAttributes(3, Attributes);
-                builder.AddContent(4, ChildContent);
+                builder.AddAttribute(3, "style", Style);
+                builder.SetKey(MenuItem.Key);
+                builder.AddMultipleAttributes(5, Attributes);
+                builder.AddContent(6, ChildContent);
                 builder.CloseElement();
             }
         }

--- a/components/menu/MenuLink.cs
+++ b/components/menu/MenuLink.cs
@@ -103,7 +103,6 @@ namespace AntDesign
                 {
                     if (_isActive && !MenuItem.IsSelected)
                     {
-                        MenuItem.Select();
                         Menu.SelectItem(MenuItem);
                     }
                     else if (MenuItem.IsSelected)


### PR DESCRIPTION
  🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [x] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
#737 
#833 
#919 
#1014 

### 💡 Background and solution
All changes are directly connected with issues. 
Plus performance optimization, as stated below.

During tests I found out that single click was causing cascading calls that were causing multiple unnecessary refreshes. After some serious debugging and trial and error I think I got to the point it is only doing necessary calls. Just to give a ballpark figure - with 5 menus, single click was causing 5 refreshes of each menu on average (my total was 29 refreshes overall). With this PR only changing menus are refreshing (so 2 changes in total - what is weird, 3 refreshes if order of menu clicking is reversed).

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
