### PR TITLE
fix(module:tree) Fix parent checkbox state calculation (ant-design-blazor#1770)

### DIFF
--- a/components/tree/TreeNode.razor.cs
+++ b/components/tree/TreeNode.razor.cs
@@ -495,7 +495,6 @@ namespace AntDesign
                 {
                     if (!item.DisableCheckbox && !item.Disabled)
                     {
-                        if (item.Indeterminate == true) break;
                         if (item.Checked == true) hasChecked = true;
                         if (item.Checked == false) hasUnchecked = true;
                     }


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/ant-design-blazor/ant-design-blazor/issues/1770

### 💡 Background and solution

Once the short-circuit optimization removed, the state of a parent node's checkbox is calculated correctly.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix parent checkbox state calculation in a Tree |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
