### PR TITLE
fix(module: rangepicker): [selected date on end picker]、[quarter panel's ranges]  are incorrect

### DIFF
--- a/components/date-picker/internal/DatePickerPanelBase.cs
+++ b/components/date-picker/internal/DatePickerPanelBase.cs
@@ -176,7 +176,7 @@ namespace AntDesign
             int? second = null)
         {
             return DateHelper.CombineNewDate(
-                GetIndexPickerValue(0),
+                PickerValue,
                 year,
                 month,
                 day,
@@ -188,16 +188,12 @@ namespace AntDesign
 
         protected void ChangePickerYearValue(int interval)
         {
-            var currentValue = GetIndexPickerValue(0);
-
-            ChangePickerValue(DateHelper.AddYearsSafely(currentValue, interval), null);
+            ChangePickerValue(DateHelper.AddYearsSafely(PickerValue, interval), null);
         }
 
         protected void ChangePickerMonthValue(int interval)
         {
-            var currentValue = GetIndexPickerValue(0);
-
-            ChangePickerValue(DateHelper.AddMonthsSafely(currentValue, interval), null);
+            ChangePickerValue(DateHelper.AddMonthsSafely(PickerValue, interval), null);
         }
 
         protected void Close()

--- a/components/date-picker/internal/DatePickerTemplate.razor.cs
+++ b/components/date-picker/internal/DatePickerTemplate.razor.cs
@@ -134,7 +134,8 @@ namespace AntDesign.Internal
 
         private bool IsDateInRange(DateTime currentColDate)
         {
-            if (!IsRange || !Picker.IsIn(DatePickerType.Date, DatePickerType.Year, DatePickerType.Month))
+            if (!IsRange ||
+                !Picker.IsIn(DatePickerType.Date, DatePickerType.Year, DatePickerType.Month, DatePickerType.Quarter))
             {
                 return false;
             }
@@ -209,7 +210,7 @@ namespace AntDesign.Internal
         private string GetRangeHoverCls(DateTime currentColDate)
         {
             if (!IsRange || DatePicker.HoverDateTime == null
-                || Picker.IsIn(DatePickerType.Date, DatePickerType.Year, DatePickerType.Month) == false)
+                || Picker.IsIn(DatePickerType.Date, DatePickerType.Year, DatePickerType.Month, DatePickerType.Quarter) == false)
             {
                 return "";
             }
@@ -291,7 +292,7 @@ namespace AntDesign.Internal
 
         private string GetRangeStartCls(DateTime currentColDate)
         {
-            if (!IsRange || Picker.IsIn(DatePickerType.Date, DatePickerType.Year, DatePickerType.Month) == false)
+            if (!IsRange || Picker.IsIn(DatePickerType.Date, DatePickerType.Year, DatePickerType.Month, DatePickerType.Quarter) == false)
             {
                 return "";
             }
@@ -332,7 +333,7 @@ namespace AntDesign.Internal
 
         private string GetRangeEndCls(DateTime currentColDate)
         {
-            if (!IsRange || Picker.IsIn(DatePickerType.Date, DatePickerType.Year, DatePickerType.Month) == false)
+            if (!IsRange || Picker.IsIn(DatePickerType.Date, DatePickerType.Year, DatePickerType.Month, DatePickerType.Quarter) == false)
             {
                 return "";
             }
@@ -374,7 +375,7 @@ namespace AntDesign.Internal
 
         private string GetRangeEdgeCls(DateTime currentColDate)
         {
-            if (!IsRange || Picker.IsIn(DatePickerType.Date, DatePickerType.Year, DatePickerType.Month) == false)
+            if (!IsRange || Picker.IsIn(DatePickerType.Date, DatePickerType.Year, DatePickerType.Month, DatePickerType.Quarter) == false)
             {
                 return "";
             }


### PR DESCRIPTION
I fix these bugs:
1. Quarter panel's ranges are not correct, see #945

2. Selected date on end picker is incorrect in Month and Quarter mode, follow these steps:
step1. Select start date on 2021-2
step2. Select end date on 2022-5

Finally, the end date would be 2021-5(it should be 2022-5)


And I found another issue #1259. I tried to fix it, but i failed.


### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     [selected date on end picker]、[quarter panel's ranges]  are incorrect      |
| 🇨🇳 Chinese |     [从结束日期面板选择的日期]、[季度面板的日期范围效果]  不正确      |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
