### PR TITLE
fix(module: select): can not set initial value for non-datasource approach

### DIFF
--- a/components/select/Select.razor.cs
+++ b/components/select/Select.razor.cs
@@ -421,6 +421,7 @@ namespace AntDesign
         private IEnumerable<TItemValue> _defaultValues;
         private bool _defaultValuesHasItems;
         private bool _isInitialized;
+        private bool _optionsHasInitialized;
         private bool _defaultValueApplied;
         private bool _defaultActiveFirstOptionApplied;
         private bool _waittingStateChange;
@@ -516,7 +517,7 @@ namespace AntDesign
                 if (!_showArrowIconChanged && SelectMode != SelectMode.Default)
                     _showArrowIcon = SuffixIcon != null;
             }
-            //_isInitialized = true;
+            _isInitialized = true;
 
             base.OnInitialized();
         }
@@ -524,9 +525,12 @@ namespace AntDesign
         protected override void OnParametersSet()
         {
             if (SelectOptions == null)
+            {
                 CreateDeleteSelectOptions();
+                _optionsHasInitialized = true;
+            }
 
-            if (_valueHasChanged && _isInitialized)
+            if (_valueHasChanged && _optionsHasInitialized)
             {
                 _valueHasChanged = false;
                 OnValueChange(_selectedValue);
@@ -536,13 +540,16 @@ namespace AntDesign
                 }
             }
 
-            _isInitialized = true;
-
             base.OnParametersSet();
         }
 
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
+            if (SelectOptions != null)
+            {
+                _optionsHasInitialized = true;
+            }
+
             if (firstRender)
             {
                 await SetInitialValuesAsync();
@@ -575,7 +582,10 @@ namespace AntDesign
             }
 
             if (_isInitialized && SelectOptions == null)
+            {
                 CreateDeleteSelectOptions();
+                _optionsHasInitialized = true;
+            }
 
             if (_waittingStateChange)
             {
@@ -1312,7 +1322,7 @@ namespace AntDesign
         /// </summary>
         protected override void OnValueChange(TItemValue value)
         {
-            if (!_isInitialized) // This is important because otherwise the initial value is overwritten by the EventCallback of ValueChanged and would be NULL.
+            if (!_optionsHasInitialized) // This is important because otherwise the initial value is overwritten by the EventCallback of ValueChanged and would be NULL.
                 return;
 
             if (!_isValueEnum && EqualityComparer<TItemValue>.Default.Equals(value, default))

--- a/components/select/Select.razor.cs
+++ b/components/select/Select.razor.cs
@@ -516,12 +516,12 @@ namespace AntDesign
                 if (!_showArrowIconChanged && SelectMode != SelectMode.Default)
                     _showArrowIcon = SuffixIcon != null;
             }
-            _isInitialized = true;
+            //_isInitialized = true;
 
             base.OnInitialized();
         }
 
-        protected override async Task OnParametersSetAsync()
+        protected override void OnParametersSet()
         {
             if (SelectOptions == null)
                 CreateDeleteSelectOptions();
@@ -535,8 +535,10 @@ namespace AntDesign
                     EditContext?.NotifyFieldChanged(FieldIdentifier);
                 }
             }
-            
-            await base.OnParametersSetAsync();
+
+            _isInitialized = true;
+
+            base.OnParametersSet();
         }
 
         protected override async Task OnAfterRenderAsync(bool firstRender)


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
Fixes #1735

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->
A sample:
![image](https://user-images.githubusercontent.com/54608128/126035136-97dbc0d7-bef1-40c4-bb03-78986c1b6ca8.png)

This issue is introduced by #1720 . In #1720, I changed the position to call `OnValueChange` method. In most cases, this change is safe. However, `OnValueChange` should do nothing for the first call(by evaluating the `_isInitialized` field), but the method is now first called after `_isInitialized` is set to `true`. We can solve this issue by simply move `_isInitialized = true;` to after the call to `OnValueChange`. Let me know if you think we should use a new variable or variable name in this case.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix the issue that can not set select component initial value for non-datasource approach  |
| 🇨🇳 Chinese | 修复当使用SelectOption方案时不能为Select组件设置初始值的问题 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
