### PR TITLE
fix(module:CountDown): fix CountDown OnFinish callback exception(#1712)

### DIFF
--- a/components/statistic/CountDown.razor.cs
+++ b/components/statistic/CountDown.razor.cs
@@ -37,7 +37,7 @@ namespace AntDesign
                 _timer.Dispose();
                 if (OnFinish.HasDelegate)
                 {
-                    OnFinish.InvokeAsync(o);
+                    InvokeAsync(() => OnFinish.InvokeAsync(o));
                 }
             }
 


### PR DESCRIPTION
Calls to OnFinish callback now won't cause InvalidOperationException.

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
https://github.com/ant-design-blazor/ant-design-blazor/issues/1712


### 💡 Background and solution

Use InvokeAsync for OnFinish call

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
