### PR TITLE
fix(module:avatar): size calculation & CssSizeLength functionality expansion

### DIFF
--- a/components/avatar/Avatar.razor
+++ b/components/avatar/Avatar.razor
@@ -3,7 +3,7 @@
 
 @if (Position == null || (Position == "shown" && !Overflow) || (Position == "hidden" && Overflow))
 {
-    <span class="@ClassMapper.Class" style="@Style" id="@Id" @ref="Ref">
+    <span class="@ClassMapper.Class" style="@_sizeStyles @Style" id="@Id" @ref="Ref">
         @if (_hasIcon)
         {
             <Icon Type="@Icon" />

--- a/components/avatar/Avatar.razor.cs
+++ b/components/avatar/Avatar.razor.cs
@@ -71,6 +71,7 @@ namespace AntDesign
         private bool _hasIcon;
 
         private string _textStyles = "";
+        private string _sizeStyles = "";
 
         protected ElementReference TextEl { get; set; }
 
@@ -144,13 +145,11 @@ namespace AntDesign
         {
             if (decimal.TryParse(Size, out var pxSize))
             {
-                var size = StyleHelper.ToCssPixel(pxSize.ToString(CultureInfo.InvariantCulture));
-                Style += $";width:{size};";
-                Style += $"height:{size};";
-                Style += $"line-height:{size};";
+                string size = new CssSizeLength(pxSize).ToString();
+                _sizeStyles = $"width:{size};height:{size};line-height:{size};";
                 if (_hasIcon)
                 {
-                    Style += $"font-size:calc(${size} / 2)";
+                    _sizeStyles += $"font-size:calc(${size} / 2);";
                 }
             }
         }
@@ -165,10 +164,10 @@ namespace AntDesign
             var childrenWidth = (await JsInvokeAsync<Element>(JSInteropConstants.GetDomInfo, TextEl))?.offsetWidth ?? 0;
             var avatarWidth = (await JsInvokeAsync<DomRect>(JSInteropConstants.GetBoundingClientRect, Ref))?.width ?? 0;
             var scale = childrenWidth != 0 && avatarWidth - 8 < childrenWidth ? (avatarWidth - 8) / childrenWidth : 1;
-            _textStyles = $"transform: scale({scale.ToString(CultureInfo.InvariantCulture)}) translateX(-50%);";
+            _textStyles = $"transform: scale({new CssSizeLength(scale, true)}) translateX(-50%);";
             if (decimal.TryParse(Size, out var pxSize))
             {
-                _textStyles += $"lineHeight:{pxSize.ToString(CultureInfo.InvariantCulture)}px;";
+                _textStyles += $"lineHeight:{(CssSizeLength)pxSize};";
             }
 
             StateHasChanged();

--- a/components/core/CssSizeLength.cs
+++ b/components/core/CssSizeLength.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Text;
 
 namespace AntDesign
 {
@@ -23,44 +21,47 @@ namespace AntDesign
         Vmax,
         Fr,
         Calc,
+        NoUnit,
     }
 
     public readonly struct CssSizeLength : IEquatable<CssSizeLength>
     {
-        public int Value => _value ?? 0;
+        public decimal Value => _value ?? 0;
 
         public string StringValue => _stringValue;
 
         internal CssSizeLengthUnit Unit => _unit;
 
-        private readonly int? _value;
+        private readonly decimal? _value;
         private readonly string _stringValue;
 
         private readonly CssSizeLengthUnit _unit;
 
         public override string ToString()
         {
-            var intValue = _value?.ToString(CultureInfo.InvariantCulture);
+            var numericValue = _value?.ToString(CultureInfo.InvariantCulture);
             var unit = _unit switch
             {
                 CssSizeLengthUnit.Percent => "%",
-                CssSizeLengthUnit.Calc => "",
+                CssSizeLengthUnit.Calc or CssSizeLengthUnit.NoUnit => "",
                 _ => Enum.GetName(typeof(CssSizeLengthUnit), _unit).ToLowerInvariant()
             };
 
-            return $"{intValue ?? StringValue}{unit}";
+            return $"{numericValue ?? StringValue}{unit}";
         }
 
-        private CssSizeLength(int value, CssSizeLengthUnit unit)
+        private CssSizeLength(decimal value, CssSizeLengthUnit unit)
         {
             _value = value;
             _stringValue = null;
             _unit = unit;
         }
 
-        public CssSizeLength(int value) : this(value, CssSizeLengthUnit.Px)
-        {
-        }
+        private static CssSizeLengthUnit EvalUnitless(bool noUnit) => (noUnit ? CssSizeLengthUnit.NoUnit : CssSizeLengthUnit.Px);
+
+        public CssSizeLength(int value, bool noUnit = false) : this(value, EvalUnitless(noUnit)) { }
+        public CssSizeLength(double value, bool noUnit = false) : this(Convert.ToDecimal(value), EvalUnitless(noUnit)) { }
+        public CssSizeLength(decimal value, bool noUnit = false) : this(value, EvalUnitless(noUnit)) { }
 
         public CssSizeLength(string value)
         {
@@ -107,6 +108,10 @@ namespace AntDesign
         }
 
         public static implicit operator CssSizeLength(int value) => new CssSizeLength(value);
+
+        public static implicit operator CssSizeLength(double value) => new CssSizeLength(value);
+
+        public static implicit operator CssSizeLength(decimal value) => new CssSizeLength(value);
 
         public static implicit operator CssSizeLength(string value) => new CssSizeLength(value);
 

--- a/tests/AntDesign.Tests/Core/CssSizeLengthTests.cs
+++ b/tests/AntDesign.Tests/Core/CssSizeLengthTests.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace AntDesign.Tests.Core
+{
+    public class CssSizeLengthTests
+    {
+        public enum DataType
+        {
+            IntegerType,
+            DoubleType,
+            DecimalType,
+            StringType
+        };
+
+        [Theory]
+        [MemberData(nameof(Css_numeric_seeds))]
+        public void Css_numeric(object value, DataType type, string expected, bool noUnit)
+        {
+            var result = type switch
+            {
+                DataType.IntegerType => noUnit ? new CssSizeLength((int)value, noUnit).ToString() : new CssSizeLength((int)value).ToString(),
+                DataType.DoubleType => noUnit ? new CssSizeLength((double)value, noUnit).ToString() : new CssSizeLength((double)value).ToString(),
+                DataType.DecimalType => noUnit ? new CssSizeLength((decimal)value, noUnit).ToString() : new CssSizeLength((decimal)value).ToString(),
+                _ => throw new ArgumentException("Only integer/double/decimal allowed in this type of test.")
+            };
+            Assert.Equal(expected, result);
+        }
+
+        public static IEnumerable<object[]> Css_numeric_seeds => new List<object[]>
+        {
+            new object[] { 1234567, DataType.IntegerType, "1234567px", false },
+            new object[] { 1234567d, DataType.DoubleType, "1234567px", false },
+            new object[] { 123456.7d, DataType.DoubleType, "123456.7px", false },
+            new object[] { 12345.67d, DataType.DoubleType, "12345.67px", false },
+            new object[] { 1234.567d, DataType.DoubleType, "1234.567px", false },
+            new object[] { 1234567m, DataType.DecimalType, "1234567px", false },
+            new object[] { 123456.7m, DataType.DecimalType, "123456.7px", false },
+            new object[] { 12345.67m, DataType.DecimalType, "12345.67px", false },
+            new object[] { 1234.567m, DataType.DecimalType, "1234.567px", false },
+
+            new object[] { 1234567, DataType.IntegerType, "1234567", true },
+            new object[] { 1234567d, DataType.DoubleType, "1234567", true },
+            new object[] { 123456.7d, DataType.DoubleType, "123456.7", true },
+            new object[] { 12345.67d, DataType.DoubleType, "12345.67", true },
+            new object[] { 1234.567d, DataType.DoubleType, "1234.567", true },
+            new object[] { 1234567m, DataType.DecimalType, "1234567", true },
+            new object[] { 123456.7m, DataType.DecimalType, "123456.7", true },
+            new object[] { 12345.67m, DataType.DecimalType, "12345.67", true },
+            new object[] { 1234.567m, DataType.DecimalType, "1234.567", true },
+        };
+
+        [Theory]
+        [MemberData(nameof(Css_implicit_numeric_seeds))]
+        public void Css_implicit_numeric(object value, DataType type, string expected)
+        {
+            var result = type switch
+            {
+                DataType.IntegerType => ((CssSizeLength)(int)value).ToString(),
+                DataType.DoubleType => ((CssSizeLength)(double)value).ToString(),
+                DataType.DecimalType => ((CssSizeLength)(decimal)value).ToString(),
+                _ => throw new ArgumentException("Only integer/double/decimal allowed in this type of test.")
+            };
+            Assert.Equal(expected, result);
+        }
+
+        public static IEnumerable<object[]> Css_implicit_numeric_seeds => new List<object[]>
+        {
+            new object[] { 1234567, DataType.IntegerType, "1234567px"},
+            new object[] { 1234567d, DataType.DoubleType, "1234567px"},
+            new object[] { 123456.7d, DataType.DoubleType, "123456.7px"},
+            new object[] { 12345.67d, DataType.DoubleType, "12345.67px"},
+            new object[] { 1234.567d, DataType.DoubleType, "1234.567px"},
+            new object[] { 1234567m, DataType.DecimalType, "1234567px"},
+            new object[] { 123456.7m, DataType.DecimalType, "123456.7px"},
+            new object[] { 12345.67m, DataType.DecimalType, "12345.67px"},
+            new object[] { 1234.567m, DataType.DecimalType, "1234.567px"},
+        };
+    }
+}


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [x] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
In `Avatar` component `Size` parameter was not doing anything when size was explicitly passed (for example "45.55px" did nothing).

### 💡 Background and solution
Following the advice from PR #1355 I extended `CssSizeLength` to handle decimal & double data types. Also, it can handle no unit (need for example in `scale` or `z-index`). I created tests to check how the handling of different numeric data types works. 

I fixed the issue with `Avatar` and `Size` parameter.

Side note: `Avatar` was using a helper method `StyleHelper.ToCssPixel()`. It seems to me that `CssSizeLength` does same + much more so I also replaced it. I think this helper could be retired in favour of `CssSizeLength` in all occurrences. 

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
