### PR TITLE
fix: missing using is causing build failure

### DIFF
--- a/components/core/JsInterop/JSInteropConstants.cs
+++ b/components/core/JsInterop/JSInteropConstants.cs
@@ -1,4 +1,6 @@
-﻿namespace AntDesign
+﻿using System;
+
+namespace AntDesign
 {
     public static class JSInteropConstants
     {


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
Current master is not building.
Edit: It is not building in my .net 6 changed deployment. 

### 💡 Background and solution
Added missing `using` statement.
Edit: It is only needed for .net 6, due to `[Obsolete]` annotation used but only behind compiler preprocessor directive.