### PR TITLE
fix(module:overlay): do not use currentculture in string interpolation

### DIFF
--- a/components/core/Component/overlay/Overlay.razor.cs
+++ b/components/core/Component/overlay/Overlay.razor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -201,7 +202,9 @@ namespace AntDesign.Internal
 
             int zIndex = await JsInvokeAsync<int>(JSInteropConstants.GetMaxZIndex);
 
-            _overlayStyle = $"z-index:{zIndex};left: {left}px;top: {top}px;{GetTransformOrigin()}";
+            _overlayStyle = $"z-index:{zIndex.ToString(CultureInfo.InvariantCulture)};" +
+                $"left: {left.ToString(CultureInfo.InvariantCulture)}px;" +
+                $"top: {top.ToString(CultureInfo.InvariantCulture)}px;{GetTransformOrigin()}";
 
             _overlayCls = Trigger.GetOverlayEnterClass();
 
@@ -615,7 +618,9 @@ namespace AntDesign.Internal
 
             int zIndex = await JsInvokeAsync<int>(JSInteropConstants.GetMaxZIndex);
 
-            _overlayStyle = $"z-index:{zIndex};left: {left}px;top: {top}px;{GetTransformOrigin()}";
+            _overlayStyle = $"z-index:{zIndex.ToString(CultureInfo.InvariantCulture)};" +
+                $"left: {left.ToString(CultureInfo.InvariantCulture)}px;" +
+                $"top: {top.ToString(CultureInfo.InvariantCulture)}px;{GetTransformOrigin()}";
 
             StateHasChanged();
         }


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
Fixes #639

### 💡 Background and solution
Regional settings were being taken into account when doing string interpolation in styles. 

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
