### PR TITLE
Select enter on form

### DIFF
--- a/components/core/JsInterop/JSInteropConstants.cs
+++ b/components/core/JsInterop/JSInteropConstants.cs
@@ -86,11 +86,21 @@ namespace AntDesign
         public static string ElementScrollIntoView => $"{FUNC_PREFIX}elementScrollIntoView";
 
         public static string BindTableHeaderAndBodyScroll => $"{FUNC_PREFIX}bindTableHeaderAndBodyScroll";
+        
         public static string UnbindTableHeaderAndBodyScroll => $"{FUNC_PREFIX}unbindTableHeaderAndBodyScroll";
-        public static string AddPreventCursorMoveOnArrowUp => $"{FUNC_PREFIX}addPreventCursorMoveOnArrowUp";
-        public static string RemovePreventCursorMoveOnArrowUp => $"{FUNC_PREFIX}removePreventCursorMoveOnArrowUp";
+        
+        public static string AddPreventKeys => $"{FUNC_PREFIX}addPreventKeys";
+        
+        public static string RemovePreventKeys => $"{FUNC_PREFIX}removePreventKeys";
+        
+        public static string AddPreventEnterOnOverlayVisible => $"{FUNC_PREFIX}addPreventEnterOnOverlayVisible";
+        
+        public static string RemovePreventEnterOnOverlayVisible => $"{FUNC_PREFIX}removePreventEnterOnOverlayVisible";
+        
         public static string GetStyle => $"{FUNC_PREFIX}getStyle";
+        
         public static string RegisterResizeTextArea => $"{FUNC_PREFIX}registerResizeTextArea";
+        
         public static string DisposeResizeTextArea => $"{FUNC_PREFIX}disposeResizeTextArea";
 
         #region Draggable Modal

--- a/components/core/JsInterop/JSInteropConstants.cs
+++ b/components/core/JsInterop/JSInteropConstants.cs
@@ -86,21 +86,21 @@ namespace AntDesign
         public static string ElementScrollIntoView => $"{FUNC_PREFIX}elementScrollIntoView";
 
         public static string BindTableHeaderAndBodyScroll => $"{FUNC_PREFIX}bindTableHeaderAndBodyScroll";
-        
+
         public static string UnbindTableHeaderAndBodyScroll => $"{FUNC_PREFIX}unbindTableHeaderAndBodyScroll";
-        
+
         public static string AddPreventKeys => $"{FUNC_PREFIX}addPreventKeys";
-        
+
         public static string RemovePreventKeys => $"{FUNC_PREFIX}removePreventKeys";
-        
+
         public static string AddPreventEnterOnOverlayVisible => $"{FUNC_PREFIX}addPreventEnterOnOverlayVisible";
-        
+
         public static string RemovePreventEnterOnOverlayVisible => $"{FUNC_PREFIX}removePreventEnterOnOverlayVisible";
-        
+
         public static string GetStyle => $"{FUNC_PREFIX}getStyle";
-        
+
         public static string RegisterResizeTextArea => $"{FUNC_PREFIX}registerResizeTextArea";
-        
+
         public static string DisposeResizeTextArea => $"{FUNC_PREFIX}disposeResizeTextArea";
 
         #region Draggable Modal

--- a/components/core/JsInterop/interop.ts
+++ b/components/core/JsInterop/interop.ts
@@ -611,19 +611,41 @@ export function unbindTableHeaderAndBodyScroll(bodyRef) {
   }
 }
 
-function preventCursorMoveOnArrowUp(e) {
-  if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+function preventKeys(e, keys: string[]) {
+  if (keys.indexOf(e.key.toUpperCase()) !== -1) {
     e.preventDefault();
     return false;
   }
 }
 
-export function addPreventCursorMoveOnArrowUp(inputElement) {
-  let dom = getDom(inputElement);
-  (dom as HTMLElement).addEventListener("keydown", preventCursorMoveOnArrowUp, false);
+export function addPreventKeys(inputElement, keys: string[]) {
+  let dom = getDom(inputElement);   
+  keys = keys.map(function (x) { return x.toUpperCase(); })
+  funcDict[inputElement.id + "keydown"] = (e) => preventKeys(e, keys);
+  (dom as HTMLElement).addEventListener("keydown", funcDict[inputElement.id + "input"], false);
 }
 
-export function removePreventCursorMoveOnArrowUp(inputElement) {
-  let dom = getDom(inputElement);
-  (dom as HTMLElement).removeEventListener("keydown", preventCursorMoveOnArrowUp);
+export function removePreventKeys(inputElement) {
+  let dom = getDom(inputElement);            
+  (dom as HTMLElement).removeEventListener("keydown", funcDict[inputElement.id + "keydown"]);
+  funcDict[inputElement.id + "keydown"] = null;
+}
+
+function preventKeyOnCondition(e, key: string, check: () => boolean) {
+  if (e.key.toUpperCase() === key.toUpperCase() && check()) {
+    e.preventDefault();
+    return false;
+  }
+}
+
+export function addPreventEnterOnOverlayVisible(element, overlayElement) {
+  let dom = getDom(element);   
+  funcDict[element.id + "keydown:Enter"] = (e) => preventKeyOnCondition(e, "enter", () => overlayElement.offsetParent !== null);
+  (dom as HTMLElement).addEventListener("keydown", funcDict[element.id + "keydown:Enter"], false);
+}
+
+export function removePreventEnterOnOverlayVisible(element) {
+  let dom = getDom(element);
+  (dom as HTMLElement).removeEventListener("keydown", funcDict[element.id + "keydown:Enter"]);
+  funcDict[element.id + "keydown:Enter"] = null;
 }

--- a/components/core/JsInterop/interop.ts
+++ b/components/core/JsInterop/interop.ts
@@ -622,7 +622,7 @@ export function addPreventKeys(inputElement, keys: string[]) {
   let dom = getDom(inputElement);   
   keys = keys.map(function (x) { return x.toUpperCase(); })
   funcDict[inputElement.id + "keydown"] = (e) => preventKeys(e, keys);
-  (dom as HTMLElement).addEventListener("keydown", funcDict[inputElement.id + "input"], false);
+    (dom as HTMLElement).addEventListener("keydown", funcDict[inputElement.id + "keydown"], false);
 }
 
 export function removePreventKeys(inputElement) {

--- a/components/select/Select.razor.cs
+++ b/components/select/Select.razor.cs
@@ -50,6 +50,29 @@ namespace AntDesign
             }
         }
 
+        /// <summary>
+        /// Default behavior for Select component on a Form is to submit
+        /// on Enter. The exception is when Enter is pressed while select 
+        /// options are visible (then Enter will set picked option as the value).
+        /// If DisableSubmitFormOnEnter = true then Enter will not submit on 
+        /// a Form.
+        /// </summary>
+        [Parameter]
+        public bool DisableSubmitFormOnEnter
+        {
+            get { return _disableSubmitFormOnEnter; }
+            set
+            {
+                if (_disableSubmitFormOnEnter != value)
+                {
+                    _disableSubmitFormOnEnter = value;
+                    if (_isInitialized)
+                    {
+                        _selectContent.ApplyEnterBehavior(_disableSubmitFormOnEnter);
+                    }
+                }
+            }
+        }
         [Parameter] public Func<RenderFragment, RenderFragment> DropdownRender { get; set; }
         [Parameter] public bool EnableSearch { get; set; }
 
@@ -82,7 +105,7 @@ namespace AntDesign
                 _getLabel = SelectItemPropertyHelper.CreateGetLabelFunc<TItem>(value);
                 if (SelectMode == SelectMode.Tags)
                 {
-                    _setLabel = SelectItemPropertyHelper.CreateSetLabelFunc<TItem>(value);                    
+                    _setLabel = SelectItemPropertyHelper.CreateSetLabelFunc<TItem>(value);
                 }
                 _labelName = value;
             }
@@ -140,7 +163,8 @@ namespace AntDesign
         /// <summary>
         /// Converts custom tag (a string) to TItemValue type.
         /// </summary>
-        [Parameter] public Func<string, TItemValue> CustomTagLabelToValue { get; set; } = (label) => (TItemValue)TypeDescriptor.GetConverter(typeof(TItemValue)).ConvertFromInvariantString(label);
+        [Parameter] public Func<string, TItemValue> CustomTagLabelToValue { get; set; } =
+            (label) => (TItemValue)TypeDescriptor.GetConverter(typeof(TItemValue)).ConvertFromInvariantString(label);
 
         [Parameter]
         public IEnumerable<TItem> DataSource
@@ -417,9 +441,10 @@ namespace AntDesign
 
         private string _valueName;
 
-        private Func<TItem, TItemValue>   _getValue;
+        private Func<TItem, TItemValue> _getValue;
 
         private Action<TItem, TItemValue> _setValue;
+        private bool _disableSubmitFormOnEnter;
 
         #endregion Properties
 

--- a/components/select/Select.razor.cs
+++ b/components/select/Select.razor.cs
@@ -50,29 +50,6 @@ namespace AntDesign
             }
         }
 
-        /// <summary>
-        /// Default behavior for Select component on a Form is to submit
-        /// on Enter. The exception is when Enter is pressed while select 
-        /// options are visible (then Enter will set picked option as the value).
-        /// If DisableSubmitFormOnEnter = true then Enter will not submit on 
-        /// a Form.
-        /// </summary>
-        [Parameter]
-        public bool DisableSubmitFormOnEnter
-        {
-            get { return _disableSubmitFormOnEnter; }
-            set
-            {
-                if (_disableSubmitFormOnEnter != value)
-                {
-                    _disableSubmitFormOnEnter = value;
-                    if (_isInitialized)
-                    {
-                        _selectContent.ApplyEnterBehavior(_disableSubmitFormOnEnter);
-                    }
-                }
-            }
-        }
         [Parameter] public Func<RenderFragment, RenderFragment> DropdownRender { get; set; }
         [Parameter] public bool EnableSearch { get; set; }
 

--- a/components/select/Select.razor.cs
+++ b/components/select/Select.razor.cs
@@ -17,7 +17,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace AntDesign
 {
-    public partial class Select<TItemValue, TItem>
+    public partial class Select<TItemValue, TItem>: AntInputComponentBase<TItemValue>
     {
         #region Parameters
 
@@ -219,7 +219,13 @@ namespace AntDesign
                 {
                     _selectedValue = value;
                     if (_isInitialized)
+                    {
                         OnValueChange(value);
+                        if (Form?.ValidateOnChange == true)
+                        {
+                            EditContext?.NotifyFieldChanged(FieldIdentifier);
+                        }
+                    }
                 }
             }
         }
@@ -345,6 +351,8 @@ namespace AntDesign
         {
             get => !string.IsNullOrWhiteSpace(GroupName);
         }
+
+        internal ElementReference DropDownRef => _dropDown.GetOverlayComponent().Ref;
 
         internal SelectMode SelectMode => Mode.ToSelectMode();
         internal bool Focused { get; private set; }
@@ -1889,6 +1897,11 @@ namespace AntDesign
                 {
                     await CloseAsync();
                 }
+            }
+
+            if ((key == "DELETE" || key == "BACKSPACE") && AllowClear)
+            {
+                await OnInputClearClickAsync(new MouseEventArgs());
             }
         }
 

--- a/components/select/internal/SelectContent.razor.cs
+++ b/components/select/internal/SelectContent.razor.cs
@@ -58,7 +58,8 @@ namespace AntDesign.Select.Internal
             if (firstRender && ParentSelect.EnableSearch)
             {
                 DomEventService.AddEventListener("window", "beforeunload", Reloading, false);
-                await Js.InvokeVoidAsync(JSInteropConstants.AddPreventCursorMoveOnArrowUp, ParentSelect._inputRef);
+                await Js.InvokeVoidAsync(JSInteropConstants.AddPreventKeys, ParentSelect._inputRef, new[] { "ArrowUp", "ArrowDown" });
+                await Js.InvokeVoidAsync(JSInteropConstants.AddPreventEnterOnOverlayVisible, ParentSelect._inputRef, ParentSelect.DropDownRef);
             }
             await base.OnAfterRenderAsync(firstRender);
         }
@@ -151,7 +152,8 @@ namespace AntDesign.Select.Internal
                 _ = InvokeAsync(async () =>
                 {
                     await Task.Delay(100);
-                    await Js.InvokeVoidAsync(JSInteropConstants.RemovePreventCursorMoveOnArrowUp, ParentSelect._inputRef);
+                    await Js.InvokeVoidAsync(JSInteropConstants.RemovePreventKeys, ParentSelect._inputRef);
+                    await Js.InvokeVoidAsync(JSInteropConstants.RemovePreventEnterOnOverlayVisible, ParentSelect._inputRef);
                 });
             }
             DomEventService.RemoveEventListerner<JsonElement>("window", "beforeunload", Reloading);

--- a/components/select/internal/SelectContent.razor.cs
+++ b/components/select/internal/SelectContent.razor.cs
@@ -58,16 +58,8 @@ namespace AntDesign.Select.Internal
             if (firstRender && ParentSelect.EnableSearch)
             {
                 DomEventService.AddEventListener("window", "beforeunload", Reloading, false);
-                if (ParentSelect.DisableSubmitFormOnEnter)
-                {
-                    Console.WriteLine("Disable Enter for submit.");
-                    await Js.InvokeVoidAsync(JSInteropConstants.AddPreventKeys, ParentSelect._inputRef, new[] { "ArrowUp", "ArrowDown", "Enter" });
-                }
-                else
-                {
-                    await Js.InvokeVoidAsync(JSInteropConstants.AddPreventKeys, ParentSelect._inputRef, new[] { "ArrowUp", "ArrowDown" });
-                    await Js.InvokeVoidAsync(JSInteropConstants.AddPreventEnterOnOverlayVisible, ParentSelect._inputRef, ParentSelect.DropDownRef);
-                }
+                await Js.InvokeVoidAsync(JSInteropConstants.AddPreventKeys, ParentSelect._inputRef, new[] { "ArrowUp", "ArrowDown" });
+                await Js.InvokeVoidAsync(JSInteropConstants.AddPreventEnterOnOverlayVisible, ParentSelect._inputRef, ParentSelect.DropDownRef);
             }
             await base.OnAfterRenderAsync(firstRender);
         }
@@ -150,25 +142,6 @@ namespace AntDesign.Select.Internal
 
         private void Reloading(JsonElement jsonElement) => _isReloading = true;
 
-        internal void ApplyEnterBehavior(bool disableSubmitFormOnEnter)
-        {
-            _ = InvokeAsync(async () =>
-            {
-                await Js.InvokeVoidAsync(JSInteropConstants.RemovePreventKeys, ParentSelect._inputRef);
-                if (disableSubmitFormOnEnter)
-                {
-                    await Js.InvokeVoidAsync(JSInteropConstants.RemovePreventEnterOnOverlayVisible, ParentSelect._inputRef);
-                    await Js.InvokeVoidAsync(JSInteropConstants.AddPreventKeys, ParentSelect._inputRef, new[] { "ArrowUp", "ArrowDown", "Enter" });
-                }
-                else
-                {
-                    await Js.InvokeVoidAsync(JSInteropConstants.AddPreventKeys, ParentSelect._inputRef, new[] { "ArrowUp", "ArrowDown" });
-                    await Js.InvokeVoidAsync(JSInteropConstants.AddPreventEnterOnOverlayVisible, ParentSelect._inputRef, ParentSelect.DropDownRef);
-                }
-            });
-        }
-
-
         public bool IsDisposed { get; private set; }
 
         protected virtual void Dispose(bool disposing)
@@ -179,10 +152,7 @@ namespace AntDesign.Select.Internal
                 {
                     await Task.Delay(100);
                     await Js.InvokeVoidAsync(JSInteropConstants.RemovePreventKeys, ParentSelect._inputRef);
-                    if (!ParentSelect.DisableSubmitFormOnEnter)
-                    {
-                        await Js.InvokeVoidAsync(JSInteropConstants.RemovePreventEnterOnOverlayVisible, ParentSelect._inputRef);
-                    }
+                    await Js.InvokeVoidAsync(JSInteropConstants.RemovePreventEnterOnOverlayVisible, ParentSelect._inputRef);                    
                 });
             }
             DomEventService.RemoveEventListerner<JsonElement>("window", "beforeunload", Reloading);


### PR DESCRIPTION
### 🤔 This is a ...

- [x] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
Fixes #1176 

### 💡 Background and solution
Except fixes to #1176, this commit also adds the following:
1. Clear selection when "Delete" key or "Backspace" key pressed.
2. Exposes new attribute `DisableSubmitFormOnEnter`: Default behavior for `Select` component on a `Form` is to submit on Enter. The exception is when Enter is pressed while select options are visible (then Enter will set picked option as the value). If `DisableSubmitFormOnEnter = true` then Enter will not submit on a `Form`.
3. Interop gets a new event handler that prevents default for passed array of keys (more flexible)
4. EditContext is notified about a change in `Select` component (if `Form.ValidateOnChange == true`)

Also, I can create a docs sample for `DisableSubmitFormOnEnter` behaviour based on this gif:
![seelct_keyBehavior](https://user-images.githubusercontent.com/6518006/109790062-a5a4ce00-7c19-11eb-922e-cf4a21345562.gif)


### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  new attribute `DisableSubmitFormOnEnter'   |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
