### PR TITLE
fix(module:datepicker): in form behavior

### DIFF
--- a/components/date-picker/DatePicker.Razor.cs
+++ b/components/date-picker/DatePicker.Razor.cs
@@ -99,7 +99,7 @@ namespace AntDesign
             }
             if (FormatAnalyzer.TryPickerStringConvert(args.Value.ToString(), out TValue changeValue, IsNullable))
             {
-                Value = changeValue;
+                CurrentValue = changeValue;
                 GetIfNotNull(changeValue, (notNullValue) =>
                 {
                     PickerValues[0] = notNullValue;
@@ -107,8 +107,6 @@ namespace AntDesign
 
                 StateHasChanged();
             }
-
-            UpdateCurrentValueAsString();
         }
 
         protected override Task OnBlur(int index)
@@ -244,8 +242,6 @@ namespace AntDesign
             }
 
             _pickerStatus[0]._hadSelectValue = true;
-
-            UpdateCurrentValueAsString();
 
             if (!IsShowTime && Picker != DatePickerType.Time)
             {

--- a/components/date-picker/RangePicker.razor.cs
+++ b/components/date-picker/RangePicker.razor.cs
@@ -149,11 +149,13 @@ namespace AntDesign
 
                 ChangePickerValue(changeValue, index);
 
+                if (_isNotifyFieldChanged && (Form?.ValidateOnChange == true))
+                {
+                    EditContext?.NotifyFieldChanged(FieldIdentifier);
+                }
 
                 StateHasChanged();
             }
-
-            UpdateCurrentValueAsString();
         }
 
         /// <summary>
@@ -407,8 +409,6 @@ namespace AntDesign
             _pickerStatus[index]._hadSelectValue = true;
             _pickerStatus[index]._currentShowHadSelectValue = true;
 
-            UpdateCurrentValueAsString(index);
-
             if (!IsShowTime && Picker != DatePickerType.Time)
             {
                 if (_pickerStatus[0]._currentShowHadSelectValue && _pickerStatus[1]._currentShowHadSelectValue)
@@ -424,6 +424,11 @@ namespace AntDesign
                     Dates = new DateTime?[] { array.GetValue(0) as DateTime?, array.GetValue(1) as DateTime? },
                     DateStrings = new string[] { GetInputValue(0), GetInputValue(1) }
                 });
+            }
+
+            if (_isNotifyFieldChanged && (Form?.ValidateOnChange == true))
+            {
+                EditContext?.NotifyFieldChanged(FieldIdentifier);
             }
         }
 
@@ -492,13 +497,6 @@ namespace AntDesign
             }
         }
 
-        protected override void UpdateCurrentValueAsString(int index = 0)
-        {
-            if (EditContext != null)
-            {
-                CurrentValueAsString = $"{GetInputValue(0)},{GetInputValue(1)}";
-            }
-        }
 
         protected override bool TryParseValueFromString(string value, out TValue result, out string validationErrorMessage)
         {

--- a/components/date-picker/internal/DatePickerBase.cs
+++ b/components/date-picker/internal/DatePickerBase.cs
@@ -449,14 +449,6 @@ namespace AntDesign
             }
         }
 
-        protected virtual void UpdateCurrentValueAsString(int index = 0)
-        {
-            if (EditContext != null)
-            {
-                CurrentValueAsString = GetInputValue(index);
-            }
-        }
-
         public void Close()
         {
             _duringManualInput = false;


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
Fixes #1615 

### 💡 Background and solution
Both pickers had a method `UpdateCurrentValueAsString` which was called on data change and was only doing something if the component was attached to a form. The problem with it is that it was trying to apply the string value of the input to `CurrentValue`. But that code is a general code that sits in `AntInputComponentBase`. It does not handle well the datepicker specific data format. So it was failing a lot and was resetting also the data. I decided to remove it. 
Also, I noticed that for `RangePicker`, when in `Form`, `EditContext.NotifyFieldChanged` was never called. In regular `DatePicker` this call is done when `CurrentValue` is updated. But in `RangePicker` `CurrentValue` is never updated as a whole, only array items are. So I added the appropriate code. Also, maybe it would be a good idea to provide `Required` attribute for `RangePicker`. Regular `Required` will not work, because the array with `DateTime?` will exist and meet the built-in attribute, even when its items are nulls. 

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
