### PR TITLE
fix(module: menu): menu item click event should be triggered when menu selectable is false

### DIFF
--- a/components/menu/Menu.razor.cs
+++ b/components/menu/Menu.razor.cs
@@ -157,9 +157,6 @@ namespace AntDesign
 
             StateHasChanged();
 
-            if (OnMenuItemClicked.HasDelegate)
-                OnMenuItemClicked.InvokeAsync(item);
-
             if (SelectedKeysChanged.HasDelegate)
                 SelectedKeysChanged.InvokeAsync(_selectedKeys);
 

--- a/components/menu/MenuItem.razor.cs
+++ b/components/menu/MenuItem.razor.cs
@@ -105,7 +105,14 @@ namespace AntDesign
                 return;
 
             if (OnClick.HasDelegate)
+            {
                 await OnClick.InvokeAsync(args);
+            }
+
+            if (RootMenu?.OnMenuItemClicked.HasDelegate == true)
+            {
+                await RootMenu.OnMenuItemClicked.InvokeAsync(this);
+            }
 
             if (!RootMenu.Selectable)
                 return;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->


fixed #1691

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   menu item click event should be triggered when menu selectable is false        |
| 🇨🇳 Chinese |   修复  menu item 的点击事件在 `Selectable=false` 时不触发的问题      |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
