### PR TITLE
fix(module: calendar): DateFullCellRender throws an exception (#2067)

### DIFF
--- a/components/calendar/internal/CalendarPanelChooser.razor
+++ b/components/calendar/internal/CalendarPanelChooser.razor
@@ -8,6 +8,8 @@
     Action<string, int> ChangePickerType = (type, index) => { Calendar.ChangePickerType(type, index); };
     Func<int, DateTime> GetIndexPickerValue = (index) => Calendar.Value;
     Func<int, DateTime?> GetIndexValue = (index) => Calendar.Value;
+    Func<DateTime, DateTime, RenderFragment> DateFullCellRender =
+        Calendar.DateFullCellRender != null ? (date, _) => Calendar.DateFullCellRender(date) : null;
 
     Dictionary<string, object> attributes =
         new Dictionary<string, object>()
@@ -23,7 +25,7 @@
             { "GetIndexPickerValue", GetIndexPickerValue },
             { "GetIndexValue", GetIndexValue },
             { "DisabledDate", Calendar.DisabledDate },
-            { "DateRender", Calendar.DateFullCellRender },
+            { "DateRender", DateFullCellRender },
             { "MonthCellRender", Calendar.MonthFullCellRender },
             { "CalendarDateRender", Calendar.DateCellRender },
             { "CalendarMonthCellRender", Calendar.MonthCellRender },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/ant-design-blazor/ant-design-blazor/issues/2067

### 💡 Background and solution

Setting `Calendar.DateFullCellRender` property would result in a cast exception thrown. That was because that function (1 parameter) was passed to `DatePickerBase` which required 2 parameters. I propose a solution where we create a new anonymous function which calls the original `Calendar.DateFullCellRender` with the second parameter discarded.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fixed `Calendar.DateFullCellRender` throwing an exception   |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
