### PR TITLE
fix(module:textarea): add rows parameter

### DIFF
--- a/components/core/JsInterop/JSInteropConstants.cs
+++ b/components/core/JsInterop/JSInteropConstants.cs
@@ -184,6 +184,7 @@ namespace AntDesign
         {
             private const string FUNC_PREFIX = JSInteropConstants.FUNC_PREFIX + "inputHelper.";
             public static string RegisterResizeTextArea => $"{FUNC_PREFIX}registerResizeTextArea";
+            public static string GetTextAreaInfo => $"{FUNC_PREFIX}getTextAreaInfo";
             public static string DisposeResizeTextArea => $"{FUNC_PREFIX}disposeResizeTextArea";
             public static string SetSelectionStart => $"{FUNC_PREFIX}setSelectionStart";
         }

--- a/components/core/JsInterop/modules/components/inputHelper.ts
+++ b/components/core/JsInterop/modules/components/inputHelper.ts
@@ -1,10 +1,10 @@
-﻿import { domInfoHelper, eventHelper } from '../dom/exports'
+﻿import { domInfoHelper } from '../dom/exports'
 import { state } from '../stateProvider';
 
 
 export class inputHelper {
 
-  private static getTextAreaInfo(element) {
+  static getTextAreaInfo(element) {
     var result = {};
     var dom = domInfoHelper.get(element);
     if (!dom) return null;
@@ -32,7 +32,7 @@ export class inputHelper {
     return result;
   }
 
-  static registerResizeTextArea(element, minRows, maxRows, objReference) {
+  static registerResizeTextArea(element: HTMLTextAreaElement, minRows: number, maxRows: number, objReference) {
     if (!objReference) {
       this.disposeResizeTextArea(element);
     }
@@ -44,22 +44,25 @@ export class inputHelper {
     }
   }
 
-  static disposeResizeTextArea(element) {
+  static disposeResizeTextArea(element: HTMLTextAreaElement) {
     element.removeEventListener("input", state.eventCallbackRegistry[element.id + "input"]);
     state.objReferenceDict[element.id] = null;
     state.eventCallbackRegistry[element.id + "input"] = null;
   }
 
-  static resizeTextArea(element, minRows, maxRows) {
-    var dims = this.getTextAreaInfo(element);
-    var rowHeight = dims["lineHeight"];
-    var offsetHeight = dims["paddingTop"] + dims["paddingBottom"] + dims["borderTop"] + dims["borderBottom"];
-    var oldHeight = parseFloat(element.style.height);
-    element.style.height = 'auto';
-
+  static resizeTextArea(element: HTMLTextAreaElement, minRows: number, maxRows: number) {
+    let dims = this.getTextAreaInfo(element);
+    let rowHeight = dims["lineHeight"];
+    let offsetHeight = dims["paddingTop"] + dims["paddingBottom"] + dims["borderTop"] + dims["borderBottom"];
+    let oldHeight = parseFloat(element.style.height);
+    //use rows attribute to evaluate real scroll height
+    let oldRows = element.rows;
+    element.rows = minRows;
+    element.style.height = 'auto';    
+    
     var rows = Math.trunc(element.scrollHeight / rowHeight);
-    rows = Math.max(minRows, rows);
-
+    element.rows = oldRows;
+    rows = Math.max(minRows, rows);    
     var newHeight = 0;
     if (rows > maxRows) {
       rows = maxRows;
@@ -75,7 +78,7 @@ export class inputHelper {
     }
     if (oldHeight !== newHeight) {
       let textAreaObj = state.objReferenceDict[element.id];
-      textAreaObj.invokeMethodAsync("ChangeSizeAsyncJs", parseFloat(element.scrollWidth), newHeight);
+      textAreaObj.invokeMethodAsync("ChangeSizeAsyncJs", element.scrollWidth, newHeight);
     }
   }
 

--- a/components/input/Input.cs
+++ b/components/input/Input.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -51,6 +50,13 @@ namespace AntDesign
         /// </summary>
         [Parameter]
         public bool AllowClear { get; set; }
+
+        /// <summary>
+        /// Controls the autocomplete attribute of the input HTML element.
+        /// Default = true
+        /// </summary>
+        [Parameter]
+        public bool AutoComplete { get; set; } = true;
 
         [Parameter]
         public bool AutoFocus
@@ -168,8 +174,11 @@ namespace AntDesign
         [Parameter]
         public bool ReadOnly { get; set; }
 
+        /// <summary>
+        /// Controls onclick & blur event propagation.
+        /// </summary>
         [Parameter]
-        public bool AutoComplete { get; set; } = true;
+        public bool StopPropagation { get; set; }
 
         /// <summary>
         /// The suffix icon for the Input.
@@ -192,9 +201,6 @@ namespace AntDesign
         /// </summary>
         [Parameter]
         public string WrapperStyle { get; set; }
-
-        [Parameter]
-        public bool StopPropagation { get; set; }
 
         public Dictionary<string, object> Attributes { get; set; }
 
@@ -645,13 +651,13 @@ namespace AntDesign
                 //TODO: Use built in @onfocus once https://github.com/dotnet/aspnetcore/issues/30070 is solved
                 //builder.AddAttribute(76, "onfocus", CallbackFactory.Create(this, OnFocusAsync));
                 builder.AddAttribute(77, "onmouseup", CallbackFactory.Create(this, OnMouseUpAsync));
-                
+
                 if (StopPropagation)
                 {
                     builder.AddEventStopPropagationAttribute(78, "onchange", true);
                     builder.AddEventStopPropagationAttribute(79, "onblur", true);
                 }
-                
+
                 builder.AddElementReferenceCapture(90, r => Ref = r);
                 builder.CloseElement();
 

--- a/components/input/InputPassword.razor.cs
+++ b/components/input/InputPassword.razor.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using AntDesign.Core.Extensions;
-using AntDesign.JsInterop;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 

--- a/components/input/TextArea.razor
+++ b/components/input/TextArea.razor
@@ -1,6 +1,5 @@
 ﻿@namespace AntDesign
 @inherits Input<string>
-<!--TODO: minheight, maxheight, onResize-->
 
 @{
     Dictionary<string, object> attributes =
@@ -19,7 +18,7 @@
             { "style", Style },
             { "class", ClassMapper.Class },
             { "disabled", Disabled },
-			{ "readonly", ReadOnly },
+			{ "readonly", ReadOnly },            
          };
 
     if (Attributes != null)
@@ -34,13 +33,13 @@
 		@if (Suffix != null)
 		{
 			<span class="@_warpperClassMapper.Class">
-				<textarea @ref="Ref" @attributes="attributes"/>
+				<textarea @ref="Ref" @attributes="attributes" @onclick:stopPropagation="@StopPropagation" @onblur:stopPropagation="@StopPropagation"/>
 				@Suffix				
 			</span>		
 		}
 		else
 		{
-			<textarea @ref="Ref" @attributes="attributes"/>
+			<textarea @ref="Ref" @attributes="attributes" @onclick:stopPropagation="@StopPropagation" @onblur:stopPropagation="@StopPropagation"/>
 		}
 		<AntDesign.Text Style="float: right; pointer-events: none; white-space: nowrap; color: rgba(0, 0, 0, 0.45)">&nbsp;@($"/ {MaxLength}")</AntDesign.Text>
 	</div>
@@ -50,12 +49,12 @@ else
 	@if (Suffix != null)
 	{
 		<span class="@_warpperClassMapper.Class">
-			<textarea @ref="Ref" @attributes="attributes"/>
+			<textarea @ref="Ref" @attributes="attributes" @onclick:stopPropagation="@StopPropagation" @onblur:stopPropagation="@StopPropagation"/>
 			@Suffix				
 		</span>
 	}
 	else
 	{
-		<textarea @ref="Ref" @attributes="attributes"/>	
+		<textarea @ref="Ref" @attributes="attributes" @onclick:stopPropagation="@StopPropagation" @onblur:stopPropagation="@StopPropagation"/>	
 	}
 }

--- a/site/AntDesign.Docs/Demos/Components/Input/demo/Area.razor
+++ b/site/AntDesign.Docs/Demos/Components/Input/demo/Area.razor
@@ -1,13 +1,13 @@
 ﻿@using AntDesign;
 
 <div>
-    <TextArea Placeholder="Autosize height based on content lines" AutoSize="true" OnResize="OnResize" @bind-Value="@txtValue"/>
+    <TextArea Placeholder="Autosize height based on content lines" AutoSize="true" OnResize="OnResize"/>
     <br />
     <br />
-    <TextArea Placeholder="Autosize height based on content lines" MinRows="2" MaxRows="6" OnResize="OnResize" @bind-Value="@txtValue"/>
+    <TextArea Placeholder="Autosize height with minimum and maximum number of lines" MinRows="2" MaxRows="6" OnResize="OnResize"/>
     <br />
     <br />
-    <TextArea Placeholder="Autosize height based on content lines" MinRows="3" MaxRows="5" OnResize="OnResize" @bind-Value="@txtValue"/>
+    <TextArea Placeholder="Controlled autosize" MinRows="3" MaxRows="5" OnResize="OnResize" @bind-Value="@txtValue"/>
 </div>
 
 @code{

--- a/site/AntDesign.Docs/Demos/Components/Input/demo/TextAreaBasic.razor
+++ b/site/AntDesign.Docs/Demos/Components/Input/demo/TextAreaBasic.razor
@@ -1,1 +1,1 @@
- <TextArea MinRows="4" />
+ <TextArea Rows="4" />

--- a/site/AntDesign.Docs/Demos/Components/Input/doc/index.en-US.md
+++ b/site/AntDesign.Docs/Demos/Components/Input/doc/index.en-US.md
@@ -22,6 +22,7 @@ A basic widget for getting the user input is a text field. Keyboard and mouse ca
 | AddOnBefore | The label text displayed before (on the left side of) the input field.                             | RenderFragment        | -         |
 | AddOnAfter            | The label text displayed after (on the right side of) the input field.           | RenderFragment         |
 | AllowClear | Allow to remove input content with clear icon                               | boolean        | false         |
+| AllowComplete | Controls the autocomplete attribute of the input HTML element.     | boolean        | true         |
 | AutoFocus            | Focus on input element.           | boolean         | false
 | Bordered | Whether has border style         | boolean         | true
 | CultureInfo          | What Culture will be used when converting string to value and value to string. Useful for InputNumber component.           | CultureInfo         | CultureInfo.CurrentCulture       |
@@ -42,6 +43,7 @@ A basic widget for getting the user input is a text field. Keyboard and mouse ca
 | Prefix | The prefix icon for the Input.                           | RenderFragment        | -        |
 | ReadOnly | When present, it specifies that an input field is read-only. | boolean | false    | 0.9
 | Size |The size of the input box. Note: in the context of a form, the `large` size is used. Available: `large` `default` `small`       | string        | -         |
+| StopPropagation Controls onclick & blur event propagation.    | boolean    | false      | 0.10.0
 | Style | Set CSS style. When using, be aware that some styles can be set only by `WrapperStyle` | string | - |  |
 | Suffix | The suffix icon for the Input.                            | RenderFragment        | -         |
 | Type            |The type of input, see: MDN(use `Input.TextArea` instead of type=`textarea`)         | string  | -         |
@@ -57,10 +59,11 @@ A basic widget for getting the user input is a text field. Keyboard and mouse ca
 
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
-| AutoSize |  | boolean        | false         |
+| AutoSize | Will adjust (grow or shrink) the `TextArea` according to content. Can work in connection with `MaxRows` & `MinRows`. Sets `resize` attribute of the `textarea` HTML element to: `none`. | boolean        | false         |
 | DefaultToEmptyString | When `false`, value will be set to `null` when content is empty or whitespace. When `true`, value will be set to empty string. | boolean        | false         |
-| MinRows | `TextArea` will allow shrinking, but it will stop when visible rows = MinRows (will not shrink further).  | int        | 1         |
-| MaxRows | `TextArea` will allow growing, but it will stop when visible rows = MaxRows (will not grow further).  | int        | uint.MaxValue         |
+| MinRows | `TextArea` will allow shrinking, but it will stop when visible rows = `MinRows` (will not shrink further). Using this property will autoset `AutoSize = true`.  | int        | 1         |
+| MaxRows | `TextArea` will allow growing, but it will stop when visible rows = `MaxRows` (will not grow further). Using this property will autoset `AutoSize = true`.  | int        | uint.MaxValue         |
+| Rows | Sets the height of the TextArea expressed in number of rows. | uint        | 3         |
 | ShowCount | Whether show text count. Requires `MaxLength` attribute to be present  | boolean | false         | 0.9
 | OnResize | Callback when the size changes | Action<OnResizeEventArgs>        | -         |
 

--- a/site/AntDesign.Docs/Demos/Components/Input/doc/index.zh-CN.md
+++ b/site/AntDesign.Docs/Demos/Components/Input/doc/index.zh-CN.md
@@ -21,6 +21,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/xS9YEJhfe/Input.svg
 | AddOnBefore | 带标签的 input，设置前置标签                               | RenderFragment        | -         |
 | AddOnAfter            | 带标签的 input，设置后置标签           | RenderFragment         |
 | AllowClear |可以点击清除图标删除内容                               | boolean        | false         |
+| AllowComplete | Controls the autocomplete attribute of the input HTML element.     | boolean        | true         |
 | AutoFocus            | Focus on input element.           | boolean         | false
 | Bordered | Whether has border style         | boolean         | true
 | CultureInfo          | What Culture will be used when converting string to value and value to string           | CultureInfo         | CultureInfo.CurrentCulture       |
@@ -41,6 +42,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/xS9YEJhfe/Input.svg
 | Prefix | 带有前缀图标的 input                               | RenderFragment        | -        |
 | ReadOnly | When present, it specifies that an input field is read-only. | boolean | false    | 0.9
 | Size |抽屉元素之间的子组件  `default`, `large`, `small`        | string        | -         |
+| StopPropagation Controls onclick & blur event propagation.    | boolean    | false      | 0.10.0
 | Style | 设置 `<input>` HTML 元素的 CSS 样式 | string | - |  |
 | Suffix | 带有后缀图标的 input                               | RenderFragment        | -         |
 | Type            |声明 input 类型，同原生 input 标签的 type 属性，见：MDN(请直接使用 Input.TextArea 代替 type="textarea")。         | string  | -         |
@@ -56,10 +58,11 @@ cover: https://gw.alipayobjects.com/zos/alicdn/xS9YEJhfe/Input.svg
 
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
-| AutoSize |  | boolean        | false         |
+| AutoSize | Will adjust (grow or shrink) the `TextArea` according to content. Can work in connection with `MaxRows` & `MinRows`. Sets `resize` attribute of the `textarea` HTML element to: `none`. | boolean        | false         |
 | DefaultToEmptyString | When `false`, value will be set to `null` when content is empty or whitespace. When `true`, value will be set to empty string. | boolean        | false         |
-| MinRows | `TextArea` will allow shrinking, but it will stop when visible rows = MinRows (will not shrink further).  | int        | 1         |
-| MaxRows | `TextArea` will allow growing, but it will stop when visible rows = MaxRows (will not grow further).  | int        | uint.MaxValue         |
+| MinRows | `TextArea` will allow shrinking, but it will stop when visible rows = `MinRows` (will not shrink further). Using this property will autoset `AutoSize = true`.  | int        | 1         |
+| MaxRows | `TextArea` will allow growing, but it will stop when visible rows = `MaxRows` (will not grow further). Using this property will autoset `AutoSize = true`.  | int        | uint.MaxValue         |
+| Rows | Sets the height of the TextArea expressed in number of rows. | uint        | 3         |
 | ShowCount | Whether show text count. Requires `MaxLength` attribute to be present  | boolean | false         | 0.9
 | OnResize | Callback when the size changes                                | Action<OnResizeEventArgs>        | -         |
 

--- a/tests/AntDesign.Tests/Input/TextAreaTests.razor
+++ b/tests/AntDesign.Tests/Input/TextAreaTests.razor
@@ -1,10 +1,21 @@
 ﻿@inherits AntDesignTestBase	
 @code {
+    AntDesign.TextArea.TextAreaInfo _textAreaInfo = new AntDesign.TextArea.TextAreaInfo
+    {
+        LineHeight = 10,
+        PaddingTop = 1,
+        PaddingBottom = 1,
+        BorderBottom = 1,
+        BorderTop = 1
+    };
+
 
 	[Fact]
 	public void TextArea_ShowCount_shows_initial_value()
 	{
 		//Arrange
+        JSInterop.Setup<AntDesign.TextArea.TextAreaInfo>(JSInteropConstants.InputComponentHelper.GetTextAreaInfo, _ => true)
+            .SetResult(_textAreaInfo);
 		string value = "0123456789";
 		var cut = Render(@<AntDesign.TextArea ShowCount MaxLength=100 Value=@value/>);
 		//Act
@@ -18,6 +29,8 @@
 	public async Task TextArea_ShowCount_increase()
 	{
 		//Arrange	
+        JSInterop.Setup<AntDesign.TextArea.TextAreaInfo>(JSInteropConstants.InputComponentHelper.GetTextAreaInfo, _ => true)
+            .SetResult(_textAreaInfo);
 		string value = "";
 		string newValue = "newValue";
 		var cut = Render<AntDesign.TextArea>(@<AntDesign.TextArea ShowCount MaxLength=100 Value=@value DebounceMilliseconds="0"/>);
@@ -34,10 +47,63 @@
 	public void TextArea_ReadOnly_creates_attribute()
 	{
 		//Arrange
+        JSInterop.Setup<AntDesign.TextArea.TextAreaInfo>(JSInteropConstants.InputComponentHelper.GetTextAreaInfo, _ => true)
+            .SetResult(_textAreaInfo);
 		var cut = Render<AntDesign.TextArea>(@<AntDesign.TextArea ReadOnly Value="@("0123456789")"/>);
 		//Act
 		var textAreaElement = cut.Find("textarea");
 		//Assert           
 		textAreaElement.HasAttribute("readonly");
+	}
+
+	[Fact]
+	public void TextArea_Rows_creates_with_expected_height()
+	{
+        //Arrange
+        JSInterop.Setup<AntDesign.TextArea.TextAreaInfo>(JSInteropConstants.InputComponentHelper.GetTextAreaInfo, _ => true)
+            .SetResult(_textAreaInfo);
+        uint rows = 4;
+        double expectedHeight = rows * _textAreaInfo.LineHeight +
+                            _textAreaInfo.PaddingTop +
+                            _textAreaInfo.PaddingBottom +
+                            _textAreaInfo.BorderBottom +
+                            _textAreaInfo.BorderTop;
+        var cut = Render<AntDesign.TextArea>(
+        @<AntDesign.TextArea Rows="@rows"/>);
+		//Act && Assert
+        var textAreaElement = cut.Find("textarea");
+        var styleAttribute = textAreaElement.GetAttribute("style");
+        styleAttribute.Should().Contain($"height: {expectedHeight}px");
+	}
+
+	[Fact]
+	public void TextArea_MinRows_creates_with_expected_height()
+	{
+        //Arrange
+        JSInterop.Setup<AntDesign.TextArea.TextAreaInfo>(JSInteropConstants.InputComponentHelper.RegisterResizeTextArea, _ => true)
+            .SetResult(_textAreaInfo);
+        uint rows = 4;
+        double expectedHeight = rows * _textAreaInfo.LineHeight +
+                            _textAreaInfo.PaddingTop +
+                            _textAreaInfo.PaddingBottom +
+                            _textAreaInfo.BorderBottom +
+                            _textAreaInfo.BorderTop;
+        var cut = Render<AntDesign.TextArea>(
+        @<AntDesign.TextArea MinRows="@rows" Rows="1"/>);
+		//Act && Assert
+        var textAreaElement = cut.Find("textarea");
+        var styleAttribute = textAreaElement.GetAttribute("style");
+        styleAttribute.Should().Contain($"height: {expectedHeight}px");        
+	}
+
+	[Fact]
+	public void TextArea_AutoSize_is_true_when_MinRows_set()
+	{
+        //Arrange
+        JSInterop.Setup<AntDesign.TextArea.TextAreaInfo>(JSInteropConstants.InputComponentHelper.RegisterResizeTextArea, _ => true)
+            .SetResult(_textAreaInfo);
+        var cut = Render<AntDesign.TextArea>(@<AntDesign.TextArea MinRows="1" AutoSize="false"/>);
+        //Act && Assert
+        cut.Instance.AutoSize.Should().BeTrue();
 	}
 }


### PR DESCRIPTION
### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [x] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [x] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
Fixes #1869

### 💡 Background and solution
1. Added `Rows` parameter. This is to cover the requirement of the issue & to align with antD. Defaults to 3, which is approx of current default of antD (in antD case it looks like the default to about 2.8).
2. Minor typescript optimizations (explicit types)
3. For `AutoSize` added style `resize:none` (align with antD) that turns-off ability to manually resize the `TextArea`. This also could be an additional parameter, but antD does not have it.
4. Debug warning if consumer tries to use either `MinRows` or `MaxRows` and set `AutoSize = false` (with automatic switch to `true`)
5. Included PR #1917 changes also in the `TextArea` component
6. Added comments, rearranged new parameter properties to keep alphabetical order (my ocd...)
7. Remove from `TextArea` unnecessary (IMO) conversion of passed value to `string`
8. Docs fixes
9. Fixed and added tests for `TextArea` to evaluate proper height calculation (only bUnit, typescript tests will have to wait for #1848 to be merged)

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Added parameter `Rows`.  |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
