### PR TITLE
fix(module:datepicker): for not nullable - on clear set to defaults

### DIFF
--- a/components/date-picker/DatePicker.Razor.cs
+++ b/components/date-picker/DatePicker.Razor.cs
@@ -174,7 +174,11 @@ namespace AntDesign
         public override void ClearValue(int index = 0)
         {
             _isSetPicker = false;
-            CurrentValue = default;
+
+            if (!IsNullable && DefaultValue != null)
+                CurrentValue = DefaultValue;
+            else
+                CurrentValue = default;
             Close();
         }
 

--- a/components/date-picker/RangePicker.razor.cs
+++ b/components/date-picker/RangePicker.razor.cs
@@ -207,8 +207,17 @@ namespace AntDesign
             _isSetPicker = false;
 
             var array = CurrentValue as Array;
-            array.SetValue(default, 0);
-            array.SetValue(default, 1);
+            if (!IsNullable && DefaultValue != null)
+            {
+                var defaults = DefaultValue as Array;
+                array.SetValue(defaults.GetValue(0), 0);
+                array.SetValue(defaults.GetValue(1), 1);
+            }
+            else
+            {
+                array.SetValue(default, 0);
+                array.SetValue(default, 1);
+            }
 
             (string first, string second) = DatePickerPlaceholder.GetRangePlaceHolderByType(_pickerStatus[0]._initPicker, Locale);
             _placeholders[0] = first;


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 💡 Background and solution
Due to the strongly typed nature of C#, `DatePicker` can get either nullable or not nullable dates. When not nullable are used, clearing the values was inputing min value for `DateTime`. There is not much we can do about (we can decide to take current date for example). This PR fixes the not nullable clearing scenario when defaults are set - in such case, date picker will assume defaults instead of `DateTime.Min`. For nullable the picker will be cleared.

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
