### PR TITLE
fix(module:checkboxGroup): option change does not lock checkboxes

### DIFF
--- a/components/checkbox/CheckboxGroup.razor.cs
+++ b/components/checkbox/CheckboxGroup.razor.cs
@@ -19,6 +19,10 @@ namespace AntDesign
             {
                 _options = value;
                 _isOptionDefined = true;
+                if (_afterFirstRender)
+                {
+                    _currentValue = GetCurrentValueFunc();
+                }
             }
         }
 


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
Fixes #1716

### 💡 Background and solution
When `Options` is changing, an attached function that calculates `CheckboxGroup` current value should also be changed. This PR is forcing the change.

#### However
I see another issue here which is tightly connected to performance. Currently. because `Options` are `OneOf`, the reset of its value is done on basically any action done on the component (so clicking on a single checkbox in the group triggers the `Options` to be set again). This I think is due to the fact that `Options` is not a primitive type (as stated in #992). In this case though I do not think we can use a primitive type. What we could use is a class that will internally hold `CheckboxOption` array and will also internally monitor for the changes. My idea here is that such class could very quickly know if it changed and a simple comparison could be done to find out if a change really happen. Then, if it did, appropriate action could be called (like clearing current value of the options and reset the aforementioned function responsible for calculation).





### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
