### PR TITLE
Add Date filter to the DateTime column of table 

### DIFF
--- a/components/locales/en-US.json
+++ b/components/locales/en-US.json
@@ -149,7 +149,8 @@
       "greaterThanOrEquals": "Greater Than Or Equals",
       "lessThanOrEquals": "Less Than Or Equals",
       "isNull": "Is Null",
-      "isNotNull": "Is Not Null"
+      "isNotNull": "Is Not Null",
+      "theSameDateWith": "The Same Date With"
     }
   },
   "Modal": {

--- a/components/locales/zh-CN.json
+++ b/components/locales/zh-CN.json
@@ -149,7 +149,8 @@
       "greaterThanOrEquals": "大于或等于",
       "lessThanOrEquals": "小于或等于",
       "isNull": "为 Null",
-      "isNotNull": "不为 Null"
+      "isNotNull": "不为 Null",
+      "theSameDateWith": "等于该日期"
     }
   },
   "Modal": {

--- a/components/table/Column.razor
+++ b/components/table/Column.razor
@@ -253,6 +253,15 @@ else if (IsBody && RowSpan != 0 && ColSpan != 0)
                                                             <SelectOption TItem="TableFilterCompareOperator" TItemValue="TableFilterCompareOperator" Value="@TableFilterCompareOperator.Contains" Label="@Table?.Locale.FilterOptions.Contains"></SelectOption>
                                                             <SelectOption TItem="TableFilterCompareOperator" TItemValue="TableFilterCompareOperator" Value="@TableFilterCompareOperator.NotContains" Label="@Table?.Locale.FilterOptions.NotContains"></SelectOption>
                                                         }
+                                                        else if (_columnDataType == typeof(DateTime))
+                                                        {
+                                                            <SelectOption TItem="TableFilterCompareOperator" TItemValue="TableFilterCompareOperator" Value="@TableFilterCompareOperator.GreaterThan" Label="@Table?.Locale.FilterOptions.GreaterThan"></SelectOption>
+                                                            <SelectOption TItem="TableFilterCompareOperator" TItemValue="TableFilterCompareOperator" Value="@TableFilterCompareOperator.LessThan" Label="@Table?.Locale.FilterOptions.LessThan"></SelectOption>
+                                                            <SelectOption TItem="TableFilterCompareOperator" TItemValue="TableFilterCompareOperator" Value="@TableFilterCompareOperator.GreaterThanOrEquals" Label="@Table?.Locale.FilterOptions.GreaterThanOrEquals"></SelectOption>
+                                                            <SelectOption TItem="TableFilterCompareOperator" TItemValue="TableFilterCompareOperator" Value="@TableFilterCompareOperator.LessThanOrEquals" Label="@Table?.Locale.FilterOptions.LessThanOrEquals"></SelectOption>
+                                                            <SelectOption TItem="TableFilterCompareOperator" TItemValue="TableFilterCompareOperator" Value="@TableFilterCompareOperator.TheSameDateWith" Label="@Table?.Locale.FilterOptions.TheSameDateWith"></SelectOption>
+                                                            <SelectOption TItem="TableFilterCompareOperator" TItemValue="TableFilterCompareOperator" Value="@TableFilterCompareOperator.TheSameMonthWith" Label="@Table?.Locale.FilterOptions.TheSameMonthWith"></SelectOption>
+                                                        }
                                                         else if (_columnDataType == typeof(Guid)) { }
                                                         else
                                                         {
@@ -314,7 +323,7 @@ else if (IsBody && RowSpan != 0 && ColSpan != 0)
     @<Template>
         @if (_columnDataType == typeof(DateTime))
         {
-            <DatePicker Value="(DateTime?)filter.Value" Format="@Format" TValue="DateTime?" ValueChanged="value => SetFilterValue(filter, value)" PopupContainerSelector="@("#popup-container-for-" + Id)"></DatePicker>
+            <DatePicker Value="(DateTime?)filter.Value" ShowTime="@true" TValue="DateTime?" ValueChanged="value => SetFilterValue(filter, value?.AddMilliseconds(-value.Value.Millisecond))" PopupContainerSelector="@("#popup-container-for-" + Id)"></DatePicker>
         }
         else if (_columnDataType.IsEnum)
         {

--- a/components/table/Column.razor
+++ b/components/table/Column.razor
@@ -323,7 +323,8 @@ else if (IsBody && RowSpan != 0 && ColSpan != 0)
     @<Template>
         @if (_columnDataType == typeof(DateTime))
         {
-            <DatePicker Value="(DateTime?)filter.Value" ShowTime="@true" TValue="DateTime?" ValueChanged="value => SetFilterValue(filter, value?.AddMilliseconds(-value.Value.Millisecond))" PopupContainerSelector="@("#popup-container-for-" + Id)"></DatePicker>
+            <DatePicker Value="(DateTime?)filter.Value" ShowTime="@(filter.FilterCompareOperator != TableFilterCompareOperator.TheSameDateWith && filter.FilterCompareOperator != TableFilterCompareOperator.TheSameMonthWith)"
+                        TValue="DateTime?" ValueChanged="value => SetFilterValue(filter, value?.AddMilliseconds(-value.Value.Millisecond))" PopupContainerSelector="@("#popup-container-for-" + Id)"></DatePicker>
         }
         else if (_columnDataType.IsEnum)
         {

--- a/components/table/Column.razor
+++ b/components/table/Column.razor
@@ -62,7 +62,7 @@ else if (IsHeader && HeaderColSpan != 0)
                 @HeaderTitle
             }
         </th>
-    </CascadingValue>    
+    </CascadingValue>
 }
 else if (IsBody && RowSpan != 0 && ColSpan != 0)
 {
@@ -117,7 +117,7 @@ else if (IsBody && RowSpan != 0 && ColSpan != 0)
                 }
             }
         </td>
-    </CascadingValue>    
+    </CascadingValue>
 }
 
 @code
@@ -314,7 +314,7 @@ else if (IsBody && RowSpan != 0 && ColSpan != 0)
     @<Template>
         @if (_columnDataType == typeof(DateTime))
         {
-            <DatePicker Value="(DateTime?)filter.Value" ShowTime="@true" TValue="DateTime?" ValueChanged="value => SetFilterValue(filter, value?.AddMilliseconds(-value.Value.Millisecond))" PopupContainerSelector="@("#popup-container-for-" + Id)"></DatePicker>
+            <DatePicker Value="(DateTime?)filter.Value" Format="@Format" TValue="DateTime?" ValueChanged="value => SetFilterValue(filter, value)" PopupContainerSelector="@("#popup-container-for-" + Id)"></DatePicker>
         }
         else if (_columnDataType.IsEnum)
         {

--- a/components/table/Column.razor
+++ b/components/table/Column.razor
@@ -260,7 +260,6 @@ else if (IsBody && RowSpan != 0 && ColSpan != 0)
                                                             <SelectOption TItem="TableFilterCompareOperator" TItemValue="TableFilterCompareOperator" Value="@TableFilterCompareOperator.GreaterThanOrEquals" Label="@Table?.Locale.FilterOptions.GreaterThanOrEquals"></SelectOption>
                                                             <SelectOption TItem="TableFilterCompareOperator" TItemValue="TableFilterCompareOperator" Value="@TableFilterCompareOperator.LessThanOrEquals" Label="@Table?.Locale.FilterOptions.LessThanOrEquals"></SelectOption>
                                                             <SelectOption TItem="TableFilterCompareOperator" TItemValue="TableFilterCompareOperator" Value="@TableFilterCompareOperator.TheSameDateWith" Label="@Table?.Locale.FilterOptions.TheSameDateWith"></SelectOption>
-                                                            <SelectOption TItem="TableFilterCompareOperator" TItemValue="TableFilterCompareOperator" Value="@TableFilterCompareOperator.TheSameMonthWith" Label="@Table?.Locale.FilterOptions.TheSameMonthWith"></SelectOption>
                                                         }
                                                         else if (_columnDataType == typeof(Guid)) { }
                                                         else
@@ -323,7 +322,7 @@ else if (IsBody && RowSpan != 0 && ColSpan != 0)
     @<Template>
         @if (_columnDataType == typeof(DateTime))
         {
-            <DatePicker Value="(DateTime?)filter.Value" ShowTime="@(filter.FilterCompareOperator != TableFilterCompareOperator.TheSameDateWith && filter.FilterCompareOperator != TableFilterCompareOperator.TheSameMonthWith)"
+            <DatePicker Value="(DateTime?)filter.Value" ShowTime="@(filter.FilterCompareOperator != TableFilterCompareOperator.TheSameDateWith)"
                         TValue="DateTime?" ValueChanged="value => SetFilterValue(filter, value?.AddMilliseconds(-value.Value.Millisecond))" PopupContainerSelector="@("#popup-container-for-" + Id)"></DatePicker>
         }
         else if (_columnDataType.IsEnum)

--- a/components/table/FilterExpression/DateFilterExpression.cs
+++ b/components/table/FilterExpression/DateFilterExpression.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
+using System.Reflection;
 using System.Text;
 
 namespace AntDesign.FilterExpression
@@ -17,6 +18,8 @@ namespace AntDesign.FilterExpression
         }
         public Expression GetFilterExpression(TableFilterCompareOperator compareOperator, Expression leftExpr, Expression rightExpr)
         {
+            leftExpr = Expression.Property(leftExpr, "Date");
+            rightExpr = Expression.Property(rightExpr, "Date");
             switch (compareOperator)
             {
                 case TableFilterCompareOperator.IsNull:

--- a/components/table/FilterExpression/DateFilterExpression.cs
+++ b/components/table/FilterExpression/DateFilterExpression.cs
@@ -12,7 +12,7 @@ namespace AntDesign.FilterExpression
 {
     public class DateFilterExpression : IFilterExpression
     {
-        public TableFilterCompareOperator GetDefaultCampareOperator()
+        public TableFilterCompareOperator GetDefaultCompareOperator()
         {
             return TableFilterCompareOperator.Equals;
         }

--- a/components/table/FilterExpression/DateFilterExpression.cs
+++ b/components/table/FilterExpression/DateFilterExpression.cs
@@ -35,11 +35,8 @@ namespace AntDesign.FilterExpression
                 case TableFilterCompareOperator.LessThanOrEquals:
                     return Expression.LessThanOrEqual(leftExpr, rightExpr);
                 case TableFilterCompareOperator.TheSameDateWith:
-                    return Expression.LessThanOrEqual(Expression.Property(leftExpr, "Date"),
+                    return Expression.Equal(Expression.Property(leftExpr, "Date"),
                         Expression.Property(rightExpr, "Date"));
-                case TableFilterCompareOperator.TheSameMonthWith:
-                    return Expression.LessThanOrEqual(Expression.Property(leftExpr, "Month"),
-                        Expression.Property(rightExpr, "Month"));
             }
             throw new InvalidOperationException();
         }

--- a/components/table/FilterExpression/DateFilterExpression.cs
+++ b/components/table/FilterExpression/DateFilterExpression.cs
@@ -18,8 +18,6 @@ namespace AntDesign.FilterExpression
         }
         public Expression GetFilterExpression(TableFilterCompareOperator compareOperator, Expression leftExpr, Expression rightExpr)
         {
-            leftExpr = Expression.Property(leftExpr, "Date");
-            rightExpr = Expression.Property(rightExpr, "Date");
             switch (compareOperator)
             {
                 case TableFilterCompareOperator.IsNull:
@@ -36,6 +34,12 @@ namespace AntDesign.FilterExpression
                     return Expression.LessThan(leftExpr, rightExpr);
                 case TableFilterCompareOperator.LessThanOrEquals:
                     return Expression.LessThanOrEqual(leftExpr, rightExpr);
+                case TableFilterCompareOperator.TheSameDateWith:
+                    return Expression.LessThanOrEqual(Expression.Property(leftExpr, "Date"),
+                        Expression.Property(rightExpr, "Date"));
+                case TableFilterCompareOperator.TheSameMonthWith:
+                    return Expression.LessThanOrEqual(Expression.Property(leftExpr, "Month"),
+                        Expression.Property(rightExpr, "Month"));
             }
             throw new InvalidOperationException();
         }

--- a/components/table/FilterExpression/EnumFilterExpression.cs
+++ b/components/table/FilterExpression/EnumFilterExpression.cs
@@ -12,7 +12,7 @@ namespace AntDesign.FilterExpression
 {
     public class EnumFilterExpression : IFilterExpression
     {
-        public TableFilterCompareOperator GetDefaultCampareOperator()
+        public TableFilterCompareOperator GetDefaultCompareOperator()
         {
             return TableFilterCompareOperator.Equals;
         }

--- a/components/table/FilterExpression/GuidFilterExpression.cs
+++ b/components/table/FilterExpression/GuidFilterExpression.cs
@@ -12,7 +12,7 @@ namespace AntDesign.FilterExpression
 {
     public class GuidFilterExpression : IFilterExpression
     {
-        public TableFilterCompareOperator GetDefaultCampareOperator()
+        public TableFilterCompareOperator GetDefaultCompareOperator()
         {
             return TableFilterCompareOperator.Equals;
         }

--- a/components/table/FilterExpression/IFilterExpression.cs
+++ b/components/table/FilterExpression/IFilterExpression.cs
@@ -11,7 +11,7 @@ namespace AntDesign.FilterExpression
 {
     public interface IFilterExpression
     {
-        TableFilterCompareOperator GetDefaultCampareOperator();
+        TableFilterCompareOperator GetDefaultCompareOperator();
         Expression GetFilterExpression(TableFilterCompareOperator compareOperator, Expression leftExpr, Expression rightExpr);
     }
 }

--- a/components/table/FilterExpression/NumberFilterExpression.cs
+++ b/components/table/FilterExpression/NumberFilterExpression.cs
@@ -17,7 +17,7 @@ namespace AntDesign.FilterExpression
             _type = type;
         }
 
-        public TableFilterCompareOperator GetDefaultCampareOperator()
+        public TableFilterCompareOperator GetDefaultCompareOperator()
         {
             return TableFilterCompareOperator.Equals;
         }

--- a/components/table/FilterExpression/StringFilterExpression.cs
+++ b/components/table/FilterExpression/StringFilterExpression.cs
@@ -12,7 +12,7 @@ namespace AntDesign.FilterExpression
 {
     public class StringFilterExpression : IFilterExpression
     {
-        public TableFilterCompareOperator GetDefaultCampareOperator()
+        public TableFilterCompareOperator GetDefaultCompareOperator()
         {
             return TableFilterCompareOperator.Contains;
         }

--- a/components/table/TableFilter.cs
+++ b/components/table/TableFilter.cs
@@ -48,7 +48,6 @@ namespace AntDesign
         IsNotNull = 12,
         NotContains = 13,
         TheSameDateWith = 14,
-        TheSameMonthWith = 15,
     }
 
     public enum TableFilterCondition

--- a/components/table/TableFilter.cs
+++ b/components/table/TableFilter.cs
@@ -47,6 +47,8 @@ namespace AntDesign
         IsNull = 11,
         IsNotNull = 12,
         NotContains = 13,
+        TheSameDateWith = 14,
+        TheSameMonthWith = 15,
     }
 
     public enum TableFilterCondition

--- a/components/table/TableLocale.cs
+++ b/components/table/TableLocale.cs
@@ -68,5 +68,9 @@ namespace AntDesign
         public string IsNull { get; set; } = "Is Null";
 
         public string IsNotNull { get; set; } = "Is Not Null";
+
+        public string TheSameDateWith { get; set; } = "The Same Date With";
+
+        public string TheSameMonthWith { get; set; } = "The Same Month With";
     }
 }

--- a/components/table/TableLocale.cs
+++ b/components/table/TableLocale.cs
@@ -70,7 +70,5 @@ namespace AntDesign
         public string IsNotNull { get; set; } = "Is Not Null";
 
         public string TheSameDateWith { get; set; } = "The Same Date With";
-
-        public string TheSameMonthWith { get; set; } = "The Same Month With";
     }
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [x] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
Fixes #1854 

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->
The purpose of this PR is to modify the expected behavior of the default filter for the `DateTime` column of the table. The original default filter eliminates the milliseconds of the selected time when filtering, but does not eliminate the milliseconds in the data, resulting in the Equal option never being obtained the expected result.
I think that usually only the year, month and day need to be considered when filtering the `DateTime` in the table, so the PR only keeps the year, month and day in the options and data when filtering, and removes the rest of the data. 

And this PR also fixes a spelling error.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  rename `GetDefaultCampareOperator` to `GetDefaultCompareOperator`  and add `leftExpr = Expression.Property(leftExpr, "Date");` before compare the `DateTime`         |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
