### PR TITLE
feat(module: select): support simple data source

### DIFF
--- a/components/select/Select.razor.cs
+++ b/components/select/Select.razor.cs
@@ -511,6 +511,11 @@ namespace AntDesign
         internal bool IsDropdownShown() => _dropDown.IsOverlayShow();
         protected override void OnInitialized()
         {
+            if (typeof(TItemValue) != typeof(TItem) && string.IsNullOrWhiteSpace(ValueName))
+            {
+                throw new ArgumentNullException(nameof(ValueName));
+            }
+
             SetClassMap();
 
             if (string.IsNullOrWhiteSpace(Style))

--- a/components/select/Select.razor.cs
+++ b/components/select/Select.razor.cs
@@ -85,10 +85,10 @@ namespace AntDesign
             get => _labelName;
             set
             {
-                _getLabel = PathHelper.GetDelegate<TItem, string>(value);
+                _getLabel = string.IsNullOrWhiteSpace(value) ? null : PathHelper.GetDelegate<TItem, string>(value);
                 if (SelectMode == SelectMode.Tags)
                 {
-                    _setLabel = PathHelper.SetDelegate<TItem, string>(value);
+                    _setLabel = string.IsNullOrWhiteSpace(value) ? null : PathHelper.SetDelegate<TItem, string>(value);
                 }
                 _labelName = value;
             }
@@ -179,8 +179,8 @@ namespace AntDesign
             get => _valueName;
             set
             {
-                _getValue = PathHelper.GetDelegate<TItem, TItemValue>(value);
-                _setValue = PathHelper.SetDelegate<TItem, TItemValue>(value);
+                _getValue = string.IsNullOrWhiteSpace(value) ? null : PathHelper.GetDelegate<TItem, TItemValue>(value);
+                _setValue = string.IsNullOrWhiteSpace(value) ? null : PathHelper.SetDelegate<TItem, TItemValue>(value);
                 _valueName = value;
             }
         }
@@ -490,6 +490,13 @@ namespace AntDesign
 
         #endregion Properties
 
+        private static readonly bool _isItemAndValueSameType;
+
+        static Select()
+        {
+            _isItemAndValueSameType = typeof(TItemValue) == typeof(TItem);
+        }
+
         private static bool IsSimpleType(Type type)
         {
             return
@@ -597,8 +604,7 @@ namespace AntDesign
         /// </summary>
         private void CreateDeleteSelectOptions()
         {
-            if (string.IsNullOrWhiteSpace(ValueName)) throw new ArgumentNullException(nameof(ValueName));
-            if (string.IsNullOrWhiteSpace(LabelName)) throw new ArgumentNullException(nameof(LabelName));
+            if (!_isItemAndValueSameType && string.IsNullOrWhiteSpace(ValueName)) throw new ArgumentNullException(nameof(ValueName));
 
             if (_datasource == null)
                 return;
@@ -637,7 +643,7 @@ namespace AntDesign
 
             foreach (var item in _datasource)
             {
-                TItemValue value = _getValue(item);
+                TItemValue value = _getValue == null ? THelper.ChangeType<TItemValue>(item) : _getValue(item);
 
                 var exists = false;
                 SelectOptionItem<TItemValue, TItem> selectOption;
@@ -656,7 +662,7 @@ namespace AntDesign
 
                 var disabled = false;
                 var groupName = string.Empty;
-                var label = _getLabel(item);
+                var label = _getLabel == null ? item.ToString() : _getLabel(item);
 
                 bool isSelected = false;
                 if (processedSelectedCount > 0)
@@ -1214,9 +1220,16 @@ namespace AntDesign
             }
             else
             {
-                item = Activator.CreateInstance<TItem>();
-                _setLabel(item, _searchValue);
-                _setValue(item, value);
+                if (_setValue == null)
+                {
+                    item = THelper.ChangeType<TItem>(value);
+                }
+                else
+                {
+                    item = Activator.CreateInstance<TItem>();
+                    _setValue(item, value);
+                }
+                _setLabel?.Invoke(item, _searchValue);
             }
             return new SelectOptionItem<TItemValue, TItem>() { Label = label, Value = value, Item = item, IsActive = isActive, IsSelected = false, IsAddedTag = true };
         }
@@ -1670,8 +1683,8 @@ namespace AntDesign
                     }
                     else
                     {
-                        _setLabel(CustomTagSelectOptionItem.Item, _searchValue);
-                        _setValue(CustomTagSelectOptionItem.Item, value);
+                        _setLabel?.Invoke(CustomTagSelectOptionItem.Item, _searchValue);
+                        _setValue?.Invoke(CustomTagSelectOptionItem.Item, value);
                     }
                 }
             }

--- a/components/select/Select.razor.cs
+++ b/components/select/Select.razor.cs
@@ -490,13 +490,6 @@ namespace AntDesign
 
         #endregion Properties
 
-        private static readonly bool _isItemAndValueSameType;
-
-        static Select()
-        {
-            _isItemAndValueSameType = typeof(TItemValue) == typeof(TItem);
-        }
-
         private static bool IsSimpleType(Type type)
         {
             return
@@ -604,8 +597,6 @@ namespace AntDesign
         /// </summary>
         private void CreateDeleteSelectOptions()
         {
-            if (!_isItemAndValueSameType && string.IsNullOrWhiteSpace(ValueName)) throw new ArgumentNullException(nameof(ValueName));
-
             if (_datasource == null)
                 return;
 

--- a/site/AntDesign.Docs/Demos/Components/Select/demo/Basic.razor
+++ b/site/AntDesign.Docs/Demos/Components/Select/demo/Basic.razor
@@ -36,17 +36,25 @@
 		Placeholder="Choose"
 		AllowClear>
 </Select>
+<Select DataSource="@_personNames"
+        @bind-Value="@_selectedValue5"
+        Style="width: 120px;"
+        Placeholder="Choose"
+        OnSelectedItemChanged="@((personName) => Console.WriteLine($"selectedItem:{personName},selectedValue:{_selectedValue5}"))">
+</Select>
 @code
 {
-	List<Person> _list;
-	string _selectedValue1, _selectedValue2, _selectedValue3;
-	string _selectedValue4 = "lucy";
-	class Person
-	{
-		public string Value { get; set; }
-		public string Name { get; set; }
-		public bool IsDisabled { get; set; }
-	}
+    List<Person> _list;
+    List<string> _personNames;
+    string _selectedValue1, _selectedValue2, _selectedValue3;
+    string _selectedValue4 = "lucy";
+    string _selectedValue5 = "Lucy";
+    class Person
+    {
+        public string Value { get; set; }
+        public string Name { get; set; }
+        public bool IsDisabled { get; set; }
+    }
 
     protected override void OnInitialized()
     {
@@ -56,7 +64,8 @@
             new Person {Value = "lucy", Name = "Lucy"},
             new Person {Value = "disabled", Name = "Disabled", IsDisabled = true},
             new Person {Value = "yaoming", Name = "YaoMing"}
-		};
+        };
+        _personNames = new List<string> { "Jack", "Lucy", "YaoMing" };
     }
 
     private void OnSelectedItemChangedHandler(Person value)


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [x] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
fixes #1454
### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | When the item in the data source and the value property of select use the same type, it is not necessary to specify ValueName; When LabelName is not specified, the return value of the ToString() method of the item in the data source is used as the label |
| 🇨🇳 Chinese | 当数据源中的项和Select的Value属性使用相同类型时，无需指定ValueName；当不指定LabelName时，将使用数据源中的项的ToString()方法的返回值作为Label |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
