### PR TITLE
refactor(module: tabs): improve rendering

### DIFF
--- a/components/tabs/TabPane.razor
+++ b/components/tabs/TabPane.razor
@@ -1,26 +1,26 @@
 ﻿@namespace AntDesign
 @inherits AntDomComponentBase
 
-@if (Pane?.Key != Key || IsEmpty)
+@if (_hasClosed)
 {
-    return;
+	return;
 }
 
 @if (IsTab)
 {
-    var ondragoverPreventDefault = IsActive;
-    var onclickStopPropagation = !IsActive;
+    var ondragoverPreventDefault = _isActive;
+    var onclickStopPropagation = !_isActive;
 
-    <div @key="Pane?.Key"
-     @ref="Pane.TabBar"
+    <div @key="Key"
+     @ref="_tabRef"
      @onclick:stopPropagation="@onclickStopPropagation"
-     @onclick="@(e => Parent.HandleTabClick(Pane))"
+     @onclick="@(e => Parent.HandleTabClick(this))"
      @ondragover:preventDefault="@ondragoverPreventDefault"
-     @ondragstart="@(e => Parent.HandleDragStart(e, Pane))"
-     @ondrop="@(_ => Parent.HandleDrop(Pane))"
+     @ondragstart="@(e => Parent.HandleDragStart(e, this))"
+     @ondrop="@(_ => Parent.HandleDrop(this))"
      aria-controls="@($"rc-tabs-{Id}-tab-{Key}")"
-     aria-selected="@(Pane?.IsActive)"
-     class="@Pane.ClassMapper.Class"
+     aria-selected="@(_isActive)"
+     class="@ClassMapper.Class"
      draggable="@Parent.Draggable.ToString()"
      id="@($"rc-tabs-{Id}-tab-{Key}")"
      ondragover="event.preventDefault();">
@@ -36,7 +36,7 @@
         </div>
         @if (Parent.Type == TabType.EditableCard && Closable)
         {
-            <button type="button" aria-label="remove" tabindex="0" class="ant-tabs-tab-remove" @onclick="(e) => Parent.RemoveTabPane(Pane)" @onclick:stopPropagation="true">
+            <button type="button" aria-label="remove" tabindex="0" class="ant-tabs-tab-remove" @onclick="(e) => Parent.RemoveTab(this)" @onclick:stopPropagation="true">
                 <Icon Type="close" />
             </button>
         }
@@ -44,19 +44,14 @@
 }
 else if (IsPane)
 {
-    if (Pane.IsActive || Pane.ForceRender || Pane.HasRendered)
-    {
-        Pane.HasRendered = true;
-
-        <div @key="Pane?.Key"
-     tabindex="@(IsActive ? "0" : "-1")"
-     class="ant-tabs-tabpane @(Pane.IsActive ? "ant-tabs-tabpane-active" : "")"
-     id="@($"rc-tabs-{Id}-panel-{Key}")"
-     role="tabpanel" aria-hidden="@(Pane.IsActive ? "false" : "true")"
-     aria-labelledby="@($"rc-tabs-{Id}-panel-{Key}")"
-     style="@(Pane.IsActive ? "" : "display: none;")">
-
-            @ChildContent
-        </div>
-    }
+    <div @key="Key"
+		  tabindex="@(_isActive ? "0" : "-1")"
+		  class="ant-tabs-tabpane @(_isActive ? "ant-tabs-tabpane-active" : "")"
+		  id="@($"rc-tabs-{Id}-panel-{Key}")"
+		  role="tabpanel" aria-hidden="@(_isActive ? "false" : "true")"
+		  aria-labelledby="@($"rc-tabs-{Id}-panel-{Key}")"
+		  style="@(_isActive ? "" : "display: none;")">
+        @ChildContent
+    </div>
+    
 }

--- a/components/tabs/TabPane.razor.cs
+++ b/components/tabs/TabPane.razor.cs
@@ -2,43 +2,24 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 
 namespace AntDesign
 {
     public partial class TabPane : AntDomComponentBase
     {
-        private const string PrefixCls = "ant-tabs-tab";
-
-        internal bool IsActive
-        {
-            get => _isActive;
-            set
-            {
-                if (_isActive != value)
-                {
-                    _isActive = value;
-                }
-            }
-        }
-
-        internal bool HasRendered { get; set; }
-        internal ElementReference TabBar { get; set; }
-
-        [CascadingParameter(Name = "IsEmpty")]
-        private bool IsEmpty { get; set; }
-
         [CascadingParameter(Name = "IsTab")]
-        private bool IsTab { get; set; }
+        internal bool IsTab { get; set; }
 
         [CascadingParameter(Name = "IsPane")]
-        private bool IsPane { get; set; }
+        internal bool IsPane { get; set; }
 
         [CascadingParameter]
         private Tabs Parent { get; set; }
-
-        [CascadingParameter(Name = "Pane")]
-        private TabPane Pane { get; set; }
 
         /// <summary>
         /// Forced render of content in tabs, not lazy render after clicking on tabs
@@ -69,68 +50,130 @@ namespace AntDesign
 
         [Parameter]
         public bool Closable { get; set; } = true;
+        internal bool IsActive => _isActive;
 
-        private bool _hasTab;
-        private bool _hasContent;
+        internal ElementReference TabRef => _tabRef;
+
+        private const string PrefixCls = "ant-tabs-tab";
+
+        private ElementReference _tabRef;
         private bool _isActive;
+        private bool _shouldRender;
+        private bool _shouldTabRender;
+        private bool _hasClosed;
 
         protected override void OnInitialized()
         {
             base.OnInitialized();
 
-            if (IsEmpty)
-            {
-                Parent?.AddTabPane(this);
-            }
+            this.SetClass();
 
-            if (IsTab && !Pane._hasTab)
-            {
-                Pane.SetTab();
-
-                Pane.ClassMapper
-                 .Add(PrefixCls)
-                 .If($"{PrefixCls}-active", () => Pane?.IsActive == true)
-                 .If($"{PrefixCls}-with-remove", () => Pane?.Closable == true)
-                 .If($"{PrefixCls}-disabled", () => Pane?.Disabled == true);
-
-                if (Parent?.Card != null)
-                {
-                    Parent.Complete(Pane);
-                }
-            }
-
-            if (IsPane && !Pane._hasContent)
-            {
-                Pane.SetContent();
-                Parent.Complete(Pane);
-            }
+            Parent?.AddTabPane(this);
         }
 
-        private void SetTab()
+        protected override void OnAfterRender(bool firstRender)
         {
-            _hasTab = true;
+            base.OnAfterRender(firstRender);
+
+            _shouldRender = false;
+            _shouldTabRender = false;
         }
 
-        private void SetContent()
+        protected override void OnParametersSet()
         {
-            _hasContent = true;
+            base.OnParametersSet();
+            _shouldRender = true;
         }
 
-        internal bool IsComplete() => _hasTab && (Parent?.Card != null || _hasContent);
+        public override async Task SetParametersAsync(ParameterView parameters)
+        {
+            // Avoid changes in tab as we modify the properties used for display when drag and drop occurs
+            if (!IsTab)
+            {
+                await base.SetParametersAsync(parameters);
+            }
+        }
 
-        protected override bool ShouldRender() => Pane?.Key == Key;
+        private void SetClass()
+        {
+            ClassMapper
+                .Add(PrefixCls)
+                .If($"{PrefixCls}-active", () => _isActive)
+                .If($"{PrefixCls}-with-remove", () => Closable)
+                .If($"{PrefixCls}-disabled", () => Disabled);
+        }
+
+        internal void SetKey(string key)
+        {
+            Key = key;
+        }
+
+        internal void SetActive(bool isActive)
+        {
+            if (_isActive != isActive)
+            {
+                _isActive = isActive;
+                _shouldTabRender = true;
+                StateHasChanged();
+            }
+        }
+
+        internal void Close()
+        {
+            _hasClosed = true;
+
+            _shouldTabRender = true;
+            _shouldRender = true;
+
+            Dispose();
+        }
 
         protected override void Dispose(bool disposing)
         {
-            if (IsEmpty)
-            {
-                Parent?._panes.Remove(this);
-            }
-            else
-            {
-                Pane = null;
-            }
+            Parent?.RemovePane(this);
+
             base.Dispose(disposing);
+        }
+
+        protected override bool ShouldRender()
+        {
+            if (IsTab)
+            {
+                return _shouldTabRender;
+            }
+
+            return _shouldRender;
+        }
+
+        internal void ExchangeWith(TabPane other)
+        {
+            var temp = other.Clone();
+            other.SetPane(this);
+            this.SetPane(temp);
+        }
+
+        private TabPane Clone()
+        {
+            return new TabPane
+            {
+                Key = Key,
+                Tab = this.Tab,
+                TabTemplate = this.TabTemplate,
+                Disabled = this.Disabled,
+                Closable = this.Closable,
+            };
+        }
+
+        private void SetPane(TabPane tabPane)
+        {
+            Key = tabPane.Key;
+            Tab = tabPane.Tab;
+            TabTemplate = tabPane.TabTemplate;
+            Disabled = tabPane.Disabled;
+            Closable = tabPane.Closable;
+
+            _shouldTabRender = true;
+            StateHasChanged();
         }
     }
 }

--- a/components/tabs/Tabs.razor
+++ b/components/tabs/Tabs.razor
@@ -2,21 +2,13 @@
 @inherits AntDomComponentBase
 
 <CascadingValue Value="this" IsFixed="@true">
-    <CascadingValue Value="true" Name="IsEmpty" IsFixed="true">
-        @ChildContent
-    </CascadingValue>
     <div class="@ClassMapper.Class" style="@Style" id="@Id">
         <!--Tab bar-->
         <div role="tablist" class="ant-tabs-nav">
             <div class="ant-tabs-nav-wrap @_tabsNavWarpPingClass" @ref="@_tabBars">
                 <div class="ant-tabs-nav-list" style="@_navStyle" @ref="@_scrollTabBar">
                     <CascadingValue Value="true" Name="IsTab" IsFixed="true">
-                        @foreach (var pane in _panes)
-                        {
-                            <CascadingValue Value="pane" Name="Pane" @key="pane.Key">
-                                @ChildContent
-                            </CascadingValue>
-                        }
+                         @ChildContent
                     </CascadingValue>
                     @if (Type == TabType.EditableCard && !HideAdd)
                     {
@@ -59,12 +51,7 @@
             <div class="ant-tabs-content-holder ">
                 <div class="ant-tabs-content ant-tabs-content-@TabPosition">
                     <CascadingValue Value="true" Name="IsPane" IsFixed="true">
-                        @foreach (var pane in _panes)
-                        {
-                            <CascadingValue Value="pane" Name="Pane">
-                                @ChildContent
-                            </CascadingValue>
-                        }
+                        @ChildContent
                     </CascadingValue>
                 </div>
             </div>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

1. Reduced object allocation - Previously, a loop was used to render `tabs` and `tabpane` in order to control the order of rendering in tabs, but this resulted in a Cartesian product of objects growing in number. Now we render the `tabpane` in ChildContnet directly, replacing only the tab's title when in drag and drop.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
