### PR TITLE
fix(module:avatar): text size calc regional independent

### DIFF
--- a/components/avatar/Avatar.razor.cs
+++ b/components/avatar/Avatar.razor.cs
@@ -165,10 +165,10 @@ namespace AntDesign
             var childrenWidth = (await JsInvokeAsync<Element>(JSInteropConstants.GetDomInfo, TextEl))?.offsetWidth ?? 0;
             var avatarWidth = (await JsInvokeAsync<DomRect>(JSInteropConstants.GetBoundingClientRect, Ref))?.width ?? 0;
             var scale = childrenWidth != 0 && avatarWidth - 8 < childrenWidth ? (avatarWidth - 8) / childrenWidth : 1;
-            _textStyles = $"transform: scale({scale}) translateX(-50%);";
+            _textStyles = $"transform: scale({scale.ToString("0.00", CultureInfo.InvariantCulture)}) translateX(-50%);";
             if (decimal.TryParse(Size, out var pxSize))
             {
-                _textStyles += $"lineHeight:{pxSize}px;";
+                _textStyles += $"lineHeight:{pxSize.ToString("0.00", CultureInfo.InvariantCulture)}px;";
             }
 
             StateHasChanged();

--- a/components/avatar/Avatar.razor.cs
+++ b/components/avatar/Avatar.razor.cs
@@ -165,10 +165,10 @@ namespace AntDesign
             var childrenWidth = (await JsInvokeAsync<Element>(JSInteropConstants.GetDomInfo, TextEl))?.offsetWidth ?? 0;
             var avatarWidth = (await JsInvokeAsync<DomRect>(JSInteropConstants.GetBoundingClientRect, Ref))?.width ?? 0;
             var scale = childrenWidth != 0 && avatarWidth - 8 < childrenWidth ? (avatarWidth - 8) / childrenWidth : 1;
-            _textStyles = $"transform: scale({scale.ToString("0.00", CultureInfo.InvariantCulture)}) translateX(-50%);";
+            _textStyles = $"transform: scale({scale.ToString(CultureInfo.InvariantCulture)}) translateX(-50%);";
             if (decimal.TryParse(Size, out var pxSize))
             {
-                _textStyles += $"lineHeight:{pxSize.ToString("0.00", CultureInfo.InvariantCulture)}px;";
+                _textStyles += $"lineHeight:{pxSize.ToString(CultureInfo.InvariantCulture)}px;";
             }
 
             StateHasChanged();


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
Fixes #1340 

### 💡 Background and solution
When scale was applied to styles, it was not made regional settings resilient. So there would be a scenario when avatar style would get something like this `scale(0,9340293843421312)` (with comma instead of dot). So when js `getDomInfo` was reading this, it was getting a value that was much grater than Int32. When c# was trying to put that into Int32, it was failing, thus exception.

@TsakiDev, thank you for you invaluable help! I could not have discovered this without your help. 

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
