### PR TITLE
Add inputmode for input number

### DIFF
--- a/components/input-number/InputNumber.razor
+++ b/components/input-number/InputNumber.razor
@@ -12,7 +12,7 @@
         </span>
     </div>
     <div class="ant-input-number-input-wrap">
-        <input @ref="Ref" role="spinbutton" aria-valuemin="@Min" aria-valuemax="@Max" autocomplete="off" max="@Max" min="@Min" step="@Step"
+        <input @ref="Ref" role="spinbutton" aria-valuemin="@Min" aria-valuemax="@Max" autocomplete="off" max="@Max" min="@Min" step="@Step" inputmode="@_inputNumberMode"
                aria-valuenow="@CurrentValue" class="ant-input-number-input" @bind="@CurrentValueAsString" @oninput="OnInput" @onkeydown="OnKeyDown" @onfocus="@OnFocus" @onblur="@OnBlurAsync" disabled="@Disabled" />
     </div>
 </div>

--- a/components/input-number/InputNumber.razor.cs
+++ b/components/input-number/InputNumber.razor.cs
@@ -115,40 +115,40 @@ namespace AntDesign
 
         private static readonly Dictionary<Type, object> _defaultMaximum = new Dictionary<Type, object>()
         {
-            { typeof(sbyte),sbyte.MaxValue },
+            { typeof(sbyte), sbyte.MaxValue },
             { typeof(byte), byte.MaxValue },
 
-            { typeof(short),short.MaxValue },
-            { typeof(ushort),ushort.MaxValue },
+            { typeof(short), short.MaxValue },
+            { typeof(ushort), ushort.MaxValue },
 
-            { typeof(int),int.MaxValue },
-            { typeof(uint),uint.MaxValue },
+            { typeof(int), int.MaxValue },
+            { typeof(uint), uint.MaxValue },
 
-            { typeof(long),long.MaxValue },
-            { typeof(ulong),ulong.MaxValue },
+            { typeof(long), long.MaxValue },
+            { typeof(ulong), ulong.MaxValue },
 
-            { typeof(float),float.PositiveInfinity },
-            { typeof(double),double.PositiveInfinity },
-            { typeof(decimal),decimal.MaxValue },
+            { typeof(float), float.PositiveInfinity },
+            { typeof(double), double.PositiveInfinity },
+            { typeof(decimal), decimal.MaxValue },
         };
 
         private static readonly Dictionary<Type, object> _defaultMinimum = new Dictionary<Type, object>()
         {
-            { typeof(sbyte),sbyte.MinValue },
+            { typeof(sbyte), sbyte.MinValue },
             { typeof(byte), byte.MinValue },
 
-            { typeof(short),short.MinValue },
-            { typeof(ushort),ushort.MinValue },
+            { typeof(short), short.MinValue },
+            { typeof(ushort), ushort.MinValue },
 
-            { typeof(int),int.MinValue },
-            { typeof(uint),uint.MinValue },
+            { typeof(int), int.MinValue },
+            { typeof(uint), uint.MinValue },
 
-            { typeof(long),long.MinValue },
-            { typeof(ulong),ulong.MinValue },
+            { typeof(long), long.MinValue },
+            { typeof(ulong), ulong.MinValue },
 
-            { typeof(float),float.NegativeInfinity},
-            { typeof(double),double.NegativeInfinity },
-            { typeof(decimal),decimal.MinValue },
+            { typeof(float), float.NegativeInfinity},
+            { typeof(double), double.NegativeInfinity },
+            { typeof(decimal), decimal.MinValue },
         };
 
         private static Type[] _floatTypes = new Type[] { typeof(float), typeof(double), typeof(decimal) };
@@ -159,6 +159,8 @@ namespace AntDesign
         private CancellationTokenSource _increaseTokenSource;
         private CancellationTokenSource _decreaseTokenSource;
         private TValue _defaultValue;
+
+        private string _inputNumberMode = "numeric";
 
         public InputNumber()
         {
@@ -203,6 +205,7 @@ namespace AntDesign
                 MethodCallExpression expRound = Expression.Call(null, typeof(InputNumberMath).GetMethod(nameof(InputNumberMath.Round), new Type[] { _surfaceType, typeof(int) }), num, decimalPlaces);
                 var lambdaRound = Expression.Lambda<Func<TValue, int, TValue>>(expRound, num, decimalPlaces);
                 _roundFunc = lambdaRound.Compile();
+                _inputNumberMode = "decimal";
             }
 
             if (_defaultMaximum.ContainsKey(underlyingType)) Max = (TValue)_defaultMaximum[underlyingType];


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [x] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
InputNumber can show correct keyboard on mobile devices, according to that example https://inputmodes.com/

| . | Old | New |
| --- | --- | --- |
| Android - not float |  ![image](https://user-images.githubusercontent.com/12235437/132419687-2169b22e-f440-4d5f-b9c0-0e69837a12a8.png)  | ![image](https://user-images.githubusercontent.com/12235437/132419397-00269220-dd20-4bc8-89bb-b8072e4b1699.png)  |
| Android - float|  ![image](https://user-images.githubusercontent.com/12235437/132419770-8ea0107d-dd2b-4e91-b1f1-e279061b9d39.png) | ![image](https://user-images.githubusercontent.com/12235437/132419789-6a50256b-c01d-4815-bb0e-ca5088ada634.png) |
| iOS - not float | ![image](https://user-images.githubusercontent.com/12235437/132420143-19001225-a2bc-4b74-ba78-5dad3fed9af1.png) | ![image](https://user-images.githubusercontent.com/12235437/132419926-2b7a0698-62fe-400f-a3de-64d9657d8204.png) |
| iOS - float |  ![image](https://user-images.githubusercontent.com/12235437/132419961-a2feab3b-b70d-404c-930b-e8a52ffe9cd0.png) | ![image](https://user-images.githubusercontent.com/12235437/132419977-4813896c-a64a-4afc-8a82-30cbdf9b6bea.png) |



<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

For floaing types input mode will be `decimal`, for all others - `numeric`

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
