### PR TITLE
fix(module:datepicker): Date picker panel click closing + some issues from #1431

### DIFF
--- a/components/core/Component/Overlay/Overlay.razor.cs
+++ b/components/core/Component/Overlay/Overlay.razor.cs
@@ -85,6 +85,12 @@ namespace AntDesign.Internal
 
         private int _overlayClientWidth = 0;
 
+        protected override void OnInitialized()
+        {
+            _overlayCls = Trigger.GetOverlayHiddenClass();
+            base.OnInitialized();
+        }
+
         protected override async Task OnParametersSetAsync()
         {
             if (!_isOverlayShow && Trigger.Visible && !_preVisible)
@@ -156,9 +162,8 @@ namespace AntDesign.Internal
                 return;
             }
             await Task.Yield();
-
             HtmlElement trigger;
-            if (Trigger.ChildContent != null)
+            if (Trigger.ChildContent is not null)
             {
                 trigger = await JsInvokeAsync<HtmlElement>(JSInteropConstants.GetFirstChildDomInfo, Trigger.Ref);
                 // fix bug in submenu: Overlay show when OvelayTrigger is not rendered complete.
@@ -583,6 +588,7 @@ namespace AntDesign.Internal
             if (!_isOverlayShow && !_isWaitForOverlayFirstRender)
             {
                 overlayCls = Trigger.GetOverlayHiddenClass();
+                _overlayCls = Trigger.GetOverlayEnterClass();
             }
             else
             {
@@ -594,14 +600,17 @@ namespace AntDesign.Internal
 
         private string GetDisplayStyle()
         {
-            string display = _isOverlayShow ? "display: inline-flex;" : "visibility: hidden;";
-
             if (!_isOverlayShow && !_isWaitForOverlayFirstRender)
-            {
-                display = "";
-            }
+                return "";
 
-            return display;
+            if (_isOverlayShow && _hasAddOverlayToBody)
+                return "display: inline-flex;";
+
+            if (_hasAddOverlayToBody)
+                return "visibility: hidden;";
+
+
+            return "display: inline-flex; visibility: hidden;";
         }
 
         internal async Task UpdatePosition(int? overlayLeft = null, int? overlayTop = null)

--- a/components/core/Helpers/DateHelper.cs
+++ b/components/core/Helpers/DateHelper.cs
@@ -9,38 +9,50 @@ namespace AntDesign
         private const int DECADE_YEAR_COUNT = 10;
         private const int QUARTER_MONTH_COUNT = 3;
 
-        public static bool IsSameDate(DateTime date, DateTime compareDate)
+        public static bool IsSameDate(DateTime? date, DateTime? compareDate)
         {
+            if (date is null || compareDate is null)
+                return false;
             return date == compareDate;
         }
 
-        public static bool IsSameYear(DateTime date, DateTime compareDate)
+        public static bool IsSameYear(DateTime? date, DateTime? compareDate)
         {
-            return date.Year == compareDate.Year;
+            if (date is null || compareDate is null)
+                return false;
+            return date.Value.Year == compareDate.Value.Year;
         }
 
-        public static bool IsSameMonth(DateTime date, DateTime compareDate)
+        public static bool IsSameMonth(DateTime? date, DateTime? compareDate)
         {
+            if (date is null || compareDate is null)
+                return false;
             return IsSameYear(date, compareDate)
-                && date.Month == compareDate.Month;
+                && date.Value.Month == compareDate.Value.Month;
         }
 
-        public static bool IsSameDay(DateTime date, DateTime compareDate)
+        public static bool IsSameDay(DateTime? date, DateTime? compareDate)
         {
+            if (date is null || compareDate is null)
+                return false;
             return IsSameYear(date, compareDate)
-                && _calendar.GetDayOfYear(date) == _calendar.GetDayOfYear(compareDate);
+                && _calendar.GetDayOfYear(date.Value) == _calendar.GetDayOfYear(compareDate.Value);
         }
 
-        public static bool IsSameWeak(DateTime date, DateTime compareDate)
+        public static bool IsSameWeak(DateTime? date, DateTime? compareDate)
         {
+            if (date is null || compareDate is null)
+                return false;
             return IsSameYear(date, compareDate)
-                && GetWeekOfYear(date) == GetWeekOfYear(compareDate);
+                && GetWeekOfYear(date.Value) == GetWeekOfYear(compareDate.Value);
         }
 
-        public static bool IsSameQuarter(DateTime date, DateTime compareDate)
+        public static bool IsSameQuarter(DateTime? date, DateTime? compareDate)
         {
+            if (date is null || compareDate is null)
+                return false;
             return IsSameYear(date, compareDate)
-                && GetDayOfQuarter(date) == GetDayOfQuarter(compareDate);
+                && GetDayOfQuarter(date.Value) == GetDayOfQuarter(compareDate.Value);
         }
 
         public static string GetDayOfQuarter(DateTime date)
@@ -51,9 +63,7 @@ namespace AntDesign
         public static int GetQuarter(DateTime date)
         {
             int offset = date.Month % QUARTER_MONTH_COUNT > 0 ? 1 : 0;
-            int quarter = date.Month / QUARTER_MONTH_COUNT + offset;
-
-            return quarter;
+            return date.Month / QUARTER_MONTH_COUNT + offset;
         }
 
         public static DateTime GetStartDateOfQuarter(DateTime date)

--- a/components/core/Helpers/DateHelper.cs
+++ b/components/core/Helpers/DateHelper.cs
@@ -39,12 +39,12 @@ namespace AntDesign
                 && _calendar.GetDayOfYear(date.Value) == _calendar.GetDayOfYear(compareDate.Value);
         }
 
-        public static bool IsSameWeak(DateTime? date, DateTime? compareDate)
+        public static bool IsSameWeak(DateTime? date, DateTime? compareDate, DayOfWeek firstDayOfWeek)
         {
             if (date is null || compareDate is null)
                 return false;
             return IsSameYear(date, compareDate)
-                && GetWeekOfYear(date.Value) == GetWeekOfYear(compareDate.Value);
+                && GetWeekOfYear(date.Value, firstDayOfWeek) == GetWeekOfYear(compareDate.Value, firstDayOfWeek);
         }
 
         public static bool IsSameQuarter(DateTime? date, DateTime? compareDate)
@@ -72,9 +72,9 @@ namespace AntDesign
             return new DateTime(date.Year, 1 + ((quarter - 1) * QUARTER_MONTH_COUNT), 1);
         }
 
-        public static int GetWeekOfYear(DateTime date)
+        public static int GetWeekOfYear(DateTime date, DayOfWeek firstDayOfWeek)
         {
-            return _calendar.GetWeekOfYear(date, CalendarWeekRule.FirstDay, DayOfWeek.Monday);
+            return _calendar.GetWeekOfYear(date, CalendarWeekRule.FirstDay, firstDayOfWeek);
         }
 
         /// <summary>

--- a/components/date-picker/DatePicker.Razor.cs
+++ b/components/date-picker/DatePicker.Razor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using AntDesign.Core.Extensions;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.JSInterop;
@@ -142,7 +143,7 @@ namespace AntDesign
         {
             if (e == null) throw new ArgumentNullException(nameof(e));
             var key = e.Key.ToUpperInvariant();
-            if (key == "ENTER" || key == "TAB")
+            if (key == "ENTER" || key == "TAB" || key == "ESCAPE")
             {
                 _duringManualInput = false;
                 if (string.IsNullOrWhiteSpace(_inputStart.Value))
@@ -150,6 +151,12 @@ namespace AntDesign
                 else
                     await TryApplyInputValue();
 
+                if (key == "ESCAPE" && _dropDown.IsOverlayShow())
+                {
+                    Close();
+                    await Js.FocusAsync(_inputStart.Ref);
+                    return;
+                }
                 if (key == "ENTER")
                 {
                     //needed only in wasm, details: https://github.com/dotnet/aspnetcore/issues/30070

--- a/components/date-picker/DatePicker.razor
+++ b/components/date-picker/DatePicker.razor
@@ -9,7 +9,7 @@
                     IsButton="@true"
                     Disabled="Disabled"
                     PopupContainerSelector="@PopupContainerSelector"
-                    OnVisibleChange="visible => OnOpenChange.InvokeAsync(visible)"
+                    OnVisibleChange="OverlayVisibleChange"					
                     OverlayEnterCls="ant-slide-up-enter ant-slide-up-enter-active ant-slide-up"
                     OverlayLeaveCls="ant-slide-up-leave ant-slide-up-leave-active ant-slide-up"
                     Trigger="new TriggerType[] { TriggerType.Click }">

--- a/components/date-picker/RangePicker.razor
+++ b/components/date-picker/RangePicker.razor
@@ -10,8 +10,9 @@
                     Disabled="Disabled"
                     PopupContainerSelector="@PopupContainerSelector"
                     OnVisibleChange="visible => OnOpenChange.InvokeAsync(visible)"
-                    OverlayEnterCls="ant-slide-up-enter ant-slide-up-enter-active ant-slide-up ant-picker-dropdown-range"
-                    OverlayLeaveCls="ant-slide-up-leave ant-slide-up-leave-active ant-slide-up ant-picker-dropdown-range"
+					OverlayClassName="ant-picker-dropdown-range"
+                    OverlayEnterCls="ant-slide-up-enter ant-slide-up-enter-active ant-slide-up"
+                    OverlayLeaveCls="ant-slide-up-leave ant-slide-up-leave-active ant-slide-up"
                     Trigger="new TriggerType[] { TriggerType.Click }">
         <Overlay>
             <div class="@(PrefixCls)-range-arrow" style="@_rangeArrowStyle"/>

--- a/components/date-picker/RangePicker.razor.cs
+++ b/components/date-picker/RangePicker.razor.cs
@@ -83,6 +83,8 @@ namespace AntDesign
             {
                 return;
             }
+            _openingOverlay = !_dropDown.IsOverlayShow();
+
             //Reset Picker to default in case the picker value was changed
             //but no value was selected (for example when a user clicks next
             //month but does not select any value)
@@ -168,11 +170,7 @@ namespace AntDesign
                 _duringManualInput = false;
                 var input = (index == 0 ? _inputStart : _inputEnd);
                 if (string.IsNullOrWhiteSpace(input.Value))
-                {
                     ClearValue(index, false);
-                    await Focus(index);
-                    return;
-                }
                 else if (!await TryApplyInputValue(index, input.Value))
                     return;
 
@@ -188,6 +186,7 @@ namespace AntDesign
                     else if (!e.ShiftKey)
                     {
                         Close();
+                        AutoFocus = false;
                     }
                 }
                 if (index == 0)
@@ -289,6 +288,9 @@ namespace AntDesign
 
         protected override Task OnBlur(int index)
         {
+            if (_openingOverlay)
+                return Task.CompletedTask;
+
             if (_duringManualInput)
             {
                 var array = Value as Array;
@@ -523,6 +525,12 @@ namespace AntDesign
             }
 
             return false;
+        }
+
+        private void OverlayVisibleChange(bool visible)
+        {
+            OnOpenChange.InvokeAsync(visible);
+            _openingOverlay = false;
         }
     }
 }

--- a/components/date-picker/RangePicker.razor.cs
+++ b/components/date-picker/RangePicker.razor.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using AntDesign.Core.Extensions;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.JSInterop;
@@ -165,7 +166,7 @@ namespace AntDesign
             if (e == null) throw new ArgumentNullException(nameof(e));
 
             var key = e.Key.ToUpperInvariant();
-            if (key == "ENTER" || key == "TAB")
+            if (key == "ENTER" || key == "TAB" || key == "ESCAPE")
             {
                 _duringManualInput = false;
                 var input = (index == 0 ? _inputStart : _inputEnd);
@@ -173,6 +174,13 @@ namespace AntDesign
                     ClearValue(index, false);
                 else if (!await TryApplyInputValue(index, input.Value))
                     return;
+
+                if (key == "ESCAPE" && _dropDown.IsOverlayShow())
+                {
+                    Close();
+                    await Js.FocusAsync(input.Ref);
+                    return;
+                }
 
                 if (index == 1)
                 {

--- a/components/date-picker/internal/DatePickerBase.cs
+++ b/components/date-picker/internal/DatePickerBase.cs
@@ -244,6 +244,7 @@ namespace AntDesign
         private bool _isLocaleSetOutside;
         private CultureInfo _cultureInfo = LocaleProvider.CurrentLocale.CurrentCulture;
         private DatePickerLocale _locale = LocaleProvider.CurrentLocale.DatePicker;
+        protected bool _openingOverlay;
 
         protected ClassMapper _panelClassMapper = new ClassMapper();
 

--- a/components/date-picker/internal/DatePickerBase.cs
+++ b/components/date-picker/internal/DatePickerBase.cs
@@ -597,7 +597,7 @@ namespace AntDesign
             if (string.IsNullOrEmpty(Format))
                 format = _pickerStatus[index]._initPicker switch
                 {
-                    DatePickerType.Week => $"{Locale.Lang.YearFormat}-{DateHelper.GetWeekOfYear(value)}{Locale.Lang.Week}",
+                    DatePickerType.Week => $"{Locale.Lang.YearFormat}-{DateHelper.GetWeekOfYear(value, Locale.FirstDayOfWeek)}{Locale.Lang.Week}",
                     DatePickerType.Quarter => $"{Locale.Lang.YearFormat}-{DateHelper.GetDayOfQuarter(value)}",
                     _ => InternalFormat,
                 };

--- a/components/date-picker/internal/DatePickerDatePanel.razor
+++ b/components/date-picker/internal/DatePickerDatePanel.razor
@@ -5,7 +5,7 @@
 @{
     var calendar = CultureInfo.Calendar;
 
-    DateTime monthFirstDayDate = new DateTime(PickerValue.Year, PickerValue.Month, 1, 0, 0, 0);
+    DateTime monthFirstDayDate = new DateTime(PickerValue.Year, PickerValue.Month, 1, 0, 0, 0);    
     int monthFirstDayOfWeek = (int)calendar.GetDayOfWeek(monthFirstDayDate);
 
     // sunday should be 7
@@ -15,7 +15,7 @@
     }
 
     int diffDay = (int) Locale.FirstDayOfWeek - monthFirstDayOfWeek;
-    DateTime startDate = monthFirstDayDate.AddDays(diffDay);
+    DateTime startDate = monthFirstDayDate.AddDays(diffDay);	
 }
 
 <div class='@($"{PrefixCls}-panel")' @ref="Ref">
@@ -53,14 +53,14 @@
                 }
             </tr>
         </RenderTableHeader>
-        <RenderFisrtCol>
+        <RenderFirstCol>
             @if (IsWeek)
-            {
+            {				
                 <td class="@(PrefixCls)-cell @(PrefixCls)-cell-weak">
-                    @DateHelper.GetWeekOfYear(context)
+                    @DateHelper.GetWeekOfYear(context, Locale.FirstDayOfWeek)
                 </td>
             }
-        </RenderFisrtCol>
+        </RenderFirstCol>
         <RenderColValue Context="currentColDate">
             @currentColDate.Day
         </RenderColValue>
@@ -96,7 +96,7 @@
 
     private string GetRowClass(DateTime viewDate)
     {
-        string selectedRowClass = IsWeek && DateHelper.IsSameWeak(viewDate, Value) ? $"{PrefixCls}-week-panel-row-selected" : "";
+        string selectedRowClass = IsWeek && DateHelper.IsSameWeak(viewDate, Value, Locale.FirstDayOfWeek) ? $"{PrefixCls}-week-panel-row-selected" : "";
         string rowClass = IsWeek ? $"{PrefixCls}-week-panel-row" : "";
 
         return $"{rowClass} {selectedRowClass}";

--- a/components/date-picker/internal/DatePickerDatetimePanel.razor
+++ b/components/date-picker/internal/DatePickerDatetimePanel.razor
@@ -63,13 +63,26 @@
         }
 
         DatePickerDisabledTime disabledTime = GetDisabledTime();
+		bool isValueNull = Value is null;
+		Func<int, int?, string> selected;
+		string localValue;
+		if (Value is null)
+		{
+			localValue = "";
+			selected = (_, _) => "";
+		}
+		else
+		{
+			localValue = Value.Value.ToString(timeFormat);
+			selected = (viewTime, valueTime) =>  viewTime == valueTime ? $"{PrefixCls}-time-panel-cell-selected" : "";
+		}		
     }
     <div class="@(PrefixCls)-time-panel">
         @if(Picker == DatePickerType.Date)
         {
             <div class="@(PrefixCls)-header">
                 <div class="@(PrefixCls)-header-view">
-                    @Value.ToString(timeFormat) <br />
+                    @localValue <br />
                 </div>
             </div>
         }
@@ -82,7 +95,7 @@
                     {
                         var viewTime = startTime;
                         bool disabled = disabledTime._disabledHours.Contains(hour);
-                        string isSelectedCls = viewTime.Hour == Value.Hour ? $"{PrefixCls}-time-panel-cell-selected" : "";
+                        string isSelectedCls = selected(viewTime.Hour, Value?.Hour);
                         string disabledCls = disabled ? $"{PrefixCls}-time-panel-cell-disabled" : "";
 
                         <li class="@(PrefixCls)-time-panel-cell @isSelectedCls @disabledCls">
@@ -103,7 +116,7 @@
                     {
                         var viewTime = startTime;
                         bool disabled = disabledTime._disabledMinutes.Contains(minute);
-                        string isSelectedCls = viewTime.Minute == Value.Minute ? $"{PrefixCls}-time-panel-cell-selected" : "";
+                        string isSelectedCls = selected(viewTime.Minute, Value?.Minute);
                         string disabledCls = disabled ? $"{PrefixCls}-time-panel-cell-disabled" : "";
 
                         <li class="@(PrefixCls)-time-panel-cell @isSelectedCls @disabledCls">
@@ -124,7 +137,7 @@
                     {
                         var viewTime = startTime;
                         bool disabled = disabledTime._disabledSeconds.Contains(second);
-                        string isSelectedCls = viewTime.Second == Value.Second ? $"{PrefixCls}-time-panel-cell-selected" : "";
+						string isSelectedCls = selected(viewTime.Second, Value?.Second);
                         string disabledCls = disabled ? $"{PrefixCls}-time-panel-cell-disabled" : "";
 
                         <li class="@(PrefixCls)-time-panel-cell @isSelectedCls @disabledCls">

--- a/components/date-picker/internal/DatePickerDatetimePanel.razor.cs
+++ b/components/date-picker/internal/DatePickerDatetimePanel.razor.cs
@@ -35,21 +35,23 @@ namespace AntDesign.Internal
             List<int> disabledHours = new List<int>();
             List<int> disabledMinutes = new List<int>();
             List<int> disabledSeconds = new List<int>();
-
-            if (DisabledHours != null)
+            DatePickerDisabledTime userDisabledTime = null;
+            if (Value is not null)
             {
-                disabledHours.AddRange(DisabledHours(Value));
+                if (DisabledHours is not null)
+                {
+                    disabledHours.AddRange(DisabledHours(Value.Value));
+                }
+                if (DisabledMinutes is not null)
+                {
+                    disabledMinutes.AddRange(DisabledMinutes(Value.Value));
+                }
+                if (DisabledSeconds is not null)
+                {
+                    disabledSeconds.AddRange(DisabledSeconds(Value.Value));
+                }
+                userDisabledTime = DisabledTime?.Invoke(Value ?? DateTime.Now);
             }
-            if (DisabledMinutes != null)
-            {
-                disabledMinutes.AddRange(DisabledMinutes(Value));
-            }
-            if (DisabledSeconds != null)
-            {
-                disabledSeconds.AddRange(DisabledSeconds(Value));
-            }
-
-            DatePickerDisabledTime userDisabledTime = DisabledTime?.Invoke(Value);
 
             if (userDisabledTime != null)
             {

--- a/components/date-picker/internal/DatePickerPanelBase.cs
+++ b/components/date-picker/internal/DatePickerPanelBase.cs
@@ -203,7 +203,7 @@ namespace AntDesign
 
         protected DateTime PickerValue { get => GetIndexPickerValue(PickerIndex); }
 
-        protected DateTime Value { get => GetIndexValue(PickerIndex) ?? DateTime.Now; }
+        protected DateTime? Value { get => GetIndexValue(PickerIndex); }
 
         public void PopUpPicker(string type)
         {

--- a/components/date-picker/internal/DatePickerTemplate.razor
+++ b/components/date-picker/internal/DatePickerTemplate.razor
@@ -14,9 +14,11 @@
                 @RenderTableHeader
             </thead>
             <tbody>
-                @{ 
+				@{					
                     var startDate = ViewStartDate;
                     bool shouldStopRender = false;
+					DateTime monthFirstDayDate = new DateTime(PickerValue.Year, PickerValue.Month, 1, 0, 0, 0);
+					bool firstWeekNotInMonth = ViewStartDate.AddDays(7).Equals(monthFirstDayDate);	
                 }
                 @for (int row = 1; row <= MaxRow; row++)
                 {
@@ -24,13 +26,13 @@
                     {
                         break;
                     }
-
                     var startColDate = startDate;
 
                     <tr class="@(GetRowClass?.Invoke(startColDate))"
-                        @onclick="e => OnRowSelect?.Invoke(startColDate)">
+                        @onclick="e => OnRowSelect?.Invoke(startColDate.CompareTo(monthFirstDayDate) < 0 && !firstWeekNotInMonth ? monthFirstDayDate: startColDate)">
+						
+						@RenderFirstCol?.Invoke(startColDate.CompareTo(monthFirstDayDate) < 0 && !firstWeekNotInMonth ? monthFirstDayDate: startColDate)
 
-                        @RenderFisrtCol?.Invoke(startColDate)
 
                         @for (int col = 1; col <= MaxCol; col++)
                         {

--- a/components/date-picker/internal/DatePickerTemplate.razor.cs
+++ b/components/date-picker/internal/DatePickerTemplate.razor.cs
@@ -17,7 +17,7 @@ namespace AntDesign.Internal
         public RenderFragment RenderTableHeader { get; set; }
 
         [Parameter]
-        public RenderFragment<DateTime> RenderFisrtCol { get; set; }
+        public RenderFragment<DateTime> RenderFirstCol { get; set; }
 
         [Parameter]
         public RenderFragment<DateTime> RenderColValue { get; set; }

--- a/components/date-picker/locale/DatePickerLocale.cs
+++ b/components/date-picker/locale/DatePickerLocale.cs
@@ -4,7 +4,7 @@ namespace AntDesign
 {
     public class DatePickerLocale
     {
-        public DayOfWeek FirstDayOfWeek { get; set; }
+        public DayOfWeek FirstDayOfWeek { get; set; } = DayOfWeek.Sunday;
 
         public DateLocale Lang { get; set; } = new DateLocale();
 
@@ -12,7 +12,7 @@ namespace AntDesign
     }
 
     public class DateLocale
-    {       
+    {
         public string Placeholder { get; set; } = "Select date";
         public string YearPlaceholder { get; set; } = "Select year";
         public string QuarterPlaceholder { get; set; } = "Select quarter";


### PR DESCRIPTION
### 🤔 This is a ...

- [x] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [x] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
1. Fixes #1431 
2. Addresses parts of #1429 ([this comment](https://github.com/ant-design-blazor/ant-design-blazor/issues/1429#issuecomment-828196477)):
   a. When first clicked, the RangePicker panel will first display on the left side of the page.
   b. The height of the RangePicker is refreshed twice when it is opened.
3. When panel was opening, `OnBlur` event is being fired.
4. When Tab+Shift on `RangePicker` was leaving the input, it is not loosing focus.
5. Initial render of `RangePicker` if rendered above the input is placed too low when panel renedered above input element:
![image](https://user-images.githubusercontent.com/6518006/116805406-10e22200-ab2f-11eb-8a7f-44f60910bfd6.png)
Closing and reopening the panel would fix that to expected behavior:
![image](https://user-images.githubusercontent.com/6518006/116805426-353dfe80-ab2f-11eb-943d-bd3a43c4c5f9.png)

### 💡 Background and solution
1. `DatePicker` in `OnBlur` event handler was calling `Close()` method and should not.
2. a. This was an issue with `Overlay` manifesting only in server-side. I guess it wasn't manifesting anywhere else except `RangePicker` because of how complex the `RangePicker` is. Anyway, the issue there was that the `RangePicker` was starting with style set to `display: inline-flex` and then its position was calculated and adjusted to match input element. I changed that initial style to `display: inline-flex; visibility: hidden;` - we still need this to render and take space but not to be visible. 
2. b. It wasn't really refreshing height 2 times. The problem was that when panel should hide, it receives class `ant-slide-up-leave-active`. That class stays there. So when it is shown again, it is made first visible with that class, and then it gets proper `ant-slide-up-enter-active`. So basically on any consecutive open the picker was first being animated with leave and then with enter css class. My solution is to reset the class to enter class after it is closed.
3. Removed `Close()` method call.
4. Missing `AutoFocus = false` was added.
5. `RangePicker` was supposed to get `OverlayClassName="ant-picker-dropdown-range`. Otherwise first render was placing the pointing arrow incorrectly. It was only affecting the panel if it was rendered above the input.

Feature: added support for `Escape` button - matches the behaviour of react antD.

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
