### PR TITLE
fix(module:overlaytrigger): premature reset of _mouseInTrigger

### DIFF
--- a/components/core/Component/Overlay/OverlayTrigger.razor.cs
+++ b/components/core/Component/Overlay/OverlayTrigger.razor.cs
@@ -431,6 +431,9 @@ namespace AntDesign.Internal
 
         protected virtual async Task OnTriggerClick()
         {
+            //_mouseInTrigger might have been set by a different event,
+            //so track that to know if should be reset at the end of this method
+            bool resetMouseInTrigger = !_mouseInTrigger;
             _mouseInTrigger = true;
             if (IsContainTrigger(TriggerType.Click))
             {
@@ -447,7 +450,10 @@ namespace AntDesign.Internal
             {
                 await Hide();
             }
-            _mouseInTrigger = false;
+            if (resetMouseInTrigger)
+            {
+                _mouseInTrigger = false;
+            }
         }
 
         protected virtual async Task OnTriggerContextmenu(MouseEventArgs args)


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
Fixes #2035

### 💡 Background and solution
PR #1977 had broken the `Popover`. That PR added setting of `_mouseInTrigger = true` when trigger was clicked and then was setting it back to `_mouseInTrigger = false`. However, due to current way the `OverlayTrigger` works, the `_mouseInTrigger` is set to 'true' much earlier (probably in js callback to `mouseenter` event). I believe this is a both performance and design issue. `OverlayTrigger` registers all the events (`mouseenter`, `mouseleave`, `focus`, `blur`, `click`, `contextmenu`) regardless of what will be the real trigger. I actually mentioned that in issue #1130. I already started working on that optimization, but it proved to be much more complex and it takes me much more time.

I also tried to do a regression test, but I gave up. Not because it is impossible, but because this test is more complex than it is worth and it cannot provide 100% accuracy. For the test to be written in a reliable manner, the optimization has to be done (the one I mentioned in the paragraph above).

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
