### PR TITLE
fix(module:select): property rename to follow docs

### DIFF
--- a/components/modal/config/ModalClosingEventArgs.cs
+++ b/components/modal/config/ModalClosingEventArgs.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Microsoft.AspNetCore.Components.Web;
+﻿using Microsoft.AspNetCore.Components.Web;
 
 namespace AntDesign
 {
@@ -21,6 +18,8 @@ namespace AntDesign
         /// <summary>
         /// 获取或设置一个值，该值指示是否应取消事件。
         /// 返回结果: true 如果应取消事件;否则为 false。
+        /// Gets or sets a value indicating whether the event should be cancelled.
+        /// Return result: true if the event should be cancelled; otherwise false.
         /// </summary>
         public bool Cancel { get; set; }
     }

--- a/components/select/Select.razor.cs
+++ b/components/select/Select.razor.cs
@@ -25,7 +25,18 @@ namespace AntDesign
         [Parameter] public bool AutoClearSearchValue { get; set; } = true;
         [Parameter] public bool Bordered { get; set; } = true;
         [Parameter] public Action<string> OnCreateCustomTag { get; set; }
-        [Parameter] public bool DefaultActiveFirstOption { get; set; } = false;
+        [Parameter]
+        public bool DefaultActiveFirstOption
+        {
+            get { return _defaultActiveFirstOption; }
+            set { 
+                _defaultActiveFirstOption = value; 
+                if (!_defaultActiveFirstOption)
+                {
+                    _defaultActiveFirstOptionApplied = true;
+                }
+            }
+        }
         [Parameter] public bool Disabled { get; set; }
         [Parameter] public string DisabledName { get; set; }
         [Parameter] public Func<RenderFragment, RenderFragment> DropdownRender { get; set; }
@@ -194,7 +205,6 @@ namespace AntDesign
                         return;
 
                     _selectedValues = value;
-
                     _ = OnValuesChangeAsync(value);
                 }
                 else if (value != null && _selectedValues == null)
@@ -301,6 +311,7 @@ namespace AntDesign
         private bool _defaultValuesHasItems;
         private bool _isInitialized;
         private bool _defaultValueApplied;
+        private bool _defaultActiveFirstOptionApplied;
         private bool _waittingStateChange;
         private bool _isPrimitive;
         internal ElementReference _inputRef;
@@ -308,6 +319,7 @@ namespace AntDesign
         protected SelectContent<TItemValue, TItem> _selectContent;
         bool _isToken;
         private SelectOptionItem<TItemValue, TItem> _activeOption;
+        private bool _defaultActiveFirstOption;
 
         internal HashSet<SelectOptionItem<TItemValue, TItem>> SelectOptionItems { get; } = new HashSet<SelectOptionItem<TItemValue, TItem>>();
         internal List<SelectOptionItem<TItemValue, TItem>> SelectedOptionItems { get; } = new List<SelectOptionItem<TItemValue, TItem>>();
@@ -383,7 +395,7 @@ namespace AntDesign
                 _defaultValueApplied = !(_defaultValueIsNotNull || _defaultValuesHasItems);
             }
 
-            if (!_defaultValueApplied)
+            if (!_defaultValueApplied || !_defaultActiveFirstOptionApplied)
             {
                 if (SelectMode == SelectMode.Default)
                 {
@@ -799,6 +811,7 @@ namespace AntDesign
             {
                 await ClearSelectedAsync();
             }
+            _defaultActiveFirstOptionApplied = true;
         }
 
         /// <summary>
@@ -1148,7 +1161,7 @@ namespace AntDesign
             }
 
             var newSelectedItems = new List<TItem>();
-
+            var deselectList = SelectedOptionItems.ToDictionary(item => item.Value, item => item);
             foreach (var item in values.ToList())
             {
                 var result = SelectOptionItems.FirstOrDefault(x => x.IsSelected == false && EqualityComparer<TItemValue>.Default.Equals(x.Value, item));
@@ -1156,7 +1169,16 @@ namespace AntDesign
                 if (result != null && !result.IsDisabled)
                 {
                     result.IsSelected = true;
-                    newSelectedItems.Add(result.Item);
+                    SelectedOptionItems.Add(result);
+                }
+                deselectList.Remove(item);
+            }
+            if (deselectList.Count > 0)
+            {
+                foreach (var item in deselectList)
+                {
+                    item.Value.IsSelected = false;
+                    SelectedOptionItems.Remove(item.Value);
                 }
             }
 
@@ -1165,7 +1187,7 @@ namespace AntDesign
                 await UpdateOverlayPositionAsync();
             }
 
-            OnSelectedItemsChanged?.Invoke(newSelectedItems);
+            OnSelectedItemsChanged?.Invoke(SelectedOptionItems.Select(s => s.Item));
             await ValuesChanged.InvokeAsync(Values);
         }
 

--- a/components/select/Select.razor.cs
+++ b/components/select/Select.razor.cs
@@ -25,7 +25,7 @@ namespace AntDesign
         [Parameter] public bool AutoClearSearchValue { get; set; } = true;
         [Parameter] public bool Bordered { get; set; } = true;
         [Parameter] public Action<string> OnCreateCustomTag { get; set; }
-        [Parameter] public bool DefaultActiveFirstItem { get; set; } = false;
+        [Parameter] public bool DefaultActiveFirstOption { get; set; } = false;
         [Parameter] public bool Disabled { get; set; }
         [Parameter] public string DisabledName { get; set; }
         [Parameter] public Func<RenderFragment, RenderFragment> DropdownRender { get; set; }
@@ -388,7 +388,7 @@ namespace AntDesign
                 if (SelectMode == SelectMode.Default)
                 {
                     if (_defaultValueIsNotNull && !HasValue && SelectOptionItems.Any()
-                        || DefaultActiveFirstItem && !HasValue && SelectOptionItems.Any())
+                        || DefaultActiveFirstOption && !HasValue && SelectOptionItems.Any())
                     {
                         await TrySetDefaultValueAsync();
                     }
@@ -396,7 +396,7 @@ namespace AntDesign
                 else
                 {
                     if (_defaultValuesHasItems && !HasValue && SelectOptionItems.Any()
-                        || DefaultActiveFirstItem && !HasValue && SelectOptionItems.Any())
+                        || DefaultActiveFirstOption && !HasValue && SelectOptionItems.Any())
                     {
                         await TrySetDefaultValuesAsync();
                     }
@@ -594,8 +594,8 @@ namespace AntDesign
         protected async Task SetDropdownStyleAsync()
         {
             var domRect = await JsInvokeAsync<DomRect>(JSInteropConstants.GetBoundingClientRect, Ref);
-
-            _dropdownStyle = $"min-width: {domRect.width}px; width: {domRect.width}px;";
+            var width = domRect.width.ToString("0.00", System.Globalization.CultureInfo.InvariantCulture);
+            _dropdownStyle = $"min-width: {width}px; width: {width}px;";
         }
 
         protected async Task OnOverlayVisibleChangeAsync(bool visible)
@@ -830,7 +830,7 @@ namespace AntDesign
                     await SetDefaultActiveFirstItemAsync();
                 }
             }
-            else if (DefaultActiveFirstItem)
+            else if (DefaultActiveFirstOption)
             {
                 await SetDefaultActiveFirstItemAsync();
             }
@@ -866,7 +866,7 @@ namespace AntDesign
 
                 if (!anySelected)
                 {
-                    if (DefaultActiveFirstItem)
+                    if (DefaultActiveFirstOption)
                     {
                         await SetDefaultActiveFirstItemAsync();
                     }
@@ -882,7 +882,7 @@ namespace AntDesign
                     await InvokeValuesChanged();
                 }
             }
-            else if (DefaultActiveFirstItem)
+            else if (DefaultActiveFirstOption)
             {
                 await SetDefaultActiveFirstItemAsync();
             }


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
#1111 

### 💡 Background and solution
1. Renamed `DefaultActiveFirstItem` to `DefaultActiveFirstOption` following the docs (it is in sync with react antDesign)
2. When current locale are of a country that uses comma as decimal separator, the calculated css width was delivered with a comma (for example 333,123123). Css was not understanding that and was ignoring the value.
3. Translated Chinese comment.
4. Fix similar to #662 that was applier to `DefaultActiveFirstOption`
5. Changing bound object to value outside of the `Select` component wasn't changing selection in the component.

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
