### PR TITLE
fix(module:select): propagation on item remove

### DIFF
--- a/components/select/Select.razor.cs
+++ b/components/select/Select.razor.cs
@@ -1205,7 +1205,8 @@ namespace AntDesign
         /// </summary>
         internal async Task UpdateOverlayPositionAsync()
         {
-            await _dropDown.GetOverlayComponent().UpdatePosition();
+            if (_dropDown.Visible)
+                await _dropDown.GetOverlayComponent().UpdatePosition();
         }
 
         #region Events

--- a/components/select/internal/SelectContent.razor
+++ b/components/select/internal/SelectContent.razor
@@ -82,7 +82,7 @@
                         <span class="@Prefix-selection-item">
                             <span class="@Prefix-selection-item-content">@selectedOption.Label</span>
                             <span unselectable="on" aria-hidden="true" style="user-select: none;" class="@Prefix-selection-item-remove"
-                                  @onclick="()=> OnRemoveSelected.InvokeAsync(selectedOption)" @onclick:stopPropagation="true">
+                                  @onmousedown="()=> OnRemoveSelected.InvokeAsync(selectedOption)" onclick="event.stopPropagation()">
                                 <Icon Type="close"></Icon>
                             </span>
                         </span>


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
Issue mentioned in [this PR1307](https://github.com/ant-design-blazor/ant-design-blazor/pull/1307#issuecomment-812895579)

### 💡 Background and solution
Removeable item is basically a span with icon, that has the `@onclick` event. That event has also `@onclick:stopPropagation="true"`. What I did not know, that this does not apply to DOM events, but only to blazor events ([source](https://github.com/dotnet/aspnetcore/issues/30199)). I could probably try to make some complex js, but the simples change was to keep this as local as possible. But, if a dedicated function in `interop.ts` is required, it can probably be done.

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
