### PR TITLE
fix(module:select): arrow down click does not auto close

### DIFF
--- a/components/core/Component/Overlay/OverlayTrigger.razor.cs
+++ b/components/core/Component/Overlay/OverlayTrigger.razor.cs
@@ -431,6 +431,7 @@ namespace AntDesign.Internal
 
         protected virtual async Task OnTriggerClick()
         {
+            _mouseInTrigger = true;
             if (IsContainTrigger(TriggerType.Click))
             {
                 if (_overlay.IsPopup())
@@ -446,6 +447,7 @@ namespace AntDesign.Internal
             {
                 await Hide();
             }
+            _mouseInTrigger = false;
         }
 
         protected virtual async Task OnTriggerContextmenu(MouseEventArgs args)


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
Fixes #1976

### 💡 Background and solution
The `OverlayTrigger` js callback `OnMouseUp` was closing the `Overlay`, because the arrow was not treated as part of the trigger. My change was to mark the flag `_mouseInTrigger = true` when trigger is clicked, and back to `false` at the end of click handling method. Because the method is async, the `OnMouseUp` runs before the click handler finishes.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
