### PR TITLE
change: test cs project to include testProjectWithAdapter

### DIFF
--- a/tests/AntDesign.TestKit/AntDesignTestBase.cs
+++ b/tests/AntDesign.TestKit/AntDesignTestBase.cs
@@ -17,6 +17,7 @@ namespace AntDesign.Tests
 
             //Needed for Tests using Overlay
             Services.AddScoped<AntDesign.JsInterop.DomEventService>(sp => new TestDomEventService(Context.JSInterop.JSRuntime));
+            JSInterop.SetupVoid(JSInteropConstants.OverlayComponentHelper.DeleteOverlayFromContainer, _ => true);
 
             CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.GetCultureInfo("en-US");
         }

--- a/tests/AntDesign.Tests/AntDesign.Tests.csproj
+++ b/tests/AntDesign.Tests/AntDesign.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net5;</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <UseDataCollector>true</UseDataCollector>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,6 +12,10 @@
     <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
 


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [x] Other (about what?)

### 💡 Background and solution
Few days ago I discovered this [Fine Code Coverage](https://marketplace.visualstudio.com/items?itemName=FortuneNgwenya.FineCodeCoverage) extension to VS that allows to generate coverlet reports and actually track the coverage. For `AntBlazor` it looks like this:
![image](https://user-images.githubusercontent.com/6518006/132995604-1192b9fd-a3d7-4f7d-b622-3d2225bd2147.png)

It required 2 changes to `AntDesign.Test.csproj` file, which I would deem completely harmless, except when you are using the aforementioned extensions - then extremely useful. 
There is a problem here though - after running tests, it takes some time for the coverage report to generate. I consulted with the creator of the extension and we found out that this is not the problem of the extension but either coverlet or blazor. Maybe you remember that we used to have a serious delay when tests were running in CI - like 18 minutes. Only after switching the tests to run in `Release` configuration, the tests execution went down to 3 minutes. Same is here. If in `Debug` configuration, then it takes much longer than when in `Release`. It is still too long, but it seems this problem is related more to coverlet or blazor (or both not cooperating nicely). I know there are going to be very few contributors using this tool (even if we put it in the wiki), but it still is useful. Even if only to me :smirk:.

Also, added mock for disposal of overlay to base class. Because overlay is often hidden in multiple different components, this will prevent occasional bunit exceptions in tests. 


### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
