### PR TITLE
fix(module:table) Table exception on refresh

### DIFF
--- a/components/core/Component/overlay/Overlay.razor.cs
+++ b/components/core/Component/overlay/Overlay.razor.cs
@@ -103,21 +103,23 @@ namespace AntDesign.Internal
         {
             if (firstRender)
             {
-                await JsInvokeAsync(JSInteropConstants.AddClsToFirstChild, Ref, $"{Trigger.PrefixCls}-trigger");
                 DomEventService.AddEventListener("window", "beforeunload", Reloading, false);
             }
 
             if (_lastDisabledState != Trigger.Disabled)
             {
-                if (Trigger.Disabled)
+                if (Ref.Id != null)
                 {
-                    await JsInvokeAsync(JSInteropConstants.AddClsToFirstChild, Ref, $"disabled");
+                    if (Trigger.Disabled)
+                    {
+                        await JsInvokeAsync(JSInteropConstants.AddClsToFirstChild, Ref, $"disabled");
+                    }
+                    else
+                    {
+                        await JsInvokeAsync(JSInteropConstants.RemoveClsFromFirstChild, Ref, $"disabled");
+                    }
                 }
-                else
-                {
-                    await JsInvokeAsync(JSInteropConstants.RemoveClsFromFirstChild, Ref, $"disabled");
-                }
-                _lastDisabledState = Trigger.Disabled;
+                 _lastDisabledState = Trigger.Disabled;
             }
 
             if (_isWaitForOverlayFirstRender && _isOverlayFirstRender)

--- a/site/AntBlazor.Docs/Demos/Components/Slider/demo/Basic.razor
+++ b/site/AntBlazor.Docs/Demos/Components/Slider/demo/Basic.razor
@@ -1,6 +1,6 @@
 ﻿<div>
-    <Slider TValue="double" DefaultValue="35" disabled="@_disabled"  />
-    <Slider TValue="(double, double)" DefaultValue="(20, 50)" disabled="@_disabled" />
+    <Slider TValue="double" DefaultValue="35" Disabled="@_disabled"  />
+    <Slider TValue="(double, double)" DefaultValue="(20, 50)" Disabled="@_disabled" />
     Disabled: <Switch Size="small" Checked="@_disabled" OnChange="(e)=>OnSwitch(e)" />
 </div>
 

--- a/site/AntBlazor.Docs/Demos/Components/Slider/demo/Basic.razor
+++ b/site/AntBlazor.Docs/Demos/Components/Slider/demo/Basic.razor
@@ -1,16 +1,16 @@
 ﻿<div>
-    <Slider TValue="double" DefaultValue="35" Disabled="@Diabled"  />
-    <Slider TValue="(double, double)" DefaultValue="(20, 50)" Disabled="@Diabled" />
-    Diabled: <Switch Size="small" Checked="@Diabled" OnChange="(e)=>OnSwitch(e)" />
+    <Slider TValue="double" DefaultValue="35" disabled="@_disabled"  />
+    <Slider TValue="(double, double)" DefaultValue="(20, 50)" disabled="@_disabled" />
+    Disabled: <Switch Size="small" Checked="@_disabled" OnChange="(e)=>OnSwitch(e)" />
 </div>
 
 @code
 {
 
-    private bool Diabled;
+    private bool _disabled;
 
     private void OnSwitch(bool args)
     {
-        Diabled = args;
+        _disabled = args;
     }
 }


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
This issue can be demonstrated on the demo pages for tables, but should surface anytime `Table` component is used (and actually any other component that uses `Overlay`). After page refresh, in about a minute a whole bunch of exceptions can be observed in the console (the log file is based on demo docs; it is pure 40kb text):
[tableExceptionsOnReload.log](https://github.com/ant-design-blazor/ant-design-blazor/files/5863104/tableExceptionsOnReload.log)


### 💡 Background and solution
The fix is similar to PR #1008. 
On top of that, there are also fixes to `Overlay` component. There were calls to no longer existing trigger elements based on no longer existing element classes (at least I could not find them and it does not really makes any sense to have those calls in my eyes). Also, there were calls to overlay container regardless if container was added - so extra check for that was added. 
After the changes no exceptions are thrown.

As a side note - it is likely that any component that has js interop calls during its `Dispose()` method will have the same issue as the `Table` component.


### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
