### PR TITLE
feat(module:upload): missing and new event

### DIFF
--- a/components/upload/Upload.razor
+++ b/components/upload/Upload.razor
@@ -115,7 +115,14 @@
                                                 }
                                                 picture = "picture";
                                             }
-                                            <a target="_blank" rel="noopener noreferrer" class="ant-upload-list-item-name" title="@file.FileName" href="@file.Url">@file.FileName</a>
+                                            @if (OnDownload.HasDelegate)
+                                            {
+                                                <a rel="noopener noreferrer" class="ant-upload-list-item-name" title="@file.FileName" @onclick="() => DownloadFile(file)">@file.FileName</a>
+                                            }
+                                            else
+                                            {
+                                                <a target="_blank" rel="noopener noreferrer" class="ant-upload-list-item-name" title="@file.FileName" href="@file.Url">@file.FileName</a>
+                                            }
                                             <span class="ant-upload-list-item-card-actions @picture">
                                                 <button title="@Locale.RemoveFile" type="button" class="ant-btn ant-btn-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-card-actions-btn" @onclick="() => RemoveFile(file)" disabled="@Disabled">
                                                     <Icon Type="delete" />

--- a/components/upload/Upload.razor.cs
+++ b/components/upload/Upload.razor.cs
@@ -13,6 +13,12 @@ namespace AntDesign
         public Func<UploadFileItem, bool> BeforeUpload { get; set; }
 
         [Parameter]
+        public Func<List<UploadFileItem>, Task<bool>> BeforeAllUploadAsync { get; set; }
+
+        [Parameter]
+        public Func<List<UploadFileItem>, bool> BeforeAllUpload { get; set; }
+
+        [Parameter]
         public string Name { get; set; }
 
         [Parameter]
@@ -70,6 +76,9 @@ namespace AntDesign
         public EventCallback<UploadFileItem> OnPreview { get; set; }
 
         [Parameter]
+        public EventCallback<UploadFileItem> OnDownload { get; set; }
+
+        [Parameter]
         public RenderFragment ChildContent { get; set; }
 
         [Parameter]
@@ -110,7 +119,6 @@ namespace AntDesign
             {
                 this.FileList.Remove(item);
                 await this.FileListChanged.InvokeAsync(this.FileList);
-
                 StateHasChanged();
             }
         }
@@ -120,6 +128,14 @@ namespace AntDesign
             if (item.State == UploadState.Success && OnPreview.HasDelegate)
             {
                 await OnPreview.InvokeAsync(item);
+            }
+        }
+
+        private async Task DownloadFile(UploadFileItem item)
+        {
+            if (item.State == UploadState.Success && OnDownload.HasDelegate)
+            {
+                await OnDownload.InvokeAsync(item);
             }
         }
     }

--- a/site/AntDesign.Docs/Demos/Components/Upload/doc/index.en-US.md
+++ b/site/AntDesign.Docs/Demos/Components/Upload/doc/index.en-US.md
@@ -23,7 +23,8 @@ Uploading is the process of publishing information (web pages, text, pictures, v
 | action | Uploading URL | string\|(file) => `Promise` | - |  |
 | method | http method of upload request | string | 'post' |  |
 | directory | support upload whole directory ([caniuse](https://caniuse.com/#feat=input-file-directory)) | boolean | false |  |
-| beforeUpload | Hook function which will be executed before uploading. Uploading will be stopped with `false` or a rejected Promise returned. **Warning：this function is not supported in IE9**。 | (file, fileList) => `boolean | Promise` | - |  |
+| BeforeUpload | Hook function which will be executed before uploading each file. Uploading will be stopped with `false` or a rejected Promise returned. **Warning：this function is not supported in IE9**。 | (file, fileList) => `boolean | Promise` | - |  |
+| BeforeAllUpload & BeforeAllUploadAsync  | Hook function which will be executed before uploading. Uploading will be stopped with `false` or a rejected Promise returned. **Warning：this function is not supported in IE9**。 | (file, fileList) => `boolean | Promise` | - |  |
 | customRequest | override for the default xhr behavior allowing for additional customization and ability to implement your own XMLHttpRequest | Function | - |  |
 | data | Uploading extra params or function which can return uploading extra params. | object\|function(file) | - |  |
 | defaultFileList | Default list of files that have been uploaded. | object\[] | - |  |

--- a/site/AntDesign.Docs/Demos/Components/Upload/doc/index.zh-CN.md
+++ b/site/AntDesign.Docs/Demos/Components/Upload/doc/index.zh-CN.md
@@ -24,7 +24,8 @@ cover: https://gw.alipayobjects.com/zos/alicdn/QaeBt_ZMg/Upload.svg
 | action | 上传的地址 | string\|(file) => `Promise` | 无 |  |
 | method | 上传请求的 http method | string | 'post' |  |
 | directory | 支持上传文件夹（[caniuse](https://caniuse.com/#feat=input-file-directory)） | boolean | false |  |
-| beforeUpload | 上传文件之前的钩子，参数为上传的文件，若返回 `false` 则停止上传。支持返回一个 Promise 对象，Promise 对象 reject 时则停止上传，resolve 时开始上传（ resolve 传入 `File` 或 `Blob` 对象则上传 resolve 传入对象）。**注意：IE9 不支持该方法**。 | (file, fileList) => `boolean | Promise` | 无 |  |
+| BeforeUpload | 上传文件之前的钩子，参数为上传的文件，若返回 `false` 则停止上传。支持返回一个 Promise 对象，Promise 对象 reject 时则停止上传，resolve 时开始上传（ resolve 传入 `File` 或 `Blob` 对象则上传 resolve 传入对象）。**注意：IE9 不支持该方法**。 | (file, fileList) => `boolean | Promise` | 无 |  |
+| BeforeAllUpload & BeforeAllUploadAsync | 上传文件之前的钩子，参数为上传的文件，若返回 `false` 则停止上传。支持返回一个 Promise 对象，Promise 对象 reject 时则停止上传，resolve 时开始上传（ resolve 传入 `File` 或 `Blob` 对象则上传 resolve 传入对象）。**注意：IE9 不支持该方法**。 | (file, fileList) => `boolean | Promise` | 无 |  |
 | customRequest | 通过覆盖默认的上传行为，可以自定义自己的上传实现 | Function | 无 |  |
 | data | 上传所需额外参数或返回上传额外参数的方法 | object\|(file) => object | 无 |  |
 | defaultFileList | 默认已经上传的文件列表 | object\[] | 无 |  |


### PR DESCRIPTION
### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
Added missing event `OnDownload` (exists in react antDesign)
Added 2 new events `BeforeAllUpload` and its async counterpart. Use case - to check whole upload list for duplicates, instead go file-by-file using `BeforeUpload`.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Added events: `OnDownload`, `BeforeAllUpload` & `BeforeAllUploadAsync`         |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
