### PR TITLE
fix(module: table): set DisplayName to null if MemberExpression is not found in the DataIndex expression tree

### DIFF
--- a/components/table/Column.razor.cs
+++ b/components/table/Column.razor.cs
@@ -100,7 +100,7 @@ namespace AntDesign
 
         private Type _columnDataType;
 
-        public string DisplayName { get; private set; }
+        public string? DisplayName { get; private set; }
 
         public string FieldName { get; private set; }
 
@@ -143,9 +143,13 @@ namespace AntDesign
             {
                 if (FieldExpression != null)
                 {
+                    if (FieldExpression.Body is not MemberExpression memberExp)
+                    {
+                        throw new ArgumentException("'Field' parameter must be child member");
+                    }
+
                     var paramExp = Expression.Parameter(ItemType);
-                    var member = ColumnExpressionHelper.GetReturnMemberInfo(FieldExpression);
-                    var bodyExp = Expression.MakeMemberAccess(paramExp, member);
+                    var bodyExp = Expression.MakeMemberAccess(paramExp, memberExp.Member);
                     GetFieldExpression = Expression.Lambda(bodyExp, paramExp);
                 }
                 else if (DataIndex != null)
@@ -156,8 +160,10 @@ namespace AntDesign
                 if (GetFieldExpression != null)
                 {
                     var member = ColumnExpressionHelper.GetReturnMemberInfo(GetFieldExpression);
-                    DisplayName = member.GetCustomAttribute<DisplayNameAttribute>(true)?.DisplayName ?? member.GetCustomAttribute<DisplayAttribute>(true)?.GetName() ?? member.Name;
-                    FieldName = DataIndex ?? member.Name;
+                    DisplayName = member?.GetCustomAttribute<DisplayNameAttribute>(true)?.DisplayName
+                               ?? member?.GetCustomAttribute<DisplayAttribute>(true)?.GetName()
+                               ?? member?.Name;
+                    FieldName = DataIndex ?? member?.Name;
                 }
 
                 if (Sortable && GetFieldExpression != null)

--- a/components/table/Internal/ColumnExpressionHelper.cs
+++ b/components/table/Internal/ColumnExpressionHelper.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Linq.Expressions;
 using System.Reflection;
 
@@ -10,7 +9,7 @@ namespace AntDesign.Internal
 {
     internal static class ColumnExpressionHelper
     {
-        internal static MemberInfo GetReturnMemberInfo(LambdaExpression expression)
+        internal static MemberInfo? GetReturnMemberInfo(LambdaExpression expression)
         {
             var accessorBody = expression.Body;
             while (true)
@@ -39,7 +38,7 @@ namespace AntDesign.Internal
 
             if (accessorBody is not MemberExpression memberExpression)
             {
-                throw new ArgumentException($"The type of the provided expression {accessorBody.GetType().Name} is not supported, it should be {nameof(MemberExpression)}.");
+                return null;
             }
 
             return memberExpression.Member;

--- a/tests/AntDesign.Tests/table/ColumnExpressionHelperTest.cs
+++ b/tests/AntDesign.Tests/table/ColumnExpressionHelperTest.cs
@@ -33,6 +33,14 @@ namespace AntDesign.Tests.Table
             Assert.Equal(nameof(T2.Arr), memberInfo.Name);
         }
 
+        [Fact]
+        public void NoMember()
+        {
+            var exp = typeof(List<Dictionary<string, string>>).BuildAccessPropertyLambdaExpression("[1][\"K2\"]");
+            var memberInfo = ColumnExpressionHelper.GetReturnMemberInfo(exp);
+            Assert.Null(memberInfo);
+        }
+
         public class T1
         {
             public T2 T2 { get; set; }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 💡 Background and solution

If there is only get_Item call of List or Dictionary in DataIndex expression tree, there is no MemberExpression, which causes an exception. 

Now I change it to set DisplayName to null when MemberExpression is not found.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | set DisplayName to null if MemberExpression is not found in the DataIndex expression tree |
| 🇨🇳 Chinese | 表达式树中找不到MemberExpression时, DisplayName置为null |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
