### PR TITLE
feat(module:dropdownbutton): each button customization

### DIFF
--- a/components/dropdown/Dropdown.razor
+++ b/components/dropdown/Dropdown.razor
@@ -10,38 +10,7 @@
 			 style="display: inline-block; width: @(Block ? "100%" : "fit-content" ); @Style"
 			 id="@Id"         			 
 			 >        
-			<CascadingValue Value="this" IsFixed="@true">
-				<DropdownGroupButton>
-					<LeftButton>
-						<Button @key="1" 
-							Size="@_buttonSize" 
-							Type="@_buttonTypeLeft" 
-							Disabled="@Disabled" 
-							Danger="@_danger" 
-							Ghost="@_ghost"
-							OnClick="@OnClick"
-							Style="@(Block ? "flex: 1 0 auto;" : "" )"
-							>
-							@ChildContent
-						</Button>
-					</LeftButton>
-					<RightButton>
-						<span @ref="@Ref">
-							<Button @key="2" 
-								Size="@_buttonSize" 
-								Type="@_buttonTypeRight" 
-								Disabled="@Disabled" 
-								OnClick="OnTriggerClick" 
-								Class="ant-dropdown-trigger" 
-								Icon="@_rightButtonIcon" 
-								Danger="@_danger" 
-								Loading="@_isLoading"
-								Style="@(Block ? "flex: 0 0 auto;" : "" )"
-								Ghost="@_ghost"/>
-						</span>
-					</RightButton>
-				</DropdownGroupButton>
-			</CascadingValue>
+			@buttons((this, ChildContent))
 		</div>		
 	}
 	else
@@ -65,38 +34,7 @@
 {
     @if (IsButton)
     {
-		<CascadingValue Value="this" IsFixed="@true">
-			<DropdownGroupButton Style=@Style>
-				<LeftButton>
-					<Button @key="1" 
-						Size="@_buttonSize" 
-						Type="@_buttonTypeLeft" 
-						Disabled="@Disabled" 
-						Danger="@_danger" 
-						Ghost="@_ghost"
-						OnClick="@OnClick"
-						Style="@(Block ? "flex: 1 0 auto;" : "" )"
-						>
-						@Unbound(default)
-					</Button>
-				</LeftButton>
-				<RightButton>
-					<span @ref="@Ref">
-						<Button @key="2" 
-							Size="@_buttonSize" 
-							Type="@_buttonTypeRight" 
-							Disabled="@Disabled" 
-							OnClick="OnTriggerClick" 
-							Class="ant-dropdown-trigger" 
-							Icon="@_rightButtonIcon" 
-							Loading="@_isLoading"
-							Danger="@_danger" 
-							Style="@(Block ? "flex: 0 0 auto;" : "" )"
-							Ghost="@_ghost"/>						
-					</span>
-				</RightButton>
-			</DropdownGroupButton>
-		</CascadingValue>
+		@buttons((this, Unbound(default)))
     }
     else
     {
@@ -111,3 +49,41 @@
              OnOverlayMouseLeave="OnOverlayMouseLeave"
              OnOverlayMouseUp="OnOverlayMouseUp" />
 </CascadingValue>
+
+
+@code {
+	RenderFragment<(Dropdown dropdown, RenderFragment childContent)> buttons = data => @<CascadingValue Value="@data.dropdown" IsFixed>			
+		<DropdownGroupButton>
+			<LeftButton>
+				<Button @key="1" 
+					Size="@data.dropdown.ButtonSize" 
+					Class="@data.dropdown.ButtonClassLeft"
+					Type="@data.dropdown.ButtonTypeLeft" 
+					Disabled="@data.dropdown.Disabled" 
+					Danger="@data.dropdown.ButtonDanger" 
+					Ghost="@data.dropdown.ButtonGhost"					
+					Style="@(data.dropdown.Block ? "flex: 1 0 auto;" + data.dropdown.ButtonStyleLeft : data.dropdown.ButtonStyleLeft)"
+					@attributes="@(new Dictionary<string, object>() { ["OnClick"] = _callbackFactory.Create<MouseEventArgs>(data.dropdown, data.dropdown.OnClick) })"
+					>
+					@data.childContent
+				</Button>
+			</LeftButton>
+			<RightButton>
+				<span @ref="@data.dropdown.Ref">
+					<Button @key="2" 
+						Size="@data.dropdown.ButtonSize" 						
+						Type="@data.dropdown.ButtonTypeRight" 
+						Disabled="@data.dropdown.Disabled" 						
+						Class="@("ant-dropdown-trigger " + @data.dropdown.ButtonClassRight)" 
+						Icon="@data.dropdown.RightButtonIcon" 
+						Danger="@data.dropdown.ButtonDanger" 
+						Loading="@data.dropdown.IsLoading"
+						Ghost="@data.dropdown.ButtonGhost"
+						Style="@(data.dropdown.Block ? "flex: 0 0 auto;" + data.dropdown.ButtonStyleRight : data.dropdown.ButtonStyleRight)"
+						@attributes="@(new Dictionary<string, object>() { ["OnClick"] = _callbackFactory.Create<MouseEventArgs>(data.dropdown, data.dropdown.OnTriggerClick) })"
+						/>
+				</span>
+			</RightButton>
+		</DropdownGroupButton>
+	</CascadingValue>;
+}

--- a/components/dropdown/Dropdown.razor.cs
+++ b/components/dropdown/Dropdown.razor.cs
@@ -19,12 +19,45 @@ namespace AntDesign
 
         private string _buttonTypeRight = ButtonType.Default;
         private string _buttonTypeLeft = ButtonType.Default;
+        protected string _buttonClassRight;
+        protected string _buttonClassLeft;
+        protected string _buttonStyleRight;
+        protected string _buttonStyleLeft;
+
+        internal string RightButtonIcon => _rightButtonIcon;
+        internal string ButtonSize => _buttonSize;
+        internal string ButtonTypeRight => _buttonTypeRight;
+        internal string ButtonTypeLeft => _buttonTypeLeft;
+        internal string ButtonClassRight => _buttonClassRight;
+        internal string ButtonClassLeft => _buttonClassLeft;
+        internal string ButtonStyleRight => _buttonStyleRight;
+        internal string ButtonStyleLeft => _buttonStyleLeft;
+        internal bool ButtonDanger => _danger;
+        internal bool ButtonGhost => _ghost;
+        internal bool IsLoading => _isLoading;
+
+        private static readonly EventCallbackFactory _callbackFactory = new EventCallbackFactory();
+
         protected void ChangeRightButtonIcon(string icon)
         {
             _rightButtonIcon = icon;
 
             StateHasChanged();
         }
+        protected void ChangeButtonClass(string leftButton, string rightButton)
+        {
+            _buttonClassLeft = leftButton;
+            _buttonClassRight = rightButton;
+            StateHasChanged();
+        }
+
+        protected void ChangeButtonStyles(string leftButton, string rightButton)
+        {
+            _buttonStyleLeft = leftButton;
+            _buttonStyleRight = rightButton;
+            StateHasChanged();
+        }
+
 
         protected void ChangeButtonSize(string size)
         {
@@ -54,9 +87,10 @@ namespace AntDesign
             StateHasChanged();
         }
 
-        protected void ChangeButtonType((string LeftButton, string RightButton) type)
+        protected void ChangeButtonType(string leftButton, string rightButton)
         {
-            (_buttonTypeLeft, _buttonTypeRight) = type;
+            _buttonTypeLeft = leftButton;
+            _buttonTypeRight = rightButton;
             StateHasChanged();
         }
 

--- a/components/dropdown/DropdownButton.cs
+++ b/components/dropdown/DropdownButton.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using AntDesign.JsInterop;
 using Microsoft.AspNetCore.Components;
+using OneOf;
 
 namespace AntDesign
 {
@@ -26,6 +27,52 @@ namespace AntDesign
         {
             get => base.ButtonsRender;
             set => base.ButtonsRender = value;
+        }
+
+        /// <summary>
+        /// Allows to set each button's css class either to the same string
+        /// or separately.
+        /// </summary>
+        [Parameter]
+        public OneOf<string, (string LeftButton, string RightButton)> ButtonsClass
+        {
+            get =>_buttonsClass; 
+            set
+            {
+                _buttonsClass = value;
+                _buttonsClass.Switch(
+                    single =>
+                    {
+                        ChangeButtonClass(single, single);
+                    },
+                    both =>
+                    {
+                        ChangeButtonClass(both.LeftButton, both.RightButton);
+                    });
+            }
+        }
+
+        /// <summary>
+        /// Allows to set each button's style either to the same string
+        /// or separately. 
+        /// </summary>
+        [Parameter]
+        public OneOf<string, (string LeftButton, string RightButton)> ButtonsStyle
+        {
+            get => _buttonsStyle;
+            set
+            {
+                _buttonsStyle = value;
+                _buttonsStyle.Switch(
+                    single =>
+                    {
+                        ChangeButtonStyles(single, single);
+                    },
+                    both =>
+                    {
+                        ChangeButtonStyles(both.LeftButton, both.RightButton);
+                    });
+            }
         }
 
         /// <summary>
@@ -102,25 +149,36 @@ namespace AntDesign
             }
         }
 
-        private (string LeftButton, string RightButton) _type = (ButtonType.Default, ButtonType.Default);
+        /// <summary>
+        /// Allows to set each button's type either to the same string
+        /// or separately. Use AntDesign.ButtonType helper class.
+        /// </summary>
+        [Parameter]
+        public OneOf<string, (string LeftButton, string RightButton)> Type
+
+        {
+            get => _buttonsType;
+            set
+            {
+                _buttonsType = value;
+                _buttonsType.Switch(
+                    single =>
+                    {
+                        ChangeButtonType(single, single);
+                    },
+                    both =>
+                    {
+                        ChangeButtonType(both.LeftButton, both.RightButton);
+                    });
+            }
+        }
+
         private bool _loading;
         private bool _danger;
         private bool _ghost = false;
-
-        /// <summary>
-        /// Button type is a tuple where first item refers to LeftButton type 
-        /// and second item refers to RightButton type.
-        /// </summary>
-        [Parameter]
-        public (string LeftButton, string RightButton) Type
-        {
-            get => _type;
-            set
-            {
-                _type = value;
-                ChangeButtonType(value);
-            }
-        }
+        private OneOf<string, (string LeftButton, string RightButton)> _buttonsStyle;
+        private OneOf<string, (string LeftButton, string RightButton)> _buttonsClass;
+        private OneOf<string, (string LeftButton, string RightButton)> _buttonsType = ButtonType.Default;
 
         public DropdownButton() => IsButton = true;
 

--- a/site/AntDesign.Docs/Demos/Components/Button/demo/multiple.md
+++ b/site/AntDesign.Docs/Demos/Components/Button/demo/multiple.md
@@ -7,8 +7,8 @@ title:
 
 ## zh-CN
 
-按钮组合使用时，推荐使用 1 个主操作 + n 个次操作，3 个以上操作时把更多操作放到 `DropdownButton` 中组合使用。
+按钮组合使用时，推荐使用 1 个主操作 + n 个次操作，3 个以上操作时把更多操作放到 [`DropdownButton`](zh-CN/components/dropdown) 中组合使用。
 
 ## en-US
 
-If you need several buttons, we recommend that you use 1 primary button + n secondary buttons, and if there are more than three operations, you can group some of them into `DropdownButton`.
+If you need several buttons, we recommend that you use 1 primary button + n secondary buttons, and if there are more than three operations, you can group some of them into [`DropdownButton`](en-US/components/dropdown).

--- a/site/AntDesign.Docs/Demos/Components/Dropdown/demo/DropdownButtonDemo.razor
+++ b/site/AntDesign.Docs/Demos/Components/Dropdown/demo/DropdownButtonDemo.razor
@@ -33,7 +33,7 @@
                 </DropdownButton>
 			</SpaceItem>
 			<SpaceItem>
-                <DropdownButton OnClick='e => { Console.WriteLine("Click on left button."); }' Danger="true">
+                <DropdownButton OnClick='e => { Console.WriteLine("Click on left button."); }' Danger>
                     <Overlay>
                         @_overlayMenu
                     </Overlay>
@@ -43,7 +43,7 @@
                 </DropdownButton>
 			</SpaceItem>
 			<SpaceItem Class="site-button-ghost-wrapper">
-                <DropdownButton OnClick='e => { Console.WriteLine("Click on left button."); }' Ghost="true">
+                <DropdownButton OnClick='e => { Console.WriteLine("Click on left button."); }' Ghost>
                     <Overlay>
                         @_overlayMenu
                     </Overlay>
@@ -53,7 +53,7 @@
                 </DropdownButton>
 			</SpaceItem>
 			<SpaceItem>
-                <DropdownButton OnClick='e => { Console.WriteLine("Click on left button."); }' Disabled="@true">
+                <DropdownButton OnClick='e => { Console.WriteLine("Click on left button."); }' Disabled>
                     <Overlay>
                         @_overlayMenu
                     </Overlay>
@@ -94,7 +94,7 @@
 	<SpaceItem>
 		<Space Size=@(("8", "16")) Wrap>
 			<SpaceItem>
-                <DropdownButton OnClick='e => { Console.WriteLine("Click on left button."); }'>
+                <DropdownButton ButtonsStyle="@("background-color: #91d5ff;")" OnClick='e => { Console.WriteLine("Click on left button."); }'>
                     <Overlay>
                         @_overlayMenu
                     </Overlay>
@@ -104,7 +104,7 @@
                 </DropdownButton>
 			</SpaceItem>
 			<SpaceItem>
-                <DropdownButton Icon="user">
+                <DropdownButton Icon="user" ButtonsStyle="@(("background-color:#91d5ff;", "background-color: #fff0f6;"))">
                     <Overlay>        
                         @_overlayMenu
                     </Overlay>    
@@ -114,7 +114,7 @@
                 </DropdownButton>
 			</SpaceItem>
 			<SpaceItem>
-                <DropdownButton OnClick='e => { Console.WriteLine("Click on left button."); }' Disabled="@true">
+                <DropdownButton OnClick='e => { Console.WriteLine("Click on left button."); }' Disabled>
                     <Overlay>
                         @_overlayMenu
                     </Overlay>
@@ -124,7 +124,7 @@
                 </DropdownButton>
 			</SpaceItem>
 			<SpaceItem>
-                <DropdownButton ButtonsRender="ButtonsRender" Loading>
+                <DropdownButton ButtonsRender="ButtonsRender" Loading ButtonsClass="@("demo-dropdown-button1")">
                     <Overlay>
                         @_overlayMenu
                     </Overlay>
@@ -138,7 +138,7 @@
                 </DropdownButton>    
 			</SpaceItem>
 			<SpaceItem>
-                <DropdownButton ButtonsRender="ButtonsRender" >
+                <DropdownButton ButtonsRender="ButtonsRender" ButtonsClass="@(("demo-dropdown-button1", "demo-dropdown-button2"))">
                     <Overlay>
                         @_overlayMenu
                     </Overlay>
@@ -169,6 +169,14 @@
         background: rgb(190, 200, 200);
         padding: 26px 16px 16px;
     }
+
+	.demo-dropdown-button1, .demo-dropdown-button1:hover {
+		background: #f6ffed;
+	}
+	
+	.demo-dropdown-button2, .demo-dropdown-button2:hover {
+		background: #b7eb8f;
+	}
 </style>
 @code
 {

--- a/site/AntDesign.Docs/Demos/Components/Dropdown/doc/index.en-US.md
+++ b/site/AntDesign.Docs/Demos/Components/Dropdown/doc/index.en-US.md
@@ -59,9 +59,11 @@ There are 2 rendering approaches for `Dropdown`:
 | --- | --- | --- | --- |
 | Block | Option to fit button width to its parent width         | bool    | false         | 0.9
 | ButtonsRender |Fully customizable button.         | Func<RenderFragment, RenderFragment, RenderFragment>    | -         | 
+| ButtonsClass |  Allows to set each button's css class either to the same string or separately.   | OneOf<string, (string LeftButton, string RightButton)>    | -         | 0.9
+| ButtonsStyle |  Allows to set each button's style either to the same string or separately.   | OneOf<string, (string LeftButton, string RightButton)>    | -         | 0.9
 | Danger | Set the danger status of button | bool    | false         | 0.9
 | Ghost | Make background transparent and invert text and border colors | bool    | false         | 0.9
 | Icon | Icon (appears on the right) | string | `ellipsis`         | 
 | Loading | Show loading indicator. You have to write the loading logic on your own.         | bool    | false         | 0.9
 | Size | Size of the button, the same as [`Button`](en-US/components/button)         | AntSizeLDSType    | `AntSizeLDSType.Default`         | 
-| Type | Type of the button, the same as [`Button`](en-US/components/button). Left and right button type can be set independently.         | Tuple<(ButtonType LeftButton, ButtonType RightButton)>    | `(LeftButton: ButtonType.Default, RightButton: ButtonType.Default)` | 0.9
+| Type | Type of the button, the same as [`Button`](en-US/components/button). Left and right button type can be set independently.         | OneOf<string, (string LeftButton, string RightButton)>    | `ButtonType.Default` | 0.9

--- a/site/AntDesign.Docs/Demos/Components/Dropdown/doc/index.zh-CN.md
+++ b/site/AntDesign.Docs/Demos/Components/Dropdown/doc/index.zh-CN.md
@@ -60,9 +60,11 @@ There are 2 rendering approaches for `Dropdown`:
 | --- | --- | --- | --- |
 | Block | 将按钮宽度调整为其父宽度的选项        | bool    | false         | 0.9
 | ButtonsRender | 自定义左右两个按钮 | Func<RenderFragment, RenderFragment, RenderFragment>    | -         | 
+| ButtonsClass |  Allows to set each button's css class either to the same string or separately.   | OneOf<string, (string LeftButton, string RightButton)>    | -         | 0.9
+| ButtonsStyle |  Allows to set each button's style either to the same string or separately.   | OneOf<string, (string LeftButton, string RightButton)>    | -         | 0.9
 | Danger | 设置危险按钮 | bool    | false         | 0.9
 | Ghost | 幽灵属性，使按钮背景透明 | bool    | false         | 0.9
 | Icon | 右侧的 icon | string | `ellipsis`         | 
 | Loading | 设置按钮载入状态         | bool    | false         | 0.9
 | Size | 按钮大小，和 [`Button`](zh-CN/components/button) 一致         | AntSizeLDSType    | `AntSizeLDSType.Default`         | 
-| Type | Type of the button, the same as [`Button`](zh-CN/components/button). Left and right button type can be set independently.         | Tuple<(ButtonType LeftButton, ButtonType RightButton)>    | `(LeftButton: ButtonType.Default, RightButton: ButtonType.Default)` | 0.9
+| Type | Type of the button, the same as [`Button`](en-US/components/button). Left and right button type can be set independently.         | OneOf<string, (string LeftButton, string RightButton)>    | `ButtonType.Default` | 0.9

--- a/tests/AntDesign.Tests/Dropdown/DropdownButton/DropdownButtonTests.razor
+++ b/tests/AntDesign.Tests/Dropdown/DropdownButton/DropdownButtonTests.razor
@@ -1,0 +1,135 @@
+﻿@inherits AntDesignTestBase	
+@code {
+
+	[Fact]
+	public void Single_button_style_applied_to_both_buttons()
+	{
+		//Arrange
+		var cut = Render<AntDesign.DropdownButton>(
+			@<DropdownButton ButtonsStyle="@("background-color: #91d5ff;")">
+                    <Overlay>
+						<AntDesing.Menu>
+							<MenuItem>item 1</MenuItem>
+						</AntDesing.Menu>
+                    </Overlay>
+                    <Unbound>Dropdown</Unbound>
+                </DropdownButton>
+		);
+		//Act
+		var buttons = cut.FindAll("[type=button]");
+		//Assert           
+		buttons.Should().HaveCount(2);
+		buttons[0].GetAttribute("style").Should().Be("background-color: #91d5ff;");
+		buttons[1].GetAttribute("style").Should().Be("background-color: #91d5ff;");	
+	}
+
+	[Fact]
+	public void Buttons_style_applied_to_both_buttons()
+	{
+		//Arrange
+		var cut = Render<AntDesign.DropdownButton>(
+			@<DropdownButton ButtonsStyle="@(("background-color: #91d5ff;", "background-color: #fff0f6;"))">
+                    <Overlay>
+						<AntDesing.Menu>
+							<MenuItem>item 1</MenuItem>
+						</AntDesing.Menu>
+                    </Overlay>
+                    <Unbound>Dropdown</Unbound>
+                </DropdownButton>
+		);
+		//Act
+		var buttons = cut.FindAll("[type=button]");
+		//Assert           
+		buttons.Should().HaveCount(2);
+		buttons[0].GetAttribute("style").Should().Be("background-color: #91d5ff;");
+		buttons[1].GetAttribute("style").Should().Be("background-color: #fff0f6;");	
+	}
+
+	[Fact]
+	public void Single_button_class_applied_to_both_buttons()
+	{
+		//Arrange
+		var cut = Render<AntDesign.DropdownButton>(
+			@<DropdownButton ButtonsClass="@("singleClass")">
+                    <Overlay>
+						<AntDesing.Menu>
+							<MenuItem>item 1</MenuItem>
+						</AntDesing.Menu>
+                    </Overlay>
+                    <Unbound>Dropdown</Unbound>
+                </DropdownButton>
+		);
+		//Act
+		var buttons = cut.FindAll("[type=button]");
+		//Assert           
+		buttons.Should().HaveCount(2);
+		buttons[0].GetAttribute("class").Should().Contain("singleClass");
+		buttons[1].GetAttribute("class").Should().Contain("singleClass");	
+	}
+
+	[Fact]
+	public void Buttons_class_applied_to_both_buttons()
+	{
+		//Arrange
+		var cut = Render<AntDesign.DropdownButton>(
+			@<DropdownButton ButtonsClass="@(("leftClass", "rightClass"))">
+                    <Overlay>
+						<AntDesing.Menu>
+							<MenuItem>item 1</MenuItem>
+						</AntDesing.Menu>
+                    </Overlay>
+                    <Unbound>Dropdown</Unbound>
+                </DropdownButton>
+		);
+		//Act
+		var buttons = cut.FindAll("[type=button]");
+		//Assert           
+		buttons.Should().HaveCount(2);
+		buttons[0].GetAttribute("class").Should().Contain("leftClass");
+		buttons[1].GetAttribute("class").Should().Contain("rightClass");	
+	}
+
+	[Fact]
+	public void Single_button_type_applied_to_both_buttons()
+	{
+		//Arrange
+		var cut = Render<AntDesign.DropdownButton>(
+			@<DropdownButton Type="@ButtonType.Primary">
+                    <Overlay>
+						<AntDesing.Menu>
+							<MenuItem>item 1</MenuItem>
+						</AntDesing.Menu>
+                    </Overlay>
+                    <Unbound>Dropdown</Unbound>
+                </DropdownButton>
+		);
+		//Act
+		var buttons = cut.FindAll("[type=button]");
+		//Assert           
+		buttons.Should().HaveCount(2);
+		buttons[0].GetAttribute("class").Should().Contain("ant-btn-primary");
+		buttons[1].GetAttribute("class").Should().Contain("ant-btn-primary");	
+	}
+
+	[Fact]
+	public void Buttons_type_applied_to_both_buttons()
+	{
+		//Arrange
+		var cut = Render<AntDesign.DropdownButton>(
+			@<DropdownButton Type="@((ButtonType.Primary, ButtonType.Dashed))">
+                    <Overlay>
+						<AntDesing.Menu>
+							<MenuItem>item 1</MenuItem>
+						</AntDesing.Menu>
+                    </Overlay>
+                    <Unbound>Dropdown</Unbound>
+                </DropdownButton>
+		);
+		//Act
+		var buttons = cut.FindAll("[type=button]");
+		//Assert           
+		buttons.Should().HaveCount(2);
+		buttons[0].GetAttribute("class").Should().Contain("ant-btn-primary");
+		buttons[1].GetAttribute("class").Should().Contain("ant-btn-dashed");	
+	}
+}

--- a/tests/AntDesign.Tests/Tag/TagTests.razor
+++ b/tests/AntDesign.Tests/Tag/TagTests.razor
@@ -21,7 +21,7 @@
 	public void Renders_predefined_tag(string color)
 	{
 		var cut = Context.Render(@<AntDesign.Tag Color="@color">Tag 1</AntDesign.Tag>);		
-		cut.MarkupMatches(@<span class="ant-tag ant-tag-@color" id:ignore>Tag 1</span>);
+		cut.MarkupMatches(@<span class="ant-tag ant-tag-@color" id:ignore style:ignore>Tag 1</span>);
 	}
 
 	[Fact]


### PR DESCRIPTION
### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [x] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [x] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)


### 💡 Background and solution
1. Adds ability to add css class & style to each button.
2. Refactored razor file to use `RenderFragment` template. This is simplifying testing (no need to do separate tests for `Unbound` and `ChildContent` versions).
3. Switched `Type` to `OneOf` to simplify user experience when using the same type for both buttons.
4. Altered demo to show the usage of new properties

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add `ButtonsStyle` & `ButtonsClass` parameters that allow to style each button separately. `Type` accepts single value that will be applied to both buttons. |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
