### PR TITLE
Form edit context dynamic change

### DIFF
--- a/components/core/Base/AntInputComponentBase.cs
+++ b/components/core/Base/AntInputComponentBase.cs
@@ -274,11 +274,11 @@ namespace AntDesign
             {
                 // Not the first run
 
-                // We don't support changing EditContext because it's messy to be clearing up state and event
-                // handlers for the previous one, and there's no strong use case. If a strong use case
-                // emerges, we can consider changing this.
-                throw new InvalidOperationException($"{GetType()} does not support changing the " +
-                    $"{nameof(EditContext)} dynamically.");
+                //Be careful when changing this. New EditContext carried from Form should
+                //already have all events transferred from original EditContext. The
+                //transfer is done in Form.BuildEditContext() method. State is lost
+                //though.
+                EditContext = Form?.EditContext;
             }
 
             // For derived components, retain the usual lifecycle with OnInit/OnParametersSet/etc.

--- a/tests/AntDesign.TestKit/AntDesign.TestKit.csproj
+++ b/tests/AntDesign.TestKit/AntDesign.TestKit.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="bunit.web" Version="1.0.0-preview-01" />
-    <PackageReference Include="bunit.xunit" Version="1.0.0-preview-01" />
+    <PackageReference Include="bunit.web" Version="1.1.5" />
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="Moq" Version="4.15.1" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/tests/AntDesign.TestKit/AntDesignTestBase.cs
+++ b/tests/AntDesign.TestKit/AntDesignTestBase.cs
@@ -3,25 +3,20 @@ using System.Globalization;
 using Bunit;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
-using Newtonsoft.Json;
 
 namespace AntDesign.Tests
 {
-    public class AntDesignTestBase : IDisposable
+    public class AntDesignTestBase : TestContext, IDisposable
     {
-        public TestContext Context { get; }
-        public TestNavigationManager NavigationManager { get; }
+        public TestContext Context => this;
+        public NavigationManager NavigationManager => Services.GetRequiredService<NavigationManager>();
 
         public AntDesignTestBase()
-        {
-            Context = new TestContext();
-            NavigationManager = new TestNavigationManager();
-
-            Context.Services.AddScoped<NavigationManager>(sp => NavigationManager);
-            Context.Services.AddAntDesign();
+        {            
+            Services.AddAntDesign();
 
             //Needed for Tests using Overlay
-            Context.Services.AddScoped<AntDesign.JsInterop.DomEventService>(sp => new TestDomEventService(Context.JSInterop.JSRuntime));
+            Services.AddScoped<AntDesign.JsInterop.DomEventService>(sp => new TestDomEventService(Context.JSInterop.JSRuntime));
 
             CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.GetCultureInfo("en-US");
         }

--- a/tests/AntDesign.TestKit/TestNavigationManager.cs
+++ b/tests/AntDesign.TestKit/TestNavigationManager.cs
@@ -1,7 +1,9 @@
-﻿using Microsoft.AspNetCore.Components;
+﻿using System;
+using Microsoft.AspNetCore.Components;
 
 namespace AntDesign.Tests
 {
+    [Obsolete("Use built in NavigationManager")]
     public class TestNavigationManager : NavigationManager
     {
         public delegate void NavigatedCallback(string uri, bool forceLoad);

--- a/tests/AntDesign.Tests/AntDesign.Tests.csproj
+++ b/tests/AntDesign.Tests/AntDesign.Tests.csproj
@@ -6,8 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="bunit.web" Version="1.0.0-preview-01" />
-    <PackageReference Include="bunit.xunit" Version="1.0.0-preview-01" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="Moq" Version="4.15.1" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/tests/AntDesign.Tests/Form/EditContext/Form.EditContext.BuildTests.razor
+++ b/tests/AntDesign.Tests/Form/EditContext/Form.EditContext.BuildTests.razor
@@ -1,0 +1,71 @@
+﻿@inherits AntDesignTestBase
+@code {
+
+	class Model
+	{
+		public string Name { get; set; }
+	}
+	Model _model = new();
+	AntDesign.Form<Model> _form;
+
+#if NET6_0
+	[Fact]
+	public void Form_EditContext_fires_OnFieldChange()
+	{
+		//Arrange
+		JSInterop.Setup<AntDesign.JsInterop.Window>(JSInteropConstants.GetWindow)
+			.SetResult(new AntDesign.JsInterop.Window());
+
+		bool handlerExecuted = false;
+		Action<FieldChangedEventArgs> onFieldChanged = (e) => handlerExecuted = true;
+		var cut = Render<AntDesign.Form<Model>>(
+			@<AntDesign.Form @ref="@_form" Model="@_model"
+				OnFieldChanged="onFieldChanged"
+				ValidateOnChange="@true">
+				<AntDesign.FormItem Label="Name">
+					<AntDesign.Input @bind-Value=@context.Name DebounceMilliseconds="0"/>
+				</AntDesign.FormItem>    
+			</AntDesign.Form>
+			);		
+		var input = cut.FindComponent<AntDesign.Input<string>>();
+		//Act
+		input.Find("input").Input("newValue");
+		input.Find("input").KeyUp(String.Empty);
+		//Assert				
+		handlerExecuted.Should().BeTrue();
+	}
+#endif
+
+#if NET6_0
+	[Fact]
+	public void Form_EditContext_Build_keep_OnFieldChange_subscription()
+	{
+		//Arrange
+		JSInterop.Setup<AntDesign.JsInterop.Window>(JSInteropConstants.GetWindow)
+			.SetResult(new AntDesign.JsInterop.Window());
+
+		bool handlerExecuted = false;
+		Action<FieldChangedEventArgs> onFieldChanged = (e) => handlerExecuted = true;
+		var cut = Render<AntDesign.Form<Model>>(
+			@<AntDesign.Form @ref="@_form" Model="@_model"
+				OnFieldChanged="onFieldChanged"
+				ValidateOnChange="@true">
+				<AntDesign.FormItem Label="Name">
+					<AntDesign.Input @bind-Value=@context.Name DebounceMilliseconds="0"/>
+				</AntDesign.FormItem>    
+			</AntDesign.Form>
+		);				
+		//Act
+		cut.Find("input").Input("newValue");
+		cut.Find("input").KeyUp(String.Empty);
+		_model = new();
+		handlerExecuted = false;
+		cut.SetParametersAndRender(parameters => parameters.Add(p => p.Model, _model));
+		var input = cut.FindComponent<AntDesign.Input<string>>();
+		input.Find("input").Input("newValue");
+		input.Find("input").KeyUp(String.Empty);
+		//Assert				
+		handlerExecuted.Should().BeTrue();
+	}
+#endif
+}

--- a/tests/AntDesign.Tests/Form/Model/ModelTests.razor
+++ b/tests/AntDesign.Tests/Form/Model/ModelTests.razor
@@ -1,0 +1,33 @@
+﻿@inherits AntDesignTestBase
+@code {
+
+	class Model
+	{
+		public string Name { get; set; }
+	}
+	Model _model = new();
+	AntDesign.Form<Model> _form;
+
+#if NET6_0
+	[Fact]
+	public void Form_Model_is_updated()
+	{
+		//Arrange
+		JSInterop.Setup<AntDesign.JsInterop.Window>(JSInteropConstants.GetWindow)
+			.SetResult(new AntDesign.JsInterop.Window());
+		
+		var cut = Render<AntDesign.Form<Model>>(
+			@<AntDesign.Form @ref="@_form" Model="@_model">
+				<AntDesign.FormItem Label="Name">
+					<AntDesign.Input @bind-Value=@context.Name DebounceMilliseconds="0"/>
+				</AntDesign.FormItem>    
+			</AntDesign.Form>
+		);				
+		//Act
+		cut.Find("input").Input("newValue");
+		cut.Find("input").KeyUp(String.Empty);		
+		//Assert				
+		_model.Name.Should().Be("newValue");
+	}
+#endif
+}

--- a/tests/AntDesign.Tests/Input/InputTests.razor
+++ b/tests/AntDesign.Tests/Input/InputTests.razor
@@ -1,0 +1,19 @@
+﻿@inherits AntDesignTestBase
+@code {
+
+	[Fact]
+	public async Task Input_Debounce_sets_value()
+	{
+		//Arrange	
+		string value = null;
+		int debounce = 50;
+		var cut = Render<AntDesign.Input<string>>(@<AntDesign.Input @bind-Value=@value DebounceMilliseconds="@debounce"/>);
+		//Act
+		cut.Find("input").Input("newValue");
+		cut.Find("input").KeyUp(String.Empty);
+		//Assert		
+		await Task.Delay(debounce + 100);		
+
+		cut.Instance.Value.Should().Be("newValue");
+	} 
+}

--- a/tests/AntDesign.Tests/_Imports.razor
+++ b/tests/AntDesign.Tests/_Imports.razor
@@ -1,0 +1,12 @@
+﻿@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.JSInterop
+@using Microsoft.Extensions.DependencyInjection
+@using AngleSharp.Dom
+@using Bunit
+@using Bunit.TestDoubles
+@using Xunit
+@using Moq
+@using AntDesign
+@using AntDesign.JsInterop
+@using FluentAssertions


### PR DESCRIPTION
### 🤔 This is a ...

- [x] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
Fixes #1254
Addresses also closed #851 and #1128

### 💡 Background and solution
Key part of the change is in `Form.razor.cs`. All `_editContext = new EditContext()` have been replaced with `BuildEditContext()` method. The issue with `EditContext` is that it cannot be just newed, because it may (and actually does) contain delegates attached to events (refer to [this issue](https://github.com/dotnet/aspnetcore/issues/18963)). So the method is using reflection to delete delegates from events of the "old" `_editContext` and transfers them to new `_editContext`. This is especially important, since `EditContext` is now also exposed as a property so any consumer can attach any number of handlers that are outside of `Form`'s control 
To keep with convention, all the events of the `EditContext` have been exposed as parameters of type `EventCallback`.

I added this to feature branch, because I am again working with assumption of exposed `EditContext`. That was done in my PR that also landed in the feature branch.

Tests for `Form` & `EditContext` require net6.

Changes done to the test projects are based on recommendations made by `bUnit`s creator (he was looking at one of the test issues on his twitch stream).

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Added  `OnFieldChanged`, `OnValidationRequested` & `OnValidationStateChanged` event callbacks that map directly to `EditContext` respective events.        |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
