### PR TITLE
feat(module: core) Allow controls to be used in default EditForm

### DIFF
--- a/components/core/Base/AntInputComponentBase.cs
+++ b/components/core/Base/AntInputComponentBase.cs
@@ -107,7 +107,10 @@ namespace AntDesign
         /// <summary>
         /// Gets the associated <see cref="EditContext"/>.
         /// </summary>
-        protected EditContext EditContext { get; set; }
+        //[CascadingParameter]
+        //protected EditContext EditContext { get; set; }
+        [CascadingParameter] 
+        private EditContext? CascadedEditContext { get; set; }
 
         /// <summary>
         /// Gets the <see cref="FieldIdentifier"/> for the bound value.
@@ -129,10 +132,11 @@ namespace AntDesign
 
                     ValueChanged.InvokeAsync(value);
 
-                    if (_isNotifyFieldChanged && (Form?.ValidateOnChange == true))
-                    {
-                        EditContext?.NotifyFieldChanged(FieldIdentifier);
-                    }
+                    OnValueNotifiedChange(FieldIdentifier);
+                    //if (_isNotifyFieldChanged && (Form?.ValidateOnChange == true))
+                    //{
+                    //    EditContext?.NotifyFieldChanged(FieldIdentifier);
+                    //}
                 }
             }
         }
@@ -166,28 +170,33 @@ namespace AntDesign
                 {
                     parsingFailed = true;
 
-                    if (EditContext != null)
+                    if (CascadedEditContext != null)
                     {
                         if (_parsingValidationMessages == null)
                         {
-                            _parsingValidationMessages = new ValidationMessageStore(EditContext);
+                            _parsingValidationMessages = new ValidationMessageStore(CascadedEditContext);
                         }
 
                         _parsingValidationMessages.Add(FieldIdentifier, validationErrorMessage);
 
                         // Since we're not writing to CurrentValue, we'll need to notify about modification from here
-                        EditContext.NotifyFieldChanged(FieldIdentifier);
+                        CascadedEditContext.NotifyFieldChanged(FieldIdentifier);
                     }
                 }
 
                 // We can skip the validation notification if we were previously valid and still are
-                if ((parsingFailed || _previousParsingAttemptFailed) && EditContext != null)
+                if ((parsingFailed || _previousParsingAttemptFailed) && CascadedEditContext != null)
                 {
-                    EditContext.NotifyValidationStateChanged();
+                    CascadedEditContext.NotifyValidationStateChanged();
                     _previousParsingAttemptFailed = parsingFailed;
                 }
             }
         }
+
+        /// <summary>
+        /// Gets or sets the current validation state value of the input.
+        /// </summary>
+        public bool IsValid { get; set; }
 
         private TValue _firstValue;
         protected bool _isNotifyFieldChanged = true;
@@ -199,7 +208,10 @@ namespace AntDesign
         /// </summary>
         protected AntInputComponentBase()
         {
-            _validationStateChangedHandler = (sender, eventArgs) => StateHasChanged();
+            _validationStateChangedHandler = (sender, eventArgs) =>
+            {
+                StateHasChanged();
+            };
         }
 
         /// <summary>
@@ -266,6 +278,14 @@ namespace AntDesign
         {
         }
 
+        protected void OnValueNotifiedChange(FieldIdentifier fieldIdentifier)
+        {
+            if (_isNotifyFieldChanged || (Form?.ValidateOnChange == true))
+            {
+                CascadedEditContext?.NotifyFieldChanged(fieldIdentifier);
+            }
+        }
+
         protected override void OnInitialized()
         {
             _isValueGuid = THelper.GetUnderlyingType<TValue>() == typeof(Guid);
@@ -282,7 +302,7 @@ namespace AntDesign
         {
             parameters.SetParameterProperties(this);
 
-            if (EditContext == null)
+            if (CascadedEditContext == null)
             {
                 // This is the first run
                 // Could put this logic in OnInit, but its nice to avoid forcing people who override OnInit to call base.OnInit()
@@ -297,16 +317,16 @@ namespace AntDesign
                     return base.SetParametersAsync(ParameterView.Empty);
                 }
 
-                EditContext = Form?.EditContext;
+                CascadedEditContext = Form?.EditContext;
                 if (ValuesExpression == null)
                     FieldIdentifier = FieldIdentifier.Create(ValueExpression);
                 else
                     FieldIdentifier = FieldIdentifier.Create(ValuesExpression);
                 _nullableUnderlyingType = Nullable.GetUnderlyingType(typeof(TValue));
 
-                EditContext.OnValidationStateChanged += _validationStateChangedHandler;
+                CascadedEditContext.OnValidationStateChanged += _validationStateChangedHandler;
             }
-            else if (Form?.EditContext != EditContext)
+            else if (Form?.EditContext != CascadedEditContext)
             {
                 // Not the first run
 
@@ -314,7 +334,8 @@ namespace AntDesign
                 //already have all events transferred from original EditContext. The
                 //transfer is done in Form.BuildEditContext() method. State is lost
                 //though.
-                EditContext = Form?.EditContext;
+                CascadedEditContext = Form?.EditContext;
+                
             }
 
             // For derived components, retain the usual lifecycle with OnInit/OnParametersSet/etc.
@@ -323,9 +344,9 @@ namespace AntDesign
 
         protected override void Dispose(bool disposing)
         {
-            if (EditContext != null)
+            if (CascadedEditContext != null)
             {
-                EditContext.OnValidationStateChanged -= _validationStateChangedHandler;
+                CascadedEditContext.OnValidationStateChanged -= _validationStateChangedHandler;
             }
 
             Form?.RemoveControl(this);

--- a/components/core/Base/AntInputComponentBase.cs
+++ b/components/core/Base/AntInputComponentBase.cs
@@ -318,12 +318,6 @@ namespace AntDesign
                 }
 
                 CascadedEditContext = Form?.EditContext;
-                if (ValuesExpression == null)
-                    FieldIdentifier = FieldIdentifier.Create(ValueExpression);
-                else
-                    FieldIdentifier = FieldIdentifier.Create(ValuesExpression);
-                _nullableUnderlyingType = Nullable.GetUnderlyingType(typeof(TValue));
-
                 CascadedEditContext.OnValidationStateChanged += _validationStateChangedHandler;
             }
             else if (Form?.EditContext != CascadedEditContext)
@@ -335,8 +329,17 @@ namespace AntDesign
                 //transfer is done in Form.BuildEditContext() method. State is lost
                 //though.
                 CascadedEditContext = Form?.EditContext;
-                
             }
+
+            if(FieldIdentifier.Model == null || string.IsNullOrEmpty(FieldIdentifier.FieldName))
+            {
+                if (ValuesExpression == null)
+                    FieldIdentifier = FieldIdentifier.Create(ValueExpression);
+                else
+                    FieldIdentifier = FieldIdentifier.Create(ValuesExpression);
+                _nullableUnderlyingType = Nullable.GetUnderlyingType(typeof(TValue));
+            }
+
 
             // For derived components, retain the usual lifecycle with OnInit/OnParametersSet/etc.
             return base.SetParametersAsync(ParameterView.Empty);

--- a/components/date-picker/RangePicker.razor.cs
+++ b/components/date-picker/RangePicker.razor.cs
@@ -149,11 +149,11 @@ namespace AntDesign
                 array.SetValue(changeValue, index);
 
                 ChangePickerValue(changeValue, index);
-
-                if (_isNotifyFieldChanged && (Form?.ValidateOnChange == true))
-                {
-                    EditContext?.NotifyFieldChanged(FieldIdentifier);
-                }
+                OnValueNotifiedChange(FieldIdentifier);
+                //if (_isNotifyFieldChanged && (Form?.ValidateOnChange == true))
+                //{
+                //    EditContext?.NotifyFieldChanged(FieldIdentifier);
+                //}
 
                 StateHasChanged();
             }
@@ -454,11 +454,11 @@ namespace AntDesign
                     DateStrings = new string[] { GetInputValue(0), GetInputValue(1) }
                 });
             }
-
-            if (_isNotifyFieldChanged && (Form?.ValidateOnChange == true))
-            {
-                EditContext?.NotifyFieldChanged(FieldIdentifier);
-            }
+            OnValueNotifiedChange(FieldIdentifier);
+            //if (_isNotifyFieldChanged && (Form?.ValidateOnChange == true))
+            //{
+            //    EditContext?.NotifyFieldChanged(FieldIdentifier);
+            //}
         }
 
         public override void ClearValue(int index = -1, bool closeDropdown = true)

--- a/components/form/FormItem.razor.cs
+++ b/components/form/FormItem.razor.cs
@@ -128,7 +128,7 @@ namespace AntDesign
 
         private bool IsShowIcon => HasFeedback && _iconMap.ContainsKey(ValidateStatus);
 
-        private EditContext EditContext => Form?.EditContext;
+        public EditContext EditContext => Form?.EditContext;
 
         private string[] _validationMessages = Array.Empty<string>();
 
@@ -141,7 +141,7 @@ namespace AntDesign
         private PropertyReflector _propertyReflector;
 
         private ClassMapper _labelClassMapper = new ClassMapper();
-        private AntLabelAlignType? FormLabelAlign => LabelAlign ?? Form.LabelAlign;
+        private AntLabelAlignType? FormLabelAlign => LabelAlign ?? Form?.LabelAlign;
 
         private FieldIdentifier _fieldIdentifier;
         private PropertyInfo _fieldPropertyInfo;
@@ -152,15 +152,15 @@ namespace AntDesign
         {
             base.OnInitialized();
 
-            if (Form == null)
-            {
-                throw new InvalidOperationException("Form is null.FormItem should be childContent of Form.");
-            }
+            //if (Form == null)
+            //{
+            //    throw new InvalidOperationException("Form is null.FormItem should be childContent of Form.");
+            //}
 
             SetClass();
             SetRequiredCss();
 
-            Form.AddFormItem(this);
+            Form?.AddFormItem(this);
 
             if (!string.IsNullOrWhiteSpace(Help))
             {
@@ -190,13 +190,13 @@ namespace AntDesign
         {
             bool isRequired = false;
 
-            if (Form.ValidateMode.IsIn(FormValidateMode.Default, FormValidateMode.Complex)
+            if ((Form != null && Form.ValidateMode.IsIn(FormValidateMode.Default, FormValidateMode.Complex))
                 && _propertyReflector.RequiredAttribute != null)
             {
                 isRequired = true;
             }
 
-            if (Form.ValidateMode.IsIn(FormValidateMode.Rules, FormValidateMode.Complex)
+            if ((Form != null && Form.ValidateMode.IsIn(FormValidateMode.Rules, FormValidateMode.Complex))
                  && Rules != null && Rules.Any(rule => rule.Required == true))
             {
                 isRequired = true;
@@ -221,9 +221,9 @@ namespace AntDesign
             {
                 labelColParameter = LabelCol;
             }
-            else if (Form.LabelCol != null)
+            else if (Form?.LabelCol != null)
             {
-                labelColParameter = Form.LabelCol;
+                labelColParameter = Form?.LabelCol;
             }
             else
             {
@@ -246,9 +246,9 @@ namespace AntDesign
             {
                 wrapperColParameter = WrapperCol;
             }
-            else if (Form.WrapperCol != null)
+            else if (Form?.WrapperCol != null)
             {
-                wrapperColParameter = Form.WrapperCol;
+                wrapperColParameter = Form?.WrapperCol;
             }
             else
             {
@@ -287,7 +287,7 @@ namespace AntDesign
             _fieldIdentifier = control.FieldIdentifier;
             this._control = control;
 
-            if (Form.ValidateMode.IsIn(FormValidateMode.Rules, FormValidateMode.Complex))
+            if (Form != null && Form.ValidateMode.IsIn(FormValidateMode.Rules, FormValidateMode.Complex))
             {
                 _fieldPropertyInfo = _fieldIdentifier.Model.GetType().GetProperty(_fieldIdentifier.FieldName);
             }
@@ -338,7 +338,7 @@ namespace AntDesign
             {
                 var propertyValue = _fieldPropertyInfo.GetValue(_fieldIdentifier.Model);
 
-                var validateMessages = Form.ValidateMessages ?? ConfigProvider?.Form?.ValidateMessages ?? new FormValidateErrorMessages();
+                var validateMessages = Form?.ValidateMessages ?? ConfigProvider?.Form?.ValidateMessages ?? new FormValidateErrorMessages();
 
                 foreach (var rule in Rules)
                 {

--- a/components/input/Input.cs
+++ b/components/input/Input.cs
@@ -464,7 +464,7 @@ namespace AntDesign
                 if (_debounceTimer != null)
                 {
                     await _debounceTimer.DisposeAsync();
-                    
+
                     _debounceTimer = null;
                 }
             }
@@ -659,6 +659,7 @@ namespace AntDesign
 
                 builder.AddElementReferenceCapture(90, r => Ref = r);
                 builder.CloseElement();
+                //input
 
                 if (Suffix != null)
                 {

--- a/components/select/Select.razor.cs
+++ b/components/select/Select.razor.cs
@@ -438,10 +438,11 @@ namespace AntDesign
             {
                 _valueHasChanged = false;
                 OnValueChange(_selectedValue);
-                if (Form?.ValidateOnChange == true)
-                {
-                    EditContext?.NotifyFieldChanged(FieldIdentifier);
-                }
+                //if (Form?.ValidateOnChange == true)
+                //{
+                //    EditContext?.NotifyFieldChanged(FieldIdentifier);
+                //}
+                OnValueNotifiedChange(FieldIdentifier);
             }
             base.OnParametersSet();
         }

--- a/components/select/SelectBase.cs
+++ b/components/select/SelectBase.cs
@@ -240,11 +240,11 @@ namespace AntDesign
 
                     _ = OnValuesChangeAsync(default);
                 }
-
-                if (_isNotifyFieldChanged && Form?.ValidateOnChange == true)
-                {
-                    EditContext?.NotifyFieldChanged(FieldIdentifier);
-                }
+                OnValueNotifiedChange(FieldIdentifier);
+                //if (_isNotifyFieldChanged && Form?.ValidateOnChange == true)
+                //{
+                //    EditContext?.NotifyFieldChanged(FieldIdentifier);
+                //}
             }
         }
 

--- a/components/tree-select/TreeSelect.razor.cs
+++ b/components/tree-select/TreeSelect.razor.cs
@@ -253,11 +253,11 @@ namespace AntDesign
 
                     _ = OnValuesChangeAsync(default);
                 }
-                if (_isNotifyFieldChanged && (Form?.ValidateOnChange == true))
-                {
-                    EditContext?.NotifyFieldChanged(FieldIdentifier);
-                }
-
+                //if (_isNotifyFieldChanged && (Form?.ValidateOnChange == true))
+                //{
+                //    EditContext?.NotifyFieldChanged(FieldIdentifier);
+                //}
+                OnValueNotifiedChange(FieldIdentifier);
             }
         }
 

--- a/site/AntDesign.Docs/Demos/Components/Form/demo/EditForm.razor
+++ b/site/AntDesign.Docs/Demos/Components/Form/demo/EditForm.razor
@@ -1,0 +1,69 @@
+﻿@using System.ComponentModel.DataAnnotations;
+@using System.Text.Json;
+@using System.ComponentModel
+@using Microsoft.AspNetCore.Components.Forms
+
+    <Divider>Default EditForm Component</Divider>
+    <Microsoft.AspNetCore.Components.Forms.EditForm Model="this.model" class="ant-form ant-form-horizontal">
+        <DataAnnotationsValidator />
+        <FormItem>
+            <Input @bind-Value="@this.model.Username" />
+        </FormItem>
+        <FormItem Label="Password">
+            <InputPassword @bind-Value="@this.model.Password" />
+        </FormItem>
+        <FormItem WrapperColOffset="8" WrapperColSpan="16">
+            <Checkbox @bind-Value="this.model.RememberMe">Remember me</Checkbox>
+        </FormItem>
+        <FormItem WrapperColOffset="8" WrapperColSpan="16">
+            <Button Type="@ButtonType.Primary" HtmlType="submit">
+                Submit
+            </Button>
+        </FormItem>
+    </Microsoft.AspNetCore.Components.Forms.EditForm>       
+
+
+    <Divider>AntDesign Form Component</Divider>
+    <Form Model="@model"
+          OnFinish="OnFinish"
+          OnFinishFailed="OnFinishFailed"
+          LabelColSpan="8"
+          WrapperColSpan="16">
+        <FormItem>
+            <Input @bind-Value="@context.Username" />
+        </FormItem>
+        <FormItem Label="Password">
+            <InputPassword @bind-Value="@context.Password" />
+        </FormItem>
+        <FormItem WrapperColOffset="8" WrapperColSpan="16">
+            <Checkbox @bind-Value="context.RememberMe">Remember me</Checkbox>
+        </FormItem>
+        <FormItem WrapperColOffset="8" WrapperColSpan="16">
+            <Button Type="@ButtonType.Primary" HtmlType="submit">
+                Submit
+            </Button>
+        </FormItem>
+    </Form>
+@code
+{
+    public class Model
+    {
+        [Required, DisplayName("User Name"), MinLength(1)]
+        public string Username { get; set; }
+        [Required, MinLength(1)]
+        public string Password { get; set; }
+        public bool RememberMe { get; set; } = true;
+    }
+
+    private Model model = new Model();
+
+    private void OnFinish(EditContext editContext)
+    {
+        Console.WriteLine($"Success:{JsonSerializer.Serialize(model)}");
+    }
+
+    private void OnFinishFailed(EditContext editContext)
+    {
+        Console.WriteLine($"Failed:{JsonSerializer.Serialize(model)}");
+    }
+}

--- a/site/AntDesign.Docs/Demos/Components/Form/demo/editform.md
+++ b/site/AntDesign.Docs/Demos/Components/Form/demo/editform.md
@@ -1,0 +1,14 @@
+---
+order: 0
+title:
+  zh-CN: 默认编辑表单
+  en-US: Default EditForm
+---
+
+## zh-CN
+
+当包装在“FormItem”控件中时，从“AntInputComponentBase”派生的控件可以用作替换项。
+
+## en-US
+
+Controls derived from `AntInputComponentBase` can be used as drop in replacements when wrapped in a `FormItem` control. 

--- a/site/AntDesign.Docs/_Imports.razor
+++ b/site/AntDesign.Docs/_Imports.razor
@@ -11,3 +11,4 @@
 @using AntDesign.Docs.Shared
 @using AntDesign.Docs.Localization
 @using System.Text.Json
+@using System.ComponentModel.DataAnnotations


### PR DESCRIPTION
### 🤔 This is a ...

- [X] New feature
- [X] Bug fix
- [X] Site / documentation update
- [X] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

Issue was detailed on Discord

### 💡 Background and solution

When trying to convert my app to use AntDesign, none of the validation styling worked. Doing some research I found that none of the controls could be used as a drop in replacement for default Blazor Controls. No validation was getting fired as the EditContext was fully able to cascade down. This in addition to the validation styling being part of the FormItem was a problem for me. 

I have updated the FormItem to be able to be used in the default EditForm and updated the AntInputComponentBase to be able to cascade the EditContext. Added a demo of this in the `Form` area of the documents.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
