### PR TITLE
feat(module: InputNumber): Add long click and keyboard event

### DIFF
--- a/components/input-number/InputNumber.razor
+++ b/components/input-number/InputNumber.razor
@@ -4,15 +4,15 @@
 
 <div class="@ClassMapper.Class" style="@Style" id="@Id">
     <div class="ant-input-number-handler-wrap">
-        <span unselectable="unselectable" role="button" aria-label="Increase Value" class="@GetIconClass("up")" @onmousedown="Increase">
+        <span unselectable="unselectable" role="button" aria-label="Increase Value" class="@GetIconClass("up")" @onmousedown="IncreaseDown" @onmouseup="IncreaseUp">
             <Icon Class="ant-input-number-handler-up-inner" Type="up"  />
         </span>
-        <span unselectable="unselectable" role="button" aria-label="Decrease Value" class="@GetIconClass("down")" @onmousedown="Decrease">
+        <span unselectable="unselectable" role="button" aria-label="Decrease Value" class="@GetIconClass("down")" @onmousedown="DecreaseDown" @onmouseup="DecreaseUp">
             <Icon Class="ant-input-number-handler-down-inner" Type="down"  />
         </span>
     </div>
     <div class="ant-input-number-input-wrap">
         <input @ref="Ref" role="spinbutton" aria-valuemin="@Min" aria-valuemax="@Max" autocomplete="off" max="@Max" min="@Min" step="@Step"
-               aria-valuenow="@CurrentValue" class="ant-input-number-input" @bind="@CurrentValueAsString" @oninput="OnInput" @onfocus="@OnFocus" @onblur="@OnBlurAsync" disabled="@Disabled" />
+               aria-valuenow="@CurrentValue" class="ant-input-number-input" @bind="@CurrentValueAsString" @oninput="OnInput" @onkeydown="OnKeyDown" @onfocus="@OnFocus" @onblur="@OnBlurAsync" disabled="@Disabled" />
     </div>
 </div>

--- a/components/input-number/InputNumber.razor.cs
+++ b/components/input-number/InputNumber.razor.cs
@@ -4,8 +4,10 @@ using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace AntDesign
 {
@@ -144,6 +146,10 @@ namespace AntDesign
         private string _inputString;
         private bool _focused;
 
+        private readonly int _interval = 200;
+        private CancellationTokenSource _increaseTokenSource;
+        private CancellationTokenSource _decreaseTokenSource;
+
         public InputNumber()
         {
             _isNullable = _surfaceType.IsGenericType && _surfaceType.GetGenericTypeDefinition() == typeof(Nullable<>);
@@ -275,7 +281,9 @@ namespace AntDesign
                 .If($"{PrefixCls}-disabled", () => this.Disabled);
         }
 
-        private async Task Increase()
+        #region Value Increase and Decrease Methods
+
+        private async Task IncreaseDown()
         {
             if (_isNullable && Value == null)
             {
@@ -288,9 +296,30 @@ namespace AntDesign
             await SetFocus();
             var num = _increaseFunc(Value, _step);
             await ChangeValueAsync(num);
+
+            _increaseTokenSource = new CancellationTokenSource();
+            _ = Increase(_increaseTokenSource.Token).ConfigureAwait(false);
         }
 
-        private async Task Decrease()
+        private void IncreaseUp() => _increaseTokenSource.Cancel();
+
+        private async Task Increase(CancellationToken cancellationToken)
+        {
+            await Task.Delay(600, CancellationToken.None);
+            while (true)
+            {
+                if (_equalToFunc(Value, Max) || cancellationToken.IsCancellationRequested)
+                {
+                    return;
+                }
+                var num = _increaseFunc(Value, _step);
+                await ChangeValueAsync(num);
+                StateHasChanged();
+                await Task.Delay(_interval, CancellationToken.None);
+            }
+        }
+
+        private async Task DecreaseDown()
         {
             if (_isNullable && Value == null)
             {
@@ -303,7 +332,58 @@ namespace AntDesign
             await SetFocus();
             var num = _decreaseFunc(Value, _step);
             await ChangeValueAsync(num);
+
+            _decreaseTokenSource = new CancellationTokenSource();
+            _ = Decrease(_decreaseTokenSource.Token).ConfigureAwait(false);
         }
+
+        private void DecreaseUp() => _decreaseTokenSource.Cancel();
+
+        private async Task Decrease(CancellationToken cancellationToken)
+        {
+            await Task.Delay(600, CancellationToken.None);
+            while (true)
+            {
+                if (_equalToFunc(Value, Min) || cancellationToken.IsCancellationRequested)
+                {
+                    return;
+                }
+                var num = _decreaseFunc(Value, _step);
+                await ChangeValueAsync(num);
+                StateHasChanged();
+                await Task.Delay(_interval, CancellationToken.None);
+            }
+        }
+
+        private async Task OnKeyDown(KeyboardEventArgs e)
+        {
+            if (_isNullable && Value == null)
+            {
+                return;
+            }
+            if (e.Key == "ArrowUp")
+            {
+                if (_equalToFunc(Value, Max))
+                {
+                    return;
+                }
+                var num = _increaseFunc(Value, _step);
+                await ChangeValueAsync(num);
+                StateHasChanged();
+            }
+            else if (e.Key == "ArrowDown")
+            {
+                if (_equalToFunc(Value, Min))
+                {
+                    return;
+                }
+                var num = _decreaseFunc(Value, _step);
+                await ChangeValueAsync(num);
+                StateHasChanged();
+            }
+        }
+
+        #endregion
 
         private async Task SetFocus()
         {

--- a/components/input-number/InputNumber.razor.cs
+++ b/components/input-number/InputNumber.razor.cs
@@ -226,6 +226,7 @@ namespace AntDesign
             SetClass();
             CurrentValue = Value ?? DefaultValue;
         }
+
         /// <summary>
         /// Always return true, if input string is invalid, result = default, if input string is null or empty, result = DefaultValue
         /// </summary>
@@ -301,7 +302,7 @@ namespace AntDesign
             _ = Increase(_increaseTokenSource.Token).ConfigureAwait(false);
         }
 
-        private void IncreaseUp() => _increaseTokenSource.Cancel();
+        private void IncreaseUp() => _increaseTokenSource?.Cancel();
 
         private async Task Increase(CancellationToken cancellationToken)
         {
@@ -337,7 +338,7 @@ namespace AntDesign
             _ = Decrease(_decreaseTokenSource.Token).ConfigureAwait(false);
         }
 
-        private void DecreaseUp() => _decreaseTokenSource.Cancel();
+        private void DecreaseUp() => _decreaseTokenSource?.Cancel();
 
         private async Task Decrease(CancellationToken cancellationToken)
         {
@@ -383,7 +384,7 @@ namespace AntDesign
             }
         }
 
-        #endregion
+        #endregion Value Increase and Decrease Methods
 
         private async Task SetFocus()
         {


### PR DESCRIPTION
### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

No such issue

### 💡 Background and solution

InputNumber‘s functions is not complete compared to offical AntDesign component.

### 📝 Changelog

1. When hold mouse down will always trigger the increase or decrease
2. `ArrowUp` or `ArrowDown` key can increase or decrease value

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   add long-click and keyboard operation        |
| 🇨🇳 Chinese |    增加长按和键盘操作      |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
