### PR TITLE
fix(module:select): support IEnumerable in form

### DIFF
--- a/components/core/Base/AntInputComponentBase.cs
+++ b/components/core/Base/AntInputComponentBase.cs
@@ -88,6 +88,9 @@ namespace AntDesign
         public Expression<Func<TValue>> ValueExpression { get; set; }
 
         [Parameter]
+        public Expression<Func<IEnumerable<TValue>>> ValuesExpression { get; set; }
+
+        [Parameter]
         public string Size { get; set; } = AntSizeLDSType.Default;
 
         /// <summary>
@@ -176,7 +179,7 @@ namespace AntDesign
         }
 
         private TValue _firstValue;
-        private bool _isNotifyFieldChanged = true;
+        protected bool _isNotifyFieldChanged = true;
 
         /// <summary>
         /// Constructs an instance of <see cref="InputBase{TValue}"/>.
@@ -263,13 +266,16 @@ namespace AntDesign
                     return base.SetParametersAsync(ParameterView.Empty);
                 }
 
-                if (ValueExpression == null)
+                if (ValueExpression == null && ValuesExpression == null)
                 {
                     return base.SetParametersAsync(ParameterView.Empty);
                 }
 
                 EditContext = Form?.EditContext;
-                FieldIdentifier = FieldIdentifier.Create(ValueExpression);
+                if (ValuesExpression == null)
+                    FieldIdentifier = FieldIdentifier.Create(ValueExpression);
+                else
+                    FieldIdentifier = FieldIdentifier.Create(ValuesExpression);
                 _nullableUnderlyingType = Nullable.GetUnderlyingType(typeof(TValue));
 
                 EditContext.OnValidationStateChanged += _validationStateChangedHandler;

--- a/components/form/FormItem.razor.cs
+++ b/components/form/FormItem.razor.cs
@@ -195,7 +195,7 @@ namespace AntDesign
         {
             if (control.FieldIdentifier.Model == null)
             {
-                throw new InvalidOperationException($"Please use @bind-Value in the control with generic type `{typeof(TValue)}`.");
+                throw new InvalidOperationException($"Please use @bind-Value (or @bind-Values for selected components) in the control with generic type `{typeof(TValue)}`.");
             }
 
             this._control = control;
@@ -216,7 +216,10 @@ namespace AntDesign
                 builder.CloseComponent();
             };
 
-            _propertyReflector = PropertyReflector.Create(control.ValueExpression);
+            if (control.ValueExpression is not null)
+                _propertyReflector = PropertyReflector.Create(control.ValueExpression);
+            else
+                _propertyReflector = PropertyReflector.Create(control.ValuesExpression);
 
             if (_propertyReflector.RequiredAttribute != null)
             {

--- a/components/locales/en-GB.json
+++ b/components/locales/en-GB.json
@@ -94,6 +94,7 @@
     },
     "timePickerLocale": { "placeholder": "Select time" }
   },
+  "global": { "placeholder": "Please select" },
   "Table": {
     "filterTitle": "Filter menu",
     "filterConfirm": "OK",

--- a/components/locales/pl-PL.json
+++ b/components/locales/pl-PL.json
@@ -108,6 +108,7 @@
       "placeholder": "Wybierz godzinę"
     }
   },
+  "global": { "placeholder": "Proszę wybrać" },
   "Table": {
     "filterTitle": "Menu filtra",
     "filterConfirm": "OK",

--- a/components/select/Select.razor.cs
+++ b/components/select/Select.razor.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Text.Json;
 using System.Threading.Tasks;
 using AntDesign.Internal;
@@ -326,6 +327,10 @@ namespace AntDesign
 
                     _ = OnValuesChangeAsync(default);
                 }
+                if (_isNotifyFieldChanged && (Form?.ValidateOnChange == true))
+                {
+                    EditContext?.NotifyFieldChanged(FieldIdentifier);
+                }
             }
         }
 
@@ -480,6 +485,7 @@ namespace AntDesign
         private Action<TItem, TItemValue> _setValue;
         private bool _disableSubmitFormOnEnter;
         private bool _showArrowIcon = true;
+        private Expression<Func<TItemValue>> _valueExpression;
 
         #endregion Properties
 

--- a/site/AntDesign.Docs/Demos/Components/Form/demo/Size.razor
+++ b/site/AntDesign.Docs/Demos/Components/Form/demo/Size.razor
@@ -46,13 +46,27 @@
     <FormItem Label="AutoComplete">
         <AutoComplete @bind-Value="@context.AutoComplete" Options="@autoCompleteOptions" Placeholder="Input here" />
     </FormItem>
+    <FormItem Label="Select">
+        <Select Mode="default"
+            DataSource="@_persons"            
+            @bind-Value="@context.Name"
+            LabelName="@nameof(Person.Name)"
+            ValueName="@nameof(Person.Name)">
+        </Select>
+    </FormItem>
+    <FormItem Label="Multiselect">
+        <Select Mode="multiple"
+            DataSource="@_persons"            
+            @bind-Values="@context.Names"
+            LabelName="@nameof(Person.Name)"
+            ValueName="@nameof(Person.Name)">
+        </Select>
+    </FormItem>
     <FormItem WrapperColOffset="8" WrapperColSpan="16">
         <Button HtmlType="submit">
             Submit
         </Button>
     </FormItem>
-
-
 </Form>
 
 @code
@@ -69,6 +83,8 @@
         public bool Switch { get; set; } = true;
         public string Radio { get; set; } = "Beijing";
         public string AutoComplete { get; set; }
+		public string Name { get; set; }
+		public IEnumerable<string> Names { get; set; } = Array.Empty<string>();
     }
 
     private Model model = new Model();
@@ -93,6 +109,15 @@
     };
 
     private List<string> autoCompleteOptions = new List<string> { "Primary", "Junior", "Senior", "Undergraduate", "Master", "Doctor" };
+
+	record Person(string Name);
+    private List<Person> _persons = new List<Person>
+        {
+            new Person("John"),
+            new Person("Lucy"),
+            new Person("Jack"),
+            new Person("Emily"),
+        };
 
     private void OnFinish(EditContext editContext)
     {

--- a/tests/AntDesign.Tests/Select/Form/Select.MultipleTests.razor
+++ b/tests/AntDesign.Tests/Select/Form/Select.MultipleTests.razor
@@ -1,0 +1,76 @@
+﻿@using System.ComponentModel.DataAnnotations
+@inherits AntDesignTestBase
+@code {
+	class Persons
+    {
+        [MinLength(1, ErrorMessage = "At least 1 is required")]
+        public IEnumerable<string> Name { get; set; } = Array.Empty<string>();
+    }
+    Persons _model = new();
+    IEnumerable<string> _datasource = new List<string>{ "Lucy", "John", "Jack", "Emily" };	
+
+#if NET6_0
+    [Fact]
+	public void Select_Validation_Shown() 
+    {
+        //Arrange
+        JSInterop.Setup<AntDesign.JsInterop.DomRect>(JSInteropConstants.GetBoundingClientRect, _ => true)
+            .SetResult(new AntDesign.JsInterop.DomRect());        
+
+		JSInterop.Setup<AntDesign.JsInterop.Window>(JSInteropConstants.GetWindow)
+			.SetResult(new AntDesign.JsInterop.Window());
+		var cut = Render<AntDesign.Form<Persons>>(
+			@<Form Model="@_model" ValidateOnChange="@true">       
+				<FormItem Label="Allowed Email Domains">
+						<Select TItem="string" TItemValue="string" Mode="multiple"
+								@bind-Values=@context.Name>
+							<SelectOptions>
+								@foreach (var item in _datasource)
+								{
+									<SelectOption TItem="string" TItemValue="string" Value="@item" Label="@item" />
+								}
+							</SelectOptions>
+						</Select>
+				</FormItem>
+			</Form>
+		);
+        //Act
+		cut.InvokeAsync(() =>  cut.Instance.Validate());
+		var validationError = cut.Find("div.ant-form-item-explain-error");
+		//Assert		
+		validationError.Text().Should().Be("At least 1 is required");
+	}
+
+    [Fact]
+	public void Select_Validation_Not_Shown() 
+    {
+        //Arrange
+        JSInterop.Setup<AntDesign.JsInterop.DomRect>(JSInteropConstants.GetBoundingClientRect, _ => true)
+            .SetResult(new AntDesign.JsInterop.DomRect());        
+
+		JSInterop.Setup<AntDesign.JsInterop.Window>(JSInteropConstants.GetWindow)
+			.SetResult(new AntDesign.JsInterop.Window());
+		_model.Name = new List<string> { "Lucy", "John" };
+		var cut = Render<AntDesign.Form<Persons>>(
+			@<Form Model="@_model" ValidateOnChange="@true">       
+				<FormItem Label="Allowed Email Domains">
+						<Select TItem="string" TItemValue="string" Mode="multiple"
+								@bind-Values=@context.Name>
+							<SelectOptions>
+								@foreach (var item in _datasource)
+								{
+									<SelectOption TItem="string" TItemValue="string" Value="@item" Label="@item" />
+								}
+							</SelectOptions>
+						</Select>
+				</FormItem>
+			</Form>
+		);
+        //Act
+		cut.InvokeAsync(() =>  cut.Instance.Validate());
+		//Assert		
+		cut.Invoking(c => cut.Find("div.ant-form-item-explain-error"))
+			.Should().Throw<ElementNotFoundException>();
+	}
+#endif
+}


### PR DESCRIPTION
### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [x] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
Fixes #1453 
Fixes #1428 
Fixes #1120

### 💡 Background and solution
My solution added new `ValuesExpression` to the `AntInputComponentBase` that is expecting `IEnumerable<>`. By default then it tries to use `ValueExpression` and if null, then falls back to `ValuesExpression`. Similar changes were made to `FormItem`. After that there were minor changes in `Select` to handle validation. 
Solution also adds tests but they will be useful only once net6 is released and AntBlazor adapts it. This is due to a known limitation of templating templates and calling context inside the template. [Bunit source (check the bottom of the section)](https://bunit.dev/docs/providing-input/passing-parameters-to-components.html#passing-html-based-templates). In my dev I already moved AntBlazor to net6-preview3 and these tests are working. These tests do not build in net5. 

Locale fix - ugly patch, the demo site was crashing in my default locale because `Cascader` needs in locale Global.Placeholder a value. In my case I was getting null. I guess we need to have this json fallback that @Zonciu found.
### 📝 Changelog


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Select mutliple/tags can be used in forms.   |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
