### PR TITLE
fix(module: Select) bind value change lock, tags and labels fix, overlay reposition

### DIFF
--- a/components/select/Select.razor.cs
+++ b/components/select/Select.razor.cs
@@ -1249,10 +1249,15 @@ namespace AntDesign
 
             EvaluateValuesChangedOutsideComponent(values);
 
-            //if (_dropDown.IsOverlayShow())
-            //{
-            //    await UpdateOverlayPositionAsync();
-            //}
+            if (_dropDown.IsOverlayShow())
+            {
+                //A delay forces a refresh better than StateHasChanged().
+                //For example when a tag is added that is causing SelectContent to grow,
+                //this Task.Delay will actually allow to reposition the Overlay to match
+                //new size of SelectContent.
+                await Task.Delay(1);
+                await UpdateOverlayPositionAsync();
+            }
 
             OnSelectedItemsChanged?.Invoke(SelectedOptionItems.Select(s => s.Item));
             await ValuesChanged.InvokeAsync(Values);

--- a/components/select/Select.razor.cs
+++ b/components/select/Select.razor.cs
@@ -80,7 +80,10 @@ namespace AntDesign
             set
             {
                 _getLabel = SelectItemPropertyHelper.CreateGetLabelFunc<TItem>(value);
-                _setLabel = SelectItemPropertyHelper.CreateSetLabelFunc<TItem>(value);
+                if (SelectMode == SelectMode.Tags)
+                {
+                    _setLabel = SelectItemPropertyHelper.CreateSetLabelFunc<TItem>(value);                    
+                }
                 _labelName = value;
             }
         }

--- a/components/select/Select.razor.cs
+++ b/components/select/Select.razor.cs
@@ -373,6 +373,11 @@ namespace AntDesign
         internal List<SelectOptionItem<TItemValue, TItem>> SelectedOptionItems { get; } = new List<SelectOptionItem<TItemValue, TItem>>();
         internal List<SelectOptionItem<TItemValue, TItem>> AddedTags { get; } = new List<SelectOptionItem<TItemValue, TItem>>();
         internal SelectOptionItem<TItemValue, TItem> CustomTagSelectOptionItem { get; set; }
+
+        /// <summary>
+        /// Currently active (highlighted) option. 
+        /// It does not have to be equal to selected option.
+        /// </summary>
         internal SelectOptionItem<TItemValue, TItem> ActiveOption
         {
             get { return _activeOption; }
@@ -397,7 +402,7 @@ namespace AntDesign
         private string _groupName = string.Empty;
 
         private Func<TItem, string> _getGroup;
-        
+
         private string _disabledName;
 
         private Func<TItem, bool> _getDisabled;
@@ -462,6 +467,7 @@ namespace AntDesign
                 await SetDropdownStyleAsync();
 
                 _defaultValueApplied = !(_defaultValueIsNotNull || _defaultValuesHasItems);
+                _defaultActiveFirstOptionApplied = !_defaultActiveFirstOption;
             }
 
             if (!_defaultValueApplied || !_defaultActiveFirstOptionApplied)
@@ -792,7 +798,7 @@ namespace AntDesign
                         await SetInputFocusAsync();
                     }
 
-                    if (selectOption.IsAddedTag && SelectOptions != null)
+                    if (selectOption.IsAddedTag)
                     {
                         CustomTagSelectOptionItem = null;
                         AddedTags.Add(selectOption);
@@ -997,7 +1003,7 @@ namespace AntDesign
                         }
 
                         result.IsSelected = true;
-
+                        ActiveOption = result;
                         if (HideSelected)
                             result.IsHidden = true;
                         SelectedOptionItems.Add(result);
@@ -1190,10 +1196,37 @@ namespace AntDesign
 
             result.IsSelected = true;
 
+            EvaluateValueChangedOutsideComponent(result, value);
+
             if (HideSelected)
                 result.IsHidden = true;
 
             ValueChanged.InvokeAsync(result.Value);
+        }
+
+        /// <summary>
+        /// When bind-Value is changed outside of the component, then component 
+        /// selected items have to be reselected according to new value passed.
+        /// </summary>
+        /// <param name="optionItem">The option item that has been selected.</param>
+        /// <param name="value">The value of the selected option item.</param>
+        private void EvaluateValueChangedOutsideComponent(SelectOptionItem<TItemValue, TItem> optionItem, TItemValue value)
+        {
+            if (ActiveOption != null && !ActiveOption.Value.Equals(value))
+            {
+                ActiveOption.IsSelected = false;
+                ActiveOption = optionItem;
+            }
+            if (SelectedOptionItems.Count > 0)
+            {
+                if (!SelectedOptionItems[0].Value.Equals(value))
+                {
+                    SelectedOptionItems[0].IsSelected = false;
+                    SelectedOptionItems[0] = optionItem;
+                }
+            }
+            else
+                SelectedOptionItems.Add(optionItem);
         }
 
         /// <summary>
@@ -1214,18 +1247,58 @@ namespace AntDesign
                 return;
             }
 
+            EvaluateValuesChangedOutsideComponent(values);
+
+            //if (_dropDown.IsOverlayShow())
+            //{
+            //    await UpdateOverlayPositionAsync();
+            //}
+
+            OnSelectedItemsChanged?.Invoke(SelectedOptionItems.Select(s => s.Item));
+            await ValuesChanged.InvokeAsync(Values);
+        }
+
+        /// <summary>
+        /// When bind-Values is changed outside of the component, then component
+        /// selected items have to be reselected according to new values passed.
+        /// TODO: (Perf) Consider using hash to identify if the passed values are different from currently selected.
+        /// </summary>
+        /// <param name="values">The values that need to be selected.</param>
+        private void EvaluateValuesChangedOutsideComponent(IEnumerable<TItemValue> values)
+        {
             var newSelectedItems = new List<TItem>();
             var deselectList = SelectedOptionItems.ToDictionary(item => item.Value, item => item);
-            foreach (var item in values.ToList())
+            foreach (var value in values.ToList())
             {
-                var result = SelectOptionItems.FirstOrDefault(x => x.IsSelected == false && EqualityComparer<TItemValue>.Default.Equals(x.Value, item));
-
-                if (result != null && !result.IsDisabled)
+                SelectOptionItem<TItemValue, TItem> result;
+                if (SelectMode == SelectMode.Multiple)
                 {
-                    result.IsSelected = true;
-                    SelectedOptionItems.Add(result);
+                    result = SelectOptionItems.FirstOrDefault(x => !x.IsSelected && EqualityComparer<TItemValue>.Default.Equals(x.Value, value));
+                    if (result != null && !result.IsDisabled)
+                    {
+                        result.IsSelected = true;
+                        SelectedOptionItems.Add(result);
+                    }
+                    deselectList.Remove(value);
                 }
-                deselectList.Remove(item);
+                else
+                {
+                    result = SelectOptionItems.FirstOrDefault(x => EqualityComparer<TItemValue>.Default.Equals(x.Value, value));
+                    if (result is null) //tag delivered from outside, needs to be added to the list of options
+                    {
+                        result = CreateSelectOptionItem(value.ToString(), true);
+                        result.IsSelected = true;
+                        AddedTags.Add(result);
+                        SelectOptionItems.Add(result);
+                        SelectedOptionItems.Add(result);
+                    }
+                    else if (result != null && !result.IsSelected && !result.IsDisabled)
+                    {
+                        result.IsSelected = true;
+                        SelectedOptionItems.Add(result);
+                    }
+                    deselectList.Remove(value);
+                }
             }
             if (deselectList.Count > 0)
             {
@@ -1233,16 +1306,13 @@ namespace AntDesign
                 {
                     item.Value.IsSelected = false;
                     SelectedOptionItems.Remove(item.Value);
+                    if (item.Value.IsAddedTag)
+                    {
+                        SelectOptionItems.Remove(item.Value);
+                        AddedTags.Remove(item.Value);
+                    }
                 }
             }
-
-            if (_dropDown.IsOverlayShow())
-            {
-                await UpdateOverlayPositionAsync();
-            }
-
-            OnSelectedItemsChanged?.Invoke(SelectedOptionItems.Select(s => s.Item));
-            await ValuesChanged.InvokeAsync(Values);
         }
 
         /// <summary>

--- a/components/select/internal/SelectContent.razor
+++ b/components/select/internal/SelectContent.razor
@@ -38,7 +38,7 @@
             @if (ParentSelect.SelectMode == SelectMode.Default)
             {                            
                 var selectedItem = ParentSelect.SelectedOptionItems.FirstOrDefault();
-
+                //Console.WriteLine($"({ParentSelect.Id}): {selectedItem.Value} => {selectedItem.Label}");
                 if (string.IsNullOrEmpty(SearchValue) && selectedItem != null)
                 {
                     @if (ParentLabelTemplate != null)


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
Fixes #1171 
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
#### Commit 25c3dcb
During my tests, it came out that if I had a class that the label was attached to a property that it had only a getter, then `Select` was crashing. The source of problems was the PR #1168. The `_setLabel` was prepared regardless of the type of select. The property that is attached to label needs to have a setter only for `SelectMode.Tags`. 

#### Commit d4e2966
Several fixes to solve #1171. The result it this:

![select_bindValueLockFix](https://user-images.githubusercontent.com/6518006/109643947-8ea0a600-7b5d-11eb-9e58-d733b91ac2a7.gif)

#### 7c7d481
Update of the overlay position was not really effective, as it was doing its updates before all the relevant changes were pushed to DOM. Adding `Task.Delay(1)` solved this issue. I am not really happy with it. The other option would be maybe to use [ResizeObserver](developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) but there might be a problem with browser compatibility. 

#### Other condierations:
All operations done in mehtods `EvaluateValueChangedOutsideComponent` and `EvaluateValuesChangedOutsideComponent` are basically needed only when `Value` and `Values` are changed outside of the component. I imagine this is going to be a much less often scenario in comparison to when they are changed by the component. At this stage, when values are changed by the component, the aforementioned methods are not necessary. This is mostly a performance issue when dealing with multiple/tags mode. But it probably would be beneficial to have some kind of a way to generate a hash or some other way to be able to compare if values were changed internally or externally. If external change is detected, then run the evaluation methods.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
