### PR TITLE
fix: exception is thrown when the DataIndex ends with the get_Item method

### DIFF
--- a/components/table/Internal/ColumnExpressionHelper.cs
+++ b/components/table/Internal/ColumnExpressionHelper.cs
@@ -13,18 +13,31 @@ namespace AntDesign.Internal
         internal static MemberInfo GetReturnMemberInfo(LambdaExpression expression)
         {
             var accessorBody = expression.Body;
-
-            if (accessorBody is ConditionalExpression conditionalExpression)
+            while (true)
             {
-                accessorBody = conditionalExpression.IfTrue;
+                if (accessorBody is UnaryExpression unaryExpression)
+                {
+                    accessorBody = unaryExpression.Operand;
+                }
+                else if (accessorBody is ConditionalExpression conditionalExpression)
+                {
+                    accessorBody = conditionalExpression.IfTrue;
+                }
+                else if (accessorBody is MethodCallExpression methodCallExpression)
+                {
+                    accessorBody = methodCallExpression.Object;
+                }
+                else if (accessorBody is BinaryExpression binaryExpression)
+                {
+                    accessorBody = binaryExpression.Left;
+                }
+                else
+                {
+                    break;
+                }
             }
 
-            if (accessorBody is UnaryExpression unaryExpression && unaryExpression.NodeType == ExpressionType.Convert)
-            {
-                accessorBody = unaryExpression.Operand;
-            }
-
-            if (!(accessorBody is MemberExpression memberExpression))
+            if (accessorBody is not MemberExpression memberExpression)
             {
                 throw new ArgumentException($"The type of the provided expression {accessorBody.GetType().Name} is not supported, it should be {nameof(MemberExpression)}.");
             }

--- a/tests/AntDesign.Tests/table/ColumnExpressionHelperTest.cs
+++ b/tests/AntDesign.Tests/table/ColumnExpressionHelperTest.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using AntDesign.core.Helpers;
+using AntDesign.Internal;
+using Xunit;
+
+namespace AntDesign.Tests.Table
+{
+    public class ColumnExpressionHelperTest
+    {
+        [Fact]
+        public void EndsWithGetItem()
+        {
+            var t1 = new T1()
+            {
+                T2 = new()
+                {
+                    Arr = new()
+                    {
+                        5,
+                        6,
+                        7
+                    }
+                }
+            };
+
+            var exp = typeof(T1).BuildAccessPropertyLambdaExpression("T2.Arr[2]");
+
+            var memberInfo = ColumnExpressionHelper.GetReturnMemberInfo(exp);
+            Assert.Equal(nameof(T2.Arr), memberInfo.Name);
+        }
+
+        public class T1
+        {
+            public T2 T2 { get; set; }
+        }
+
+        public class T2
+        {
+            public List<int> Arr { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

Fix #1470 

### 💡 Background and solution

Iterate backwards through the expression tree until we find the `MemberExpression`.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix exception is thrown when the DataIndex ends with the get_Item method |
| 🇨🇳 Chinese | 修复DataIndex以get_Item方法结束时会抛异常的问题 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
