### PR TITLE
fix(module:dropdownbutton): align with react

### DIFF
--- a/components/core/Component/Overlay/OverlayTrigger.razor.cs
+++ b/components/core/Component/Overlay/OverlayTrigger.razor.cs
@@ -139,7 +139,7 @@ namespace AntDesign.Internal
         }
 
         [Inject]
-        private DomEventService DomEventService { get; set; }
+        protected DomEventService DomEventService { get; set; }
 
         private bool _mouseInTrigger = false;
         private bool _mouseInOverlay = false;
@@ -173,22 +173,22 @@ namespace AntDesign.Internal
             return base.OnAfterRenderAsync(firstRender);
         }
 
-        private void OnUnboundMouseEnter(JsonElement jsonElement) => OnTriggerMouseEnter();
+        protected void OnUnboundMouseEnter(JsonElement jsonElement) => OnTriggerMouseEnter();
 
-        private void OnUnboundMouseLeave(JsonElement jsonElement) => OnTriggerMouseLeave();
+        protected void OnUnboundMouseLeave(JsonElement jsonElement) => OnTriggerMouseLeave();
 
-        private void OnUnboundFocusIn(JsonElement jsonElement) => OnTriggerFocusIn();
+        protected void OnUnboundFocusIn(JsonElement jsonElement) => OnTriggerFocusIn();
 
-        private void OnUnboundFocusOut(JsonElement jsonElement) => OnTriggerFocusOut();
+        protected void OnUnboundFocusOut(JsonElement jsonElement) => OnTriggerFocusOut();
 
-        private async void OnUnboundClick(JsonElement jsonElement)
+        protected async void OnUnboundClick(JsonElement jsonElement)
         {
             var eventArgs = JsonSerializer.Deserialize<MouseEventArgs>(jsonElement.ToString(),
                 new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
             await OnClickDiv(eventArgs);
         }
 
-        private async void OnContextMenu(JsonElement jsonElement)
+        protected async void OnContextMenu(JsonElement jsonElement)
         {
             var eventArgs = JsonSerializer.Deserialize<MouseEventArgs>(jsonElement.ToString(),
                 new JsonSerializerOptions { PropertyNameCaseInsensitive = true });

--- a/components/dropdown/Dropdown.razor
+++ b/components/dropdown/Dropdown.razor
@@ -4,49 +4,60 @@
 
 @if (ChildContent != null)
 {
-    <div class="@ClassMapper.Class"
-         style="display: inline-block; width: fit-content; @Style"
-         id="@Id"
-         @ref="@Ref"
-         @onclick="OnClickDiv"
-         @onmouseenter="OnTriggerMouseEnter"
-         @onmouseleave="OnTriggerMouseLeave"
-         @oncontextmenu="OnTriggerContextmenu"
-         @oncontextmenu:preventDefault>
-        @if (IsButton)
-        {
-            <CascadingValue Value="this" IsFixed="@true">
-                <DropdownGroupButton>
-                    <LeftButton>
-                        <Button @key="1" Size="@_buttonSize" Type="@_buttonType" Disabled="@Disabled">@ChildContent</Button>
-                    </LeftButton>
-                    <RightButton>
-                        <Button @key="2" Size="@_buttonSize" Type="@_buttonType" Disabled="@Disabled" OnClick="OnTriggerClick" Class="ant-dropdown-trigger" Icon="@_rightButtonIcon" />
-                    </RightButton>
-                </DropdownGroupButton>
-            </CascadingValue>
-        }
-        else
-        {
-            @ChildContent
-        }
-    </div>
+	@if (IsButton)
+	{
+		<div class="@ClassMapper.Class"
+			 style="display: inline-block; width: fit-content; @Style"
+			 id="@Id"         
+			 @onclick="OnClickDiv"
+			 >        
+			<CascadingValue Value="this" IsFixed="@true">
+				<DropdownGroupButton>
+					<LeftButton>
+						<Button @key="1" Size="@_buttonSize" Type="@_buttonType" Disabled="@Disabled">@ChildContent</Button>
+					</LeftButton>
+					<RightButton>
+						<span @ref="@Ref">
+							<Button @key="2" Size="@_buttonSize" Type="@_buttonType" Disabled="@Disabled" OnClick="OnTriggerClick" Class="ant-dropdown-trigger" Icon="@_rightButtonIcon" />						
+						</span>
+					</RightButton>
+				</DropdownGroupButton>
+			</CascadingValue>
+		</div>		
+	}
+	else
+	{
+		<div class="@ClassMapper.Class"
+			 style="display: inline-block; width: fit-content; @Style"
+			 id="@Id"
+			 @ref="@Ref"
+			 @onclick="OnClickDiv"
+			 @onmouseenter="OnTriggerMouseEnter"
+			 @onmouseleave="OnTriggerMouseLeave"
+			 @oncontextmenu="OnTriggerContextmenu"
+			 @oncontextmenu:preventDefault
+			 >		
+			 @ChildContent
+		 </div>
+	}
 }
 
 @if (Unbound != null)
 {
     @if (IsButton)
     {
-        <CascadingValue Value="this" IsFixed="@true">
-            <DropdownGroupButton>
-                <LeftButton>
-                    <Button @key="1" Size="@_buttonSize" Type="@_buttonType" Disabled="@Disabled">@ChildContent</Button>
-                </LeftButton>
-                <RightButton>
-                    <Button @key="2" Size="@_buttonSize" Type="@_buttonType" Disabled="@Disabled" OnClick="OnTriggerClick" Class="ant-dropdown-trigger" Icon="@_rightButtonIcon" />
-                </RightButton>
-            </DropdownGroupButton>
-        </CascadingValue>
+		<CascadingValue Value="this" IsFixed="@true">
+			<DropdownGroupButton>
+				<LeftButton>
+					<Button @key="1" Size="@_buttonSize" Type="@_buttonType" Disabled="@Disabled">@Unbound(default)</Button>
+				</LeftButton>
+				<RightButton>
+					<span @ref="@Ref">
+						<Button @key="2" Size="@_buttonSize" Type="@_buttonType" Disabled="@Disabled" OnClick="OnTriggerClick" Class="ant-dropdown-trigger" Icon="@_rightButtonIcon" />						
+					</span>
+				</RightButton>
+			</DropdownGroupButton>
+		</CascadingValue>
     }
     else
     {

--- a/components/dropdown/Dropdown.razor.cs
+++ b/components/dropdown/Dropdown.razor.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Threading.Tasks;
 using AntDesign.Internal;
 using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Web;
 
 namespace AntDesign
 {

--- a/components/dropdown/DropdownButton.cs
+++ b/components/dropdown/DropdownButton.cs
@@ -1,21 +1,96 @@
-﻿using Microsoft.AspNetCore.Components;
+﻿using System.Text.Json;
+using System.Threading.Tasks;
+using AntDesign.JsInterop;
+using Microsoft.AspNetCore.Components;
 
 namespace AntDesign
 {
     public class DropdownButton : Dropdown
     {
+        protected override void OnInitialized()
+        {
+            Placement = PlacementType.BottomRight;
+            base.OnInitialized();
+        }
+
+        /// <summary>
+        /// Force overlay trigger to be attached to wrapping element of 
+        /// the right button. Right button has to be wrapped, 
+        /// because overlay will be looking for first child
+        /// element of the overlay trigger to calculate the overlay position.
+        /// If the right button was the trigger, then its first child
+        /// would be the icon/ellipsis and the overlay would have been 
+        /// rendered too high.
+        /// </summary>
+        /// <param name="firstRender"></param>
+        /// <returns></returns>
+        protected override Task OnAfterRenderAsync(bool firstRender)
+        {
+            if (firstRender)
+            {
+                Ref = RefBack.Current;
+                DomEventService.AddEventListener(Ref, "click", OnUnboundClick, true);
+                DomEventService.AddEventListener(Ref, "mouseover", OnUnboundMouseEnter, true);
+                DomEventService.AddEventListener(Ref, "mouseout", OnUnboundMouseLeave, true);
+                DomEventService.AddEventListener(Ref, "focusin", OnUnboundFocusIn, true);
+                DomEventService.AddEventListener(Ref, "focusout", OnUnboundFocusOut, true);
+                DomEventService.AddEventListener(Ref, "contextmenu", OnContextMenu, true, true);
+            }
+            return base.OnAfterRenderAsync(firstRender);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            DomEventService.RemoveEventListerner<JsonElement>(Ref, "click", OnUnboundClick);
+            DomEventService.RemoveEventListerner<JsonElement>(Ref, "mouseover", OnUnboundMouseEnter);
+            DomEventService.RemoveEventListerner<JsonElement>(Ref, "mouseout", OnUnboundMouseLeave);
+            DomEventService.RemoveEventListerner<JsonElement>(Ref, "focusin", OnUnboundFocusIn);
+            DomEventService.RemoveEventListerner<JsonElement>(Ref, "focusout", OnUnboundFocusOut);
+            DomEventService.RemoveEventListerner<JsonElement>(Ref, "contextmenu", OnContextMenu);
+
+            base.Dispose(disposing);
+        }
+
+        internal override async Task Show(int? overlayLeft = null, int? overlayTop = null)
+        {
+            if (!Loading)
+            {
+                await _overlay.Show(overlayLeft, overlayTop);
+            }
+        }
+
+        [Parameter]
+        public bool Loading
+        {
+            get => _loading;
+            set
+            {
+                _loading = value;
+                if (value)
+                {
+                    _preLoadingIcon = _icon;
+                    Icon = "loading";
+                }
+                else
+                {
+                    Icon = _preLoadingIcon;
+                }
+            }
+        }
+
+        private string _preLoadingIcon;
         private string _icon = "ellipsis";
         [Parameter]
         public string Icon
         {
-            get
-            {
-                return _icon;
-            }
+            get => _icon;
             set
             {
-                _icon = value;
-                ChangeRightButtonIcon(value);
+                if (!_loading || value == "loading")
+                {
+                    _icon = value;
+                    ChangeRightButtonIcon(value);
+                }
             }
         }
 
@@ -23,10 +98,7 @@ namespace AntDesign
         [Parameter]
         public string Size
         {
-            get
-            {
-                return _size;
-            }
+            get => _size;
             set
             {
                 _size = value;
@@ -35,13 +107,12 @@ namespace AntDesign
         }
 
         private string _type = ButtonType.Default;
+        private bool _loading;
+
         [Parameter]
         public string Type
         {
-            get
-            {
-                return _type;
-            }
+            get => _type;
             set
             {
                 _type = value;
@@ -49,9 +120,6 @@ namespace AntDesign
             }
         }
 
-        public DropdownButton()
-        {
-            IsButton = true;
-        }
+        public DropdownButton() => IsButton = true;
     }
 }

--- a/site/AntDesign.Docs/Demos/Components/Button/demo/Block.razor
+++ b/site/AntDesign.Docs/Demos/Components/Button/demo/Block.razor
@@ -1,6 +1,11 @@
-﻿<div>
-    <Button Type="primary" Block>Primary</Button>
-    <Button Block>Default</Button>
-    <Button Type="dashed" Block>Dashed</Button>
-    <Button Type="link" Block>Link</Button>
+﻿<style>
+	#button-block-demo > * {
+		margin-bottom: 12px;
+	}
+</style>
+<div id="button-block-demo">
+	<Button Type="primary" Block>Primary</Button>
+	<Button Block>Default</Button>
+	<Button Type="dashed" Block>Dashed</Button>
+	<Button Type="link" Block>Link</Button>
 </div>

--- a/site/AntDesign.Docs/Demos/Components/Button/demo/Multiple.razor
+++ b/site/AntDesign.Docs/Demos/Components/Button/demo/Multiple.razor
@@ -8,8 +8,11 @@
 
 <Button Type="primary">primary</Button>
 <Button>secondary</Button>
-<Dropdown Overlay=@menu>
-    <Button>
-        Actions <Icon Type="down" />
-    </Button>
-</Dropdown>
+<DropdownButton>
+    <Overlay>
+        @menu
+    </Overlay>
+    <Unbound>
+        Actions
+    </Unbound>
+</DropdownButton>

--- a/site/AntDesign.Docs/Demos/Components/Button/demo/multiple.md
+++ b/site/AntDesign.Docs/Demos/Components/Button/demo/multiple.md
@@ -7,8 +7,8 @@ title:
 
 ## zh-CN
 
-按钮组合使用时，推荐使用 1 个主操作 + n 个次操作，3 个以上操作时把更多操作放到 `Dropdown.Button` 中组合使用。
+按钮组合使用时，推荐使用 1 个主操作 + n 个次操作，3 个以上操作时把更多操作放到 `DropdownButton` 中组合使用。
 
 ## en-US
 
-If you need several buttons, we recommend that you use 1 primary button + n secondary buttons, and if there are more than three operations, you can group some of them into `Dropdown.Button`.
+If you need several buttons, we recommend that you use 1 primary button + n secondary buttons, and if there are more than three operations, you can group some of them into `DropdownButton`.

--- a/site/AntDesign.Docs/Demos/Components/Dropdown/demo/DropdownButtonDemo.razor
+++ b/site/AntDesign.Docs/Demos/Components/Dropdown/demo/DropdownButtonDemo.razor
@@ -1,48 +1,139 @@
-﻿<DropdownButton OnClick='e => { Console.WriteLine("Click on left button."); }'>
-    <Overlay>
-        @_overlayMenu
-    </Overlay>
-    <ChildContent>
-        Dropdown
-    </ChildContent>
-</DropdownButton>
-<DropdownButton Icon="user">
-    <Overlay>
-        @_overlayMenu
-    </Overlay>
-    <ChildContent>
-        Dropdown
-    </ChildContent>
-</DropdownButton>
-<DropdownButton OnClick='e => { Console.WriteLine("Click on left button."); }' Disabled="@true">
-    <Overlay>
-        @_overlayMenu
-    </Overlay>
-    <ChildContent>
-        Dropdown
-    </ChildContent>
-</DropdownButton>
-<Tooltip Title="@("tooltip")">
-    <Unbound>
-        <DropdownButton ButtonsRender="ButtonsRender" RefBack="@context" Icon="loading">
-            <Overlay>
-                @_overlayMenu
-            </Overlay>
-            <ChildContent>
-                With ToolTip
-            </ChildContent>
-        </DropdownButton>
-    </Unbound>
-</Tooltip>
-<Dropdown>
-    <Overlay>
-        @_overlayMenu
-    </Overlay>
-    <ChildContent>
-        <Button>Button <Icon Type="down" /></Button>
-    </ChildContent>
-</Dropdown>
-
+﻿<Divider Orientation="left" Plain>Div</Divider>
+<Space Direction="@DirectionVHType.Vertical" Style="width: 100%">
+	<SpaceItem>
+		<Space Size=@(("8", "16")) Wrap>
+			<SpaceItem>
+                <DropdownButton OnClick='e => { Console.WriteLine("Click on left button."); }'>
+                    <Overlay>
+                        @_overlayMenu
+                    </Overlay>
+                    <ChildContent>
+                        Dropdown
+                    </ChildContent>
+                </DropdownButton>
+			</SpaceItem>
+			<SpaceItem>
+                <DropdownButton Icon="user">
+                    <Overlay>        
+                        @_overlayMenu
+                    </Overlay>    
+                    <ChildContent>
+                        Dropdown
+                    </ChildContent>
+                </DropdownButton>
+			</SpaceItem>
+			<SpaceItem>
+                <DropdownButton OnClick='e => { Console.WriteLine("Click on left button."); }' Disabled="@true">
+                    <Overlay>
+                        @_overlayMenu
+                    </Overlay>
+                    <ChildContent>
+                        Dropdown
+                    </ChildContent>
+                </DropdownButton>
+			</SpaceItem>
+			<SpaceItem>
+                <DropdownButton ButtonsRender="ButtonsRender" Loading>
+                    <Overlay>
+                        @_overlayMenu
+                    </Overlay>
+                    <ChildContent>
+                        <Tooltip Title="@("tooltip")">
+                            <Unbound>
+                                <span @ref="@context.Current">With ToolTip</span>
+                            </Unbound>
+                        </Tooltip>
+                    </ChildContent>
+                </DropdownButton>    
+			</SpaceItem>
+			<SpaceItem>
+                <Dropdown>
+                    <Overlay>
+                        @_overlayMenu
+                    </Overlay>
+                    <ChildContent>
+                        <Button>Button <Icon Type="down" /></Button>
+                    </ChildContent>
+                </Dropdown>
+		</SpaceItem>
+		</Space>
+	</SpaceItem>
+</Space>
+<Divider Orientation="left" Plain>Unbound</Divider>
+<Space Direction="@DirectionVHType.Vertical" Style="width: 100%">
+	<SpaceItem>
+		<Space Size=@(("8", "16")) Wrap>
+			<SpaceItem>
+                <DropdownButton OnClick='e => { Console.WriteLine("Click on left button."); }'>
+                    <Overlay>
+                        @_overlayMenu
+                    </Overlay>
+                    <Unbound>
+                        Dropdown
+                    </Unbound>
+                </DropdownButton>
+			</SpaceItem>
+			<SpaceItem>
+                <DropdownButton Icon="user">
+                    <Overlay>        
+                        @_overlayMenu
+                    </Overlay>    
+                    <Unbound>
+                        Dropdown
+                    </Unbound>
+                </DropdownButton>
+			</SpaceItem>
+			<SpaceItem>
+                <DropdownButton OnClick='e => { Console.WriteLine("Click on left button."); }' Disabled="@true">
+                    <Overlay>
+                        @_overlayMenu
+                    </Overlay>
+                    <Unbound>
+                        Dropdown
+                    </Unbound>
+                </DropdownButton>
+			</SpaceItem>
+			<SpaceItem>
+                <DropdownButton ButtonsRender="ButtonsRender" Loading>
+                    <Overlay>
+                        @_overlayMenu
+                    </Overlay>
+                    <Unbound>
+                        <Tooltip Title="@("tooltip")">
+                            <Unbound Context="tooltip">
+                                <span @ref="@tooltip.Current">With ToolTip</span>
+                            </Unbound>
+                        </Tooltip>
+                    </Unbound>
+                </DropdownButton>    
+			</SpaceItem>
+			<SpaceItem>
+                <DropdownButton ButtonsRender="ButtonsRender" >
+                    <Overlay>
+                        @_overlayMenu
+                    </Overlay>
+                    <Unbound>
+                        <Tooltip Title="@("tooltip")">
+                            <Unbound Context="tooltip">
+                                <span @ref="@tooltip.Current">ButtonsRender</span>
+                            </Unbound>
+                        </Tooltip>
+                    </Unbound>
+                </DropdownButton>    
+			</SpaceItem>
+			<SpaceItem>
+                <Dropdown>
+                    <Overlay>
+                        @_overlayMenu
+                    </Overlay>
+                    <Unbound>
+                        <Button RefBack=@context>Button <Icon Type="down" /></Button>
+                    </Unbound>
+                </Dropdown>
+		</SpaceItem>
+		</Space>
+	</SpaceItem>
+</Space>
 @code
 {
 private RenderFragment _overlayMenu =@<Menu>


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [x] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
Current behaviour is this:
![dropdownButton-issues](https://user-images.githubusercontent.com/6518006/120393585-d391cf80-c33a-11eb-8190-15a69fb69558.gif)

Expected is this:
![dropdownButton-expected](https://user-images.githubusercontent.com/6518006/120393138-228b3500-c33a-11eb-9500-35e40beb048b.gif)
1. Hovering over left button should not open the dropdown.
2. When loading, dropdown should be disabled.
3. Overlay should be position to the right edge of the right button.

### 💡 Background and solution
1. The issue here was that overlay trigger was set on the wrapping div instead of on the right button. 
2. Exposed `Loading` parameter. This is different than in react, but actually is the same as in a number of other components.
3. Hardcoded the position of the overlay in `DropdownButton`

Other changes:
1. Fixed docs for the `Button` in area of `Multiple` and fixed styling for block buttons.

### 📝 Changelog

<!--
Describe changes from user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Added `Loading` parameter to `DropdownButton`         |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
