### PR TITLE
fix(module:inputnumber): allow culture info to format input

### DIFF
--- a/components/core/Base/AntInputComponentBase.cs
+++ b/components/core/Base/AntInputComponentBase.cs
@@ -93,6 +93,9 @@ namespace AntDesign
         [Parameter]
         public string Size { get; set; } = AntSizeLDSType.Default;
 
+        [Parameter]
+        public CultureInfo CultureInfo { get; set; } = CultureInfo.CurrentCulture;
+
         /// <summary>
         /// Gets the associated <see cref="EditContext"/>.
         /// </summary>
@@ -215,7 +218,7 @@ namespace AntDesign
             }
 
             var success = BindConverter.TryConvertTo<TValue>(
-               value, CultureInfo.CurrentCulture, out var parsedValue);
+               value, CultureInfo, out var parsedValue);
 
             if (success)
             {

--- a/components/input-number/InputNumberMath.cs
+++ b/components/input-number/InputNumberMath.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text;
 
 namespace AntDesign
@@ -86,114 +87,114 @@ namespace AntDesign
         #endregion
 
         #region Parse
-        public static sbyte Parse(string input, sbyte defaultValue)
+        public static sbyte Parse(string input, sbyte defaultValue, CultureInfo culture)
         {
-            return sbyte.TryParse(input, out var number) ? number : defaultValue;
+            return sbyte.TryParse(input, NumberStyles.Any, culture, out var number) ? number : defaultValue;
         }
 
-        public static sbyte? Parse(string input, sbyte? defaultValue)
+        public static sbyte? Parse(string input, sbyte? defaultValue, CultureInfo culture)
         {
-            return sbyte.TryParse(input, out var number) ? number : defaultValue;
+            return sbyte.TryParse(input, NumberStyles.Any, culture, out var number) ? number : defaultValue;
         }
 
-        public static byte Parse(string input, byte defaultValue)
+        public static byte Parse(string input, byte defaultValue, CultureInfo culture)
         {
-            return byte.TryParse(input, out var number) ? number : defaultValue;
+            return byte.TryParse(input, NumberStyles.Any, culture, out var number) ? number : defaultValue;
         }
 
-        public static byte? Parse(string input, byte? defaultValue)
+        public static byte? Parse(string input, byte? defaultValue, CultureInfo culture)
         {
-            return byte.TryParse(input, out var number) ? number : defaultValue;
+            return byte.TryParse(input, NumberStyles.Any, culture, out var number) ? number : defaultValue;
         }
 
-        public static short Parse(string input, short defaultValue)
+        public static short Parse(string input, short defaultValue, CultureInfo culture)
         {
-            return short.TryParse(input, out var number) ? number : defaultValue;
+            return short.TryParse(input, NumberStyles.Any, culture, out var number) ? number : defaultValue;
         }
 
-        public static short? Parse(string input, short? defaultValue)
+        public static short? Parse(string input, short? defaultValue, CultureInfo culture)
         {
-            return short.TryParse(input, out var number) ? number : defaultValue;
+            return short.TryParse(input, NumberStyles.Any, culture, out var number) ? number : defaultValue;
         }
 
-        public static ushort Parse(string input, ushort defaultValue)
+        public static ushort Parse(string input, ushort defaultValue, CultureInfo culture)
         {
-            return ushort.TryParse(input, out var number) ? number : defaultValue;
+            return ushort.TryParse(input, NumberStyles.Any, culture, out var number) ? number : defaultValue;
         }
 
-        public static ushort? Parse(string input, ushort? defaultValue)
+        public static ushort? Parse(string input, ushort? defaultValue, CultureInfo culture)
         {
-            return ushort.TryParse(input, out var number) ? number : defaultValue;
+            return ushort.TryParse(input, NumberStyles.Any, culture, out var number) ? number : defaultValue;
         }
 
-        public static int Parse(string input, int defaultValue)
+        public static int Parse(string input, int defaultValue, CultureInfo culture)
         {
-            return int.TryParse(input, out var number) ? number : defaultValue;
+            return int.TryParse(input, NumberStyles.Any, culture, out var number) ? number : defaultValue;
         }
 
-        public static int? Parse(string input, int? defaultValue)
+        public static int? Parse(string input, int? defaultValue, CultureInfo culture)
         {
-            return int.TryParse(input, out var number) ? number : defaultValue;
+            return int.TryParse(input, NumberStyles.Any, culture, out var number) ? number : defaultValue;
         }
 
-        public static uint Parse(string input, uint defaultValue)
+        public static uint Parse(string input, uint defaultValue, CultureInfo culture)
         {
-            return uint.TryParse(input, out var number) ? number : defaultValue;
+            return uint.TryParse(input, NumberStyles.Any, culture, out var number) ? number : defaultValue;
         }
 
-        public static uint? Parse(string input, uint? defaultValue)
+        public static uint? Parse(string input, uint? defaultValue, CultureInfo culture)
         {
-            return uint.TryParse(input, out var number) ? number : defaultValue;
+            return uint.TryParse(input, NumberStyles.Any, culture, out var number) ? number : defaultValue;
         }
 
-        public static long Parse(string input, long defaultValue)
+        public static long Parse(string input, long defaultValue, CultureInfo culture)
         {
-            return long.TryParse(input, out var number) ? number : defaultValue;
+            return long.TryParse(input, NumberStyles.Any, culture, out var number) ? number : defaultValue;
         }
 
-        public static long? Parse(string input, long? defaultValue)
+        public static long? Parse(string input, long? defaultValue, CultureInfo culture)
         {
-            return long.TryParse(input, out var number) ? number : defaultValue;
+            return long.TryParse(input, NumberStyles.Any, culture, out var number) ? number : defaultValue;
         }
 
-        public static ulong Parse(string input, ulong defaultValue)
+        public static ulong Parse(string input, ulong defaultValue, CultureInfo culture)
         {
-            return ulong.TryParse(input, out var number) ? number : defaultValue;
+            return ulong.TryParse(input, NumberStyles.Any, culture, out var number) ? number : defaultValue;
         }
 
-        public static ulong? Parse(string input, ulong? defaultValue)
+        public static ulong? Parse(string input, ulong? defaultValue, CultureInfo culture)
         {
-            return ulong.TryParse(input, out var number) ? number : defaultValue;
+            return ulong.TryParse(input, NumberStyles.Any, culture, out var number) ? number : defaultValue;
         }
 
-        public static float Parse(string input, float defaultValue)
+        public static float Parse(string input, float defaultValue, CultureInfo culture)
         {
-            return float.TryParse(input, out var number) ? number : defaultValue;
+            return float.TryParse(input, NumberStyles.Any, culture, out var number) ? number : defaultValue;
         }
 
-        public static float? Parse(string input, float? defaultValue)
+        public static float? Parse(string input, float? defaultValue, CultureInfo culture)
         {
-            return float.TryParse(input, out var number) ? number : defaultValue;
+            return float.TryParse(input, NumberStyles.Any, culture, out var number) ? number : defaultValue;
         }
 
-        public static double Parse(string input, double defaultValue)
+        public static double Parse(string input, double defaultValue, CultureInfo culture)
         {
-            return double.TryParse(input, out var number) ? number : defaultValue;
+            return double.TryParse(input, NumberStyles.Any, culture, out var number) ? number : defaultValue;
         }
 
-        public static double? Parse(string input, double? defaultValue)
+        public static double? Parse(string input, double? defaultValue, CultureInfo culture)
         {
-            return double.TryParse(input, out var number) ? number : defaultValue;
+            return double.TryParse(input, NumberStyles.Any, culture, out var number) ? number : defaultValue;
         }
 
-        public static decimal Parse(string input, decimal defaultValue)
+        public static decimal Parse(string input, decimal defaultValue, CultureInfo culture)
         {
-            return decimal.TryParse(input, out var number) ? number : defaultValue;
+            return decimal.TryParse(input, NumberStyles.Any, culture, out var number) ? number : defaultValue;
         }
 
-        public static decimal? Parse(string input, decimal? defaultValue)
+        public static decimal? Parse(string input, decimal? defaultValue, CultureInfo culture)
         {
-            return decimal.TryParse(input, out var number) ? number : defaultValue;
+            return decimal.TryParse(input, NumberStyles.Any, culture, out var number) ? number : defaultValue;
         }
     }
     #endregion

--- a/site/AntDesign.Docs/Demos/Components/Input/doc/index.en-US.md
+++ b/site/AntDesign.Docs/Demos/Components/Input/doc/index.en-US.md
@@ -22,6 +22,7 @@ A basic widget for getting the user input is a text field. Keyboard and mouse ca
 | AddOnBefore | The label text displayed before (on the left side of) the input field.                             | RenderFragment        | -         |
 | AddOnAfter            | The label text displayed after (on the right side of) the input field.           | RenderFragment         |
 | ChildContent            | Child content           | RenderFragment         |-       |
+| CultureInfo          | What Culture will be used when converting string to value and value to string           | CultureInfo         | CultureInfo.CurrentCulture       |
 | Size |The size of the input box. Note: in the context of a form, the `large` size is used. Available: `large` `default` `small`       | string        | -         |
 | Placeholder              | Provide prompt information that describes the expected value of the input field        | string        | -        |
 | DefaultValue |  	The initial input content                              | string        | -         |

--- a/site/AntDesign.Docs/Demos/Components/Input/doc/index.zh-CN.md
+++ b/site/AntDesign.Docs/Demos/Components/Input/doc/index.zh-CN.md
@@ -21,6 +21,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/xS9YEJhfe/Input.svg
 | AddOnBefore | 带标签的 input，设置前置标签                               | RenderFragment        | -         |
 | AddOnAfter            | 带标签的 input，设置后置标签           | RenderFragment         |
 | ChildContent            |子组件           | RenderFragment         |-       |
+| CultureInfo          | What Culture will be used when converting string to value and value to string           | CultureInfo         | CultureInfo.CurrentCulture       |
 | Size |抽屉元素之间的子组件  `default`, `large`, `small`        | string        | -         |
 | Placeholder              |提供可描述输入字段预期值的提示信息        | string        | -        |
 | DefaultValue |输入框默认内容                              | string        | -         |

--- a/site/AntDesign.Docs/Demos/Components/InputNumber/demo/Culture.md
+++ b/site/AntDesign.Docs/Demos/Components/InputNumber/demo/Culture.md
@@ -1,0 +1,13 @@
+﻿---
+order: 7
+title:
+  zh-CN: Culture
+  en-US: Culture
+---
+
+## zh-CN
+CultureInfo can be set to ensure proper parsing of strings depending on set locale. Especially useful in ServerSide deployments.
+
+
+## en-US
+CultureInfo can be set to ensure proper parsing of strings depending on set locale. Especially useful in ServerSide deployments.

--- a/site/AntDesign.Docs/Demos/Components/InputNumber/demo/Culture.md
+++ b/site/AntDesign.Docs/Demos/Components/InputNumber/demo/Culture.md
@@ -1,13 +1,14 @@
 ﻿---
 order: 7
 title:
-  zh-CN: Culture
+  zh-CN: 本地化
   en-US: Culture
 ---
 
 ## zh-CN
-CultureInfo can be set to ensure proper parsing of strings depending on set locale. Especially useful in ServerSide deployments.
 
+可以设置 CultureInfo 以确保能正确解析字符串。在 Server Side 部署中特别有用。
 
 ## en-US
+
 CultureInfo can be set to ensure proper parsing of strings depending on set locale. Especially useful in ServerSide deployments.

--- a/site/AntDesign.Docs/Demos/Components/InputNumber/demo/Culture.razor
+++ b/site/AntDesign.Docs/Demos/Components/InputNumber/demo/Culture.razor
@@ -1,0 +1,19 @@
+﻿@using System.Globalization
+<div>    
+    <AntDesign.InputNumber ValueChanged="(double val)=>OnClickChange(val, 0)"></AntDesign.InputNumber>
+    CurrentCulture: "@CultureInfo.CurrentCulture.Name" Input-Number = @myValue[0]
+</div>
+<div style="margin: 20px 0px 20px 0px;">    
+    <AntDesign.InputNumber CultureInfo="@CI" ValueChanged="(double val)=>OnClickChange(val, 1)"></AntDesign.InputNumber>
+    CultureInfo: "@CI.Name": Input-Number = @myValue[1]
+</div>
+
+@code {
+    private double[] myValue { get; set; } = new double[2];
+    private CultureInfo CI = CultureInfo.GetCultureInfo("de-DE");
+    private void OnClickChange(double val, int i)
+    {
+        Console.WriteLine(val);
+        myValue[i] = val;
+    }
+}

--- a/site/AntDesign.Docs/Demos/Components/InputNumber/doc/index.en-US.md
+++ b/site/AntDesign.Docs/Demos/Components/InputNumber/doc/index.en-US.md
@@ -23,6 +23,7 @@ Nullable types of the above types are also supported. For example, `ushort?`, `i
 | Property | Description | Type | Default Value |
 | --- | --- | --- | --- |
 | AutoFocus |get focus when component mounted                              | boolean        | -         |
+| CultureInfo          | What Culture will be used when converting string to value and value to string           | CultureInfo         | CultureInfo.CurrentCulture       |
 | DefaultValue            |initial value           | number         |
 | Disabled            | disable the input          | boolean         |-       |
 | Formatter |Specifies the format of the value presented      | function(double,string)        | -         |

--- a/site/AntDesign.Docs/Demos/Components/InputNumber/doc/index.zh-CN.md
+++ b/site/AntDesign.Docs/Demos/Components/InputNumber/doc/index.zh-CN.md
@@ -23,6 +23,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/XOS8qZ0kU/InputNumber.svg
 | 参数             | 说明                                         | 类型          | 默认值    |
 | ---------------- | -------------------------------------------- | ------------- | --------- |
 | AutoFocus | 自动获取焦点                              | boolean        | -         |
+| CultureInfo          | What Culture will be used when converting string to value and value to string           | CultureInfo         | CultureInfo.CurrentCulture       |
 | DefaultValue            | 初始值           | number         |
 | Disabled            |禁用           | boolean         |-       |
 | Formatter |指定输入框展示值的格式      | function(double,string)        | -         |

--- a/site/AntDesign.Docs/Demos/Components/InputNumber/doc/index.zh-CN.md
+++ b/site/AntDesign.Docs/Demos/Components/InputNumber/doc/index.zh-CN.md
@@ -23,7 +23,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/XOS8qZ0kU/InputNumber.svg
 | 参数             | 说明                                         | 类型          | 默认值    |
 | ---------------- | -------------------------------------------- | ------------- | --------- |
 | AutoFocus | 自动获取焦点                              | boolean        | -         |
-| CultureInfo          | What Culture will be used when converting string to value and value to string           | CultureInfo         | CultureInfo.CurrentCulture       |
+| CultureInfo  | 设置数值与字符串互相转换时使用的语言     | CultureInfo         | CultureInfo.CurrentCulture       |
 | DefaultValue            | 初始值           | number         |
 | Disabled            |禁用           | boolean         |-       |
 | Formatter |指定输入框展示值的格式      | function(double,string)        | -         |


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [x] Site / documentation update
- [x] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
Fixes #1477 
### 💡 Background and solution
I added `CultureInfo` to base class `AntInputComponentBase`. I decided to do that in base class, because of the method `TryParseValueFromString` that is using current culture for conversion, when probably it should use passed culture. This is mostly important for server-side deployments, when browser culture not always is used and this way consumer can force browser settings.
Generally to me it seems that this component is a bit overengineered. I think it may be possible to make it a bit simpler while getting the same functionality without sacrificing performance. Also, I think this component should move from `double` to `decimal`, this way we will avoid rounding issues, especially there are a lot of rounding issues already:

![inputNumber_roundingIssues](https://user-images.githubusercontent.com/6518006/117366065-e692ba80-aec8-11eb-9f37-ee8c89883683.gif)

Another issue is `Parser` attribute. The docs state this is `Func<string, double>` but code says it is `Func<string, string>`. Anyway, `Parser` is basically useless now. It should probably work together with `Formatter` or maybe `Formatter` should take precedence over `Parser` - this requires discussion. 

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Added `CultureInfo` attribute to `Input` type components        |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
