### PR TITLE
fix(module: radio): `Radio` in a group should always keep `Disabled` …

### DIFF
--- a/components/radio/Radio.razor.cs
+++ b/components/radio/Radio.razor.cs
@@ -93,10 +93,9 @@ namespace AntDesign
                 .If($"{prefixCls}-button-inner", () => RadioButton);
         }
 
-        internal void SetName(string name)
-        {
-            _name = name;
-        }
+        internal void SetName(string name) => _name = name;
+
+        internal void SetDisabledValue(bool value) => Disabled = value;
 
         protected override void OnInitialized()
         {
@@ -108,11 +107,6 @@ namespace AntDesign
             }
 
             RadioGroup?.AddRadio(this);
-
-            if (RadioGroup?.Disabled == true)
-            {
-                Disabled = true;
-            }
 
             if (_hasDefaultChecked && !_defaultCheckedSetted)
             {

--- a/components/radio/RadioGroup.razor.cs
+++ b/components/radio/RadioGroup.razor.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using OneOf;
@@ -13,7 +12,18 @@ namespace AntDesign
         public RenderFragment ChildContent { get; set; }
 
         [Parameter]
-        public bool Disabled { get; set; }
+        public bool Disabled
+        {
+            get => _disabled;
+            set
+            {
+                if (_disabled != value)
+                {
+                    _disabled = value;
+                    OnDisabledValueChanged?.Invoke(_disabled);
+                }
+            }
+        }
 
         [Parameter]
         public RadioButtonStyle ButtonStyle { get; set; } = RadioButtonStyle.Outline;
@@ -38,12 +48,15 @@ namespace AntDesign
         [Parameter]
         public OneOf<string[], RadioOption<TValue>[]> Options { get; set; }
 
-        private List<Radio<TValue>> _radioItems = new List<Radio<TValue>>();
+        private bool _disabled;
+        private Action<bool> OnDisabledValueChanged { get; set; }
 
         private TValue _defaultValue;
 
         private bool _hasDefaultValue;
         private bool _defaultValueSetted;
+
+        private readonly List<Radio<TValue>> _radioItems = new();
 
         private static readonly Dictionary<RadioButtonStyle, string> _buttonStyleDics = new()
         {
@@ -77,6 +90,8 @@ namespace AntDesign
                 radio.SetName(Name);
             }
             _radioItems.Add(radio);
+            radio.SetDisabledValue(_disabled);
+            OnDisabledValueChanged += radio.SetDisabledValue;
             if (EqualsValue(this.CurrentValue, radio.Value))
             {
                 await radio.Select();
@@ -87,6 +102,7 @@ namespace AntDesign
         internal void RemoveRadio(Radio<TValue> radio)
         {
             _radioItems.Remove(radio);
+            OnDisabledValueChanged -= radio.SetDisabledValue;
         }
 
         protected override async Task OnParametersSetAsync()


### PR DESCRIPTION
…as same as `RadioGroup.Disabled`

Fix issue #2141 

<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    `Radio` in a group should always keep `Disabled` as same as `RadioGroup.Disabled`     |
| 🇨🇳 Chinese |     `Radio`作为组成员时`Disabled`属性应当始终与 `RadioGroup.Disabled` 一致      |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
