### PR TITLE
fix(module:antinputcomponentbase): guid optimization

### DIFF
--- a/components/core/Base/AntInputComponentBase.cs
+++ b/components/core/Base/AntInputComponentBase.cs
@@ -183,6 +183,8 @@ namespace AntDesign
 
         private TValue _firstValue;
         protected bool _isNotifyFieldChanged = true;
+        private bool _isValueGuid;
+
 
         /// <summary>
         /// Constructs an instance of <see cref="InputBase{TValue}"/>.
@@ -221,10 +223,11 @@ namespace AntDesign
             bool success;
 
             // BindConverter.TryConvertTo<Guid> doesn't work for a incomplete Guid fragment. Remove this when the BCL bug is fixed.
-            if (THelper.GetUnderlyingType<TValue>() == typeof(Guid))
+            if (_isValueGuid)
             {
                 success = Guid.TryParse(value, out Guid parsedGuidValue);
-                if (success) parsedValue = THelper.ChangeType<TValue>(parsedGuidValue);
+                if (success)
+                    parsedValue = THelper.ChangeType<TValue>(parsedGuidValue);
             }
             else
             {
@@ -257,6 +260,7 @@ namespace AntDesign
 
         protected override void OnInitialized()
         {
+            _isValueGuid = THelper.GetUnderlyingType<TValue>() == typeof(Guid);
             base.OnInitialized();
 
             FormItem?.AddControl(this);


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [x] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 💡 Background and solution
A minor optimization of @anranruye PR #1510. Moved reflection to `OnInitialized` since the type of the input is set once. 

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
