### PR TITLE
fix(module: upload): treat 2xx response codes success

### DIFF
--- a/components/core/JsInterop/interop.ts
+++ b/components/core/JsInterop/interop.ts
@@ -125,7 +125,8 @@ export function uploadFile(element, index, data, headers, fileId, url, name, ins
   const req = new XMLHttpRequest()
   req.onreadystatechange = function () {
     if (req.readyState === 4) {
-      if (req.status != 200) {
+      // #1655 Any 2xx response code is okay
+      if (req.status < 200 || req.status > 299) {
         instance.invokeMethodAsync(errorMethod, fileId, `{"status": ${req.status}}`);
         return;
       }


### PR DESCRIPTION
Treat all 2xx status codes as success in the upload module.

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
#1655 (The 'Upload' component will treat the 201 (created) HTTP status code as a failure result)

### 💡 Background and solution
Depending on how the server receiving to the uploaded file is configured, successful requests might not be responded with 200 as a status code. Fix is to be less strict and treat any 2xx status code as successful.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Treat all 2xx status codes in responses in the upload module as successful |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
