### PR TITLE
fix(module:select): duplicated tags

### DIFF
--- a/components/select/Select.razor.cs
+++ b/components/select/Select.razor.cs
@@ -12,6 +12,7 @@ using AntDesign.Select.Internal;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using OneOf;
+using OneOf.Types;
 
 #pragma warning disable 1591 // Disable missing XML comment
 #pragma warning disable CA1716 // Disable Select name warning
@@ -438,7 +439,7 @@ namespace AntDesign
         internal List<SelectOptionItem<TItemValue, TItem>> SelectedOptionItems { get; } = new List<SelectOptionItem<TItemValue, TItem>>();
         internal List<SelectOptionItem<TItemValue, TItem>> AddedTags { get; } = new List<SelectOptionItem<TItemValue, TItem>>();
         internal SelectOptionItem<TItemValue, TItem> CustomTagSelectOptionItem { get; set; }
-
+        
         /// <summary>
         /// Currently active (highlighted) option.
         /// It does not have to be equal to selected option.
@@ -930,7 +931,9 @@ namespace AntDesign
                     SelectedOptionItems[0] = selectOption;
                 }
                 else
+                {
                     SelectedOptionItems.Add(selectOption);
+                }
 
                 selectOption.IsSelected = true;
                 await ValueChanged.InvokeAsync(selectOption.Value);
@@ -1013,7 +1016,9 @@ namespace AntDesign
                         firstEnabled.IsHidden = true;
 
                     if (SelectedOptionItems.Count == 0)
+                    {
                         SelectedOptionItems.Add(firstEnabled);
+                    }
                     else
                         SelectedOptionItems[0] = firstEnabled;
 
@@ -1063,7 +1068,9 @@ namespace AntDesign
 
                     _waittingStateChange = true;
                     if (SelectedOptionItems.Count == 0)
+                    {
                         SelectedOptionItems.Add(result);
+                    }
                     else
                         SelectedOptionItems[0] = result;
                     await ValueChanged.InvokeAsync(result.Value);
@@ -1385,7 +1392,9 @@ namespace AntDesign
                 }
             }
             else
+            {
                 SelectedOptionItems.Add(optionItem);
+            }
         }
 
         /// <summary>

--- a/components/select/SelectOption.razor.cs
+++ b/components/select/SelectOption.razor.cs
@@ -249,8 +249,9 @@ namespace AntDesign
         {
             if (SelectParent?.SelectOptions != null)
             {
-                // The SelectOptionItem must be explicitly removed if the SelectOption was not created using the DataSource.
-                var selectOptionItem = SelectParent.SelectOptionItems.FirstOrDefault(x => x.InternalId == InternalId);
+                // The SelectOptionItem must be explicitly removed if the SelectOption was not created using the DataSource .
+                var selectOptionItem = SelectParent.SelectOptionItems
+                    .FirstOrDefault(x => x.InternalId == InternalId && !x.IsSelected);
                 if (selectOptionItem is not null)
                     SelectParent.SelectOptionItems.Remove(selectOptionItem);
             }

--- a/components/select/internal/SelectContent.razor
+++ b/components/select/internal/SelectContent.razor
@@ -145,7 +145,7 @@ else //ParentSelect.SelectMode != SelectMode.Default
                             <span class="@Prefix-selection-item">
                                 <span class="@Prefix-selection-item-content">@FormatLabel(selectedOption.Label)</span>
                                 <span unselectable="on" aria-hidden="true" style="user-select: none;" class="@Prefix-selection-item-remove"
-                                        @onmousedown="()=> OnRemoveSelected.InvokeAsync(selectedOption)" onclick="event.stopPropagation()">
+                                        @onmousedown="(e)=> RemoveClicked(e, selectedOption)" onclick="event.stopPropagation()">
                                     <Icon Type="close"></Icon>
                                 </span>
                             </span>
@@ -191,7 +191,7 @@ else //ParentSelect.SelectMode != SelectMode.Default
                             <span class="@Prefix-selection-item">
                                 <span class="@Prefix-selection-item-content">@FormatLabel(selectedOption.Label)</span>
                                 <span unselectable="on" aria-hidden="true" style="user-select: none;" class="@Prefix-selection-item-remove"
-                                        @onmousedown="()=> OnRemoveSelected.InvokeAsync(selectedOption)" onclick="event.stopPropagation()">
+                                        @onmousedown="(e)=> RemoveClicked(e, selectedOption)" onclick="event.stopPropagation()">
                                     <Icon Type="close"></Icon>
                                 </span>
                             </span>
@@ -235,7 +235,7 @@ else //ParentSelect.SelectMode != SelectMode.Default
                             <span class="@Prefix-selection-item">
                                 <span class="@Prefix-selection-item-content">@FormatLabel(selectedOption.Label)</span>
                                 <span unselectable="on" aria-hidden="true" style="user-select: none;" class="@Prefix-selection-item-remove"
-                                        @onmousedown="()=> OnRemoveSelected.InvokeAsync(selectedOption)" onclick="event.stopPropagation()">
+                                        @onmousedown="(e)=> RemoveClicked(e, selectedOption)" onclick="event.stopPropagation()">
                                     <Icon Type="close"></Icon>
                                 </span>
                             </span>

--- a/components/select/internal/SelectContent.razor.cs
+++ b/components/select/internal/SelectContent.razor.cs
@@ -378,6 +378,14 @@ namespace AntDesign.Select.Internal
             await OnClearClick.InvokeAsync(args);
         }
 
+        private async Task RemoveClicked(MouseEventArgs e, SelectOptionItem<TItemValue, TItem> selectedOption)
+        {
+            if (e.Button == 0)
+            {
+                await OnRemoveSelected.InvokeAsync(selectedOption);
+            }
+        }
+
         //TODO: Use built in @onfocus once https://github.com/dotnet/aspnetcore/issues/30070 is solved
         private async void OnFocusInternal(JsonElement e) => await OnFocus.InvokeAsync(new());
 

--- a/tests/AntDesign.Tests/Select/Form/Select.MultipleTests.razor
+++ b/tests/AntDesign.Tests/Select/Form/Select.MultipleTests.razor
@@ -9,7 +9,7 @@
     Persons _model = new();
     IEnumerable<string> _datasource = new List<string>{ "Lucy", "John", "Jack", "Emily" };	
 
-#if NET6_0
+#if NET6_0_OR_GREATER
     [Fact]
 	public void Select_Validation_Shown() 
     {

--- a/tests/AntDesign.Tests/Select/Select.Tags.Tests.razor
+++ b/tests/AntDesign.Tests/Select/Select.Tags.Tests.razor
@@ -1,0 +1,47 @@
+﻿@inherits AntDesignTestBase
+@code {
+
+    [Fact]
+    public async Task Single_tag_creation() //issue #1645
+    {
+        //Arrange
+        JSInterop.Setup<AntDesign.JsInterop.DomRect>(JSInteropConstants.GetBoundingClientRect, _ => true)
+            .SetResult(new AntDesign.JsInterop.DomRect());         			
+		JSInterop.Setup<HtmlElement>(JSInteropConstants.GetDomInfo, _ => true)
+            .SetResult(new HtmlElement());        
+		JSInterop.SetupVoid(JSInteropConstants.AddPreventKeys, _ => true);		
+		JSInterop.SetupVoid(JSInteropConstants.AddElementTo, _ => true);		
+		#if !NET6_0_OR_GREATER
+			JSInterop.SetupVoid(JSInteropConstants.Focus, _ => true);
+		#endif
+
+        var cut = Render<AntDesign.Select<string, string>>(
+        @<AntDesign.Select Mode="tags"        		
+			TItemValue="string"
+			TItem="string"		
+			EnableSearch>
+			<SelectOptions>						
+				<SelectOption TItemValue="string" TItem="string" Value="@("1")" Label="1" />			
+			</SelectOptions>
+		</AntDesign.Select>
+	);
+		//Act
+		var input = cut.Find("input.ant-select-selection-search-input");
+		input.Input("A");
+		await Task.Delay(1);
+		input.KeyUp("ENTER");
+		await Task.Delay(1);
+		input.Input("B");
+		await Task.Delay(1);
+		input.KeyUp("ENTER");
+		await Task.Delay(1);
+		input.Input("C");
+		await Task.Delay(1);
+		input.KeyUp("ENTER");
+		await Task.Delay(1);
+		var addedTags = cut.FindAll("span.ant-select-selection-item-content")
+			.Where(d => d.TextContent.Trim() == "B");
+		//Assert
+		addedTags.Should().HaveCount(1);
+    }
+}


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
1. Fixes #1645 
2. Any mouse button click on "x" in selected item is removing it.

### 💡 Background and solution
1. `SelectOption` was being removed in the `Dispose()` method irrespective of it being selected. `Dispose` method now checks if `SelectOption` is selected and prevents removing.
2. Selected item will be removed only if the "x" receives left mouse button click.
### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
