### PR TITLE
Use invariant culture for progress

### DIFF
--- a/components/progress/Progress.razor.cs
+++ b/components/progress/Progress.razor.cs
@@ -231,9 +231,8 @@ namespace AntDesign
             {
                 try
                 {
-                    style.Append(" background-image: linear-gradient(to right, ");
-                    style.AppendJoin(", ", StrokeColor.AsT1.Select(pair => $"{ToRGB(pair.Value)} {pair.Key}"));
-                    style.Append(')');
+                    var gradientPoints = string.Join(", ", StrokeColor.AsT1.Select(pair => $"{ToRGB(pair.Value)} {pair.Key}"));
+                    style.Append($" background-image: linear-gradient(to right, {gradientPoints})");
                 }
                 catch
                 {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] Bundle size optimization
- [x] Performance optimization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
Progress use `double ToString` in interpolated strings, and in `ru-RU` culture for example double `50.9` converts as `50,9`. That converting broke CSS, where ',' is service character.

1. All formattable strings with `double` was wrapped with FormattableString.Invariant
2. All string sums was replaced with `StringBuilder` `Append`
3. ToRGB method now uses Regex to improve code readability
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
