### PR TITLE
fix(module:select): OnDataSourceChange called when expected

### DIFF
--- a/components/select/Select.razor.cs
+++ b/components/select/Select.razor.cs
@@ -228,10 +228,12 @@ namespace AntDesign
                     SelectedOptionItems.Clear();
 
                     Value = default;
+                    var sameObject = object.ReferenceEquals(_datasource, value);
 
                     _datasource = value;
 
-                    OnDataSourceChanged?.Invoke();
+                    if (!sameObject)
+                        OnDataSourceChanged?.Invoke();
 
                     return;
                 }

--- a/tests/AntDesign.Tests/Select/Actions/Select.OnDataSourceChangeTests.razor
+++ b/tests/AntDesign.Tests/Select/Actions/Select.OnDataSourceChangeTests.razor
@@ -53,4 +53,50 @@
         //Assert
         handlerCalled.Should().BeFalse();
     }
+
+    [Fact]
+    public async Task Action_not_fired_when_datasource_item_removed()
+    {
+        //Arrange
+        JSInterop.Setup<AntDesign.JsInterop.DomRect>(JSInteropConstants.GetBoundingClientRect, _ => true)
+            .SetResult(new AntDesign.JsInterop.DomRect());
+        bool handlerCalled = false;
+        Action OnDataSourceChangedHandler = () => handlerCalled = true;
+        _persons = new List<Person> { _persons[0] };
+        var cut = Render<AntDesign.Select<int, Person>>(
+        @<AntDesign.Select DataSource="@_persons"            
+            LabelName="@nameof(Person.Name)"
+            ValueName="@nameof(Person.Id)"
+            Value="0"
+            OnDataSourceChanged="OnDataSourceChangedHandler">
+        </AntDesign.Select>);
+        //Act
+        _persons.RemoveAt(0);
+        cut.SetParametersAndRender(parameters => parameters.Add(p => p.DataSource, _persons));
+        //Assert
+        handlerCalled.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Action_not_fired_when_datasource_cleared()
+    {
+        //Arrange
+        JSInterop.Setup<AntDesign.JsInterop.DomRect>(JSInteropConstants.GetBoundingClientRect, _ => true)
+            .SetResult(new AntDesign.JsInterop.DomRect());        
+        bool handlerCalled = false;
+        Action OnDataSourceChangedHandler = () => handlerCalled = true;
+        
+        var cut = Render<AntDesign.Select<int, Person>>(
+        @<AntDesign.Select DataSource="@_persons"            
+            LabelName="@nameof(Person.Name)"
+            ValueName="@nameof(Person.Id)"
+            Value="0"
+            OnDataSourceChanged="OnDataSourceChangedHandler">
+        </AntDesign.Select>);
+        //Act
+        _persons.Clear();
+        cut.SetParametersAndRender(parameters => parameters.Add(p => p.DataSource, _persons));
+        //Assert
+        handlerCalled.Should().BeFalse();
+    }
 }  

--- a/tests/AntDesign.Tests/Select/Actions/Select.OnDataSourceChangeTests.razor
+++ b/tests/AntDesign.Tests/Select/Actions/Select.OnDataSourceChangeTests.razor
@@ -1,0 +1,56 @@
+﻿@inherits AntDesignTestBase
+@code {
+    record Person(int Id, string Name);
+    List<Person> _persons = new List<Person>
+    {
+        new Person(1, "John"),
+        new Person(2, "Lucy"),
+        new Person(3, "Jack"),
+        new Person(4, "Emily"),
+    };
+
+    [Fact]
+    public async Task Action_fired_when_datasource_changed()
+    {
+        //Arrange
+        JSInterop.Setup<AntDesign.JsInterop.DomRect>(JSInteropConstants.GetBoundingClientRect, _ => true)
+            .SetResult(new AntDesign.JsInterop.DomRect());        
+        bool handlerCalled = false;
+        Action OnDataSourceChangedHandler = () => handlerCalled = true;
+
+        var cut = Render<AntDesign.Select<int, Person>>(
+        @<AntDesign.Select DataSource="@_persons"            
+            LabelName="@nameof(Person.Name)"
+            ValueName="@nameof(Person.Id)"
+            Value="0"
+            OnDataSourceChanged="OnDataSourceChangedHandler">
+        </AntDesign.Select>);
+        //Act
+        cut.SetParametersAndRender(parameters => parameters.Add(p => p.DataSource, new List<Person>()));        
+        //Assert
+        handlerCalled.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Action_not_fired_when_datasource_item_added()
+    {
+        //Arrange
+        JSInterop.Setup<AntDesign.JsInterop.DomRect>(JSInteropConstants.GetBoundingClientRect, _ => true)
+            .SetResult(new AntDesign.JsInterop.DomRect());        
+        bool handlerCalled = false;
+        Action OnDataSourceChangedHandler = () => handlerCalled = true;
+        
+        var cut = Render<AntDesign.Select<int, Person>>(
+        @<AntDesign.Select DataSource="@_persons"            
+            LabelName="@nameof(Person.Name)"
+            ValueName="@nameof(Person.Id)"
+            Value="0"
+            OnDataSourceChanged="OnDataSourceChangedHandler">
+        </AntDesign.Select>);
+        //Act
+        _persons.Add(new Person(5, "Fank"));
+        cut.SetParametersAndRender(parameters => parameters.Add(p => p.DataSource, _persons));
+        //Assert
+        handlerCalled.Should().BeFalse();
+    }
+}  

--- a/tests/AntDesign.Tests/_Imports.razor
+++ b/tests/AntDesign.Tests/_Imports.razor
@@ -8,4 +8,5 @@
 @using Xunit
 @using Moq
 @using AntDesign
+@using AntDesign.JsInterop
 @using FluentAssertions


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
Fixes #1412

### 💡 Background and solution
Added object reference comparer to figure out if `DataSource` has really changed to a different one.

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
