### PR TITLE
if CanDraggable, missed MatchedClass and error if TreeComponent.Searc…

### DIFF
--- a/components/tree/TreeNodeTitle.razor
+++ b/components/tree/TreeNodeTitle.razor
@@ -36,9 +36,9 @@
                 {
                     @SelfNode.TitleTemplate
                 }
-                else if (SelfNode.Matched)
+                else if (SelfNode.Matched && !string.IsNullOrWhiteSpace(TreeComponent.SearchValue))
                 {
-                    var value = $"<span Style=\"{TreeComponent.MatchedStyle}\">{TreeComponent.SearchValue}</span>";
+                    var value = $"<span class=\"{TreeComponent.MatchedClass}\" style=\"{TreeComponent.MatchedStyle}\">{TreeComponent.SearchValue}</span>";
                     <span>
                         @((MarkupString)SelfNode.Title.Replace(TreeComponent.SearchValue, value))
                     </span>


### PR DESCRIPTION
Hi,

This is a bug fix for TreeNodeTitle.razor. It's possible there is/are any more bug because Razor code inside in CanDraggable and else is not the same

regards

