### PR TITLE
fix(module: date-picker): fix ShowToday when ShowTime is true (#1817)

### DIFF
--- a/components/date-picker/internal/DatePickerDatetimePanel.razor
+++ b/components/date-picker/internal/DatePickerDatetimePanel.razor
@@ -175,12 +175,15 @@
 
 <div class="@(PrefixCls)-footer">
     <ul class="@(PrefixCls)-ranges">
-        <li class="@(PrefixCls)-now">
-            <a class="@(PrefixCls)-now-btn"
-               @onclick="e => { OnSelectTime(DateTime.Now); Close(); }">
-                @Locale.Lang.Now
-            </a>
-        </li>
+        @if (ShowToday)
+        {
+            <li class="@(PrefixCls)-now">
+                <a class="@(PrefixCls)-now-btn"
+                @onclick="e => { OnSelectTime(DateTime.Now); Close(); }">
+                    @Locale.Lang.Now
+                </a>
+            </li>            
+        }
         <li class="@(PrefixCls)-ok">
             <Button Type="@ButtonType.Primary"
                        OnClick="OnOkClick">


### PR DESCRIPTION


### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

#1817 `ShowToday = false` was not working when `ShowTime` was set to `true`

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | DatePicker: fix ShowToday behaviour when ShowTime set to true |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
