### PR TITLE
fix(module:rangepicker): placeholder and value equals null

### DIFF
--- a/components/date-picker/RangePicker.razor.cs
+++ b/components/date-picker/RangePicker.razor.cs
@@ -101,6 +101,11 @@ namespace AntDesign
             RangePickerDefaults.ProcessDefaults(Value, DefaultValue, DefaultPickerValue, PickerValues, UseDefaultPickerValue);
             _pickerValuesAfterInit[0] = PickerValues[0];
             _pickerValuesAfterInit[1] = PickerValues[1];
+            if (_value == null)
+            {
+                _value = CreateInstance();
+                ValueChanged.InvokeAsync(_value);
+            }
         }
 
         /// <summary>
@@ -204,6 +209,10 @@ namespace AntDesign
             var array = CurrentValue as Array;
             array.SetValue(default, 0);
             array.SetValue(default, 1);
+
+            (string first, string second) = DatePickerPlaceholder.GetRangePlaceHolderByType(_pickerStatus[0]._initPicker, Locale);
+            _placeholders[0] = first;
+            _placeholders[1] = second;
 
             _pickerStatus[0]._hadSelectValue = false;
             _pickerStatus[1]._hadSelectValue = false;

--- a/components/date-picker/internal/DatePickerBase.cs
+++ b/components/date-picker/internal/DatePickerBase.cs
@@ -609,18 +609,17 @@ namespace AntDesign
                 if (IsNullable)
                 {
                     var tempValue = value as DateTime?[];
+                    if (tempValue[0] == null || tempValue[1] == null)
+                        return orderedValue;
+
                     if ((tempValue[0] ?? DateTime.Now).CompareTo((tempValue[1] ?? DateTime.Now)) > 0)
-                    {
                         orderedValue = DataConvertionExtensions.Convert<DateTime?[], TValue>(new DateTime?[] { tempValue[1], tempValue[0] });
-                    }
                 }
                 else
                 {
                     var tempValue = value as DateTime[];
                     if (tempValue[0].CompareTo(tempValue[1]) > 0)
-                    {
                         orderedValue = DataConvertionExtensions.Convert<DateTime[], TValue>(new DateTime[] { tempValue[1], tempValue[0] });
-                    }
                 }
             }
             return orderedValue;


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
#1068
#1070
### 💡 Background and solution
If `Value` provided to `RangePicker` was null, it was throwing `NullReferenceException`. Now during initialization, the `Value` is checked and if `null`, it is instantiated to `TValue`. 
Placeholders were not reset on clear - are now.

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
