### PR TITLE
Improve sync logic about `Disabled` between `RadioGroup` and `Radio`s

### DIFF
--- a/components/radio/Radio.razor
+++ b/components/radio/Radio.razor
@@ -8,7 +8,7 @@
                autofocus="@AutoFocus"
                class="@_inputClassMapper.Class"
                disabled="@Disabled"
-               checked="@IsChecked"
+               checked="@Checked"
                name="@_name"
                value="@Value"
                @ref="_inputRef" />

--- a/components/radio/Radio.razor.cs
+++ b/components/radio/Radio.razor.cs
@@ -19,7 +19,11 @@ namespace AntDesign
         public bool RadioButton { get; set; }
 
         [Parameter]
-        public bool Checked { get => _checked ?? false; set { _checked = value; } }
+        public bool Checked
+        {
+            get => _checked.GetValueOrDefault();
+            set => _checked = value;
+        }
 
         [Parameter]
         public bool DefaultChecked
@@ -47,13 +51,11 @@ namespace AntDesign
         [CascadingParameter(Name = "InGroup")]
         public bool InGroup { get; set; }
 
-        private ClassMapper _radioClassMapper = new ClassMapper();
-        private ClassMapper _inputClassMapper = new ClassMapper();
-        private ClassMapper _innerClassMapper = new ClassMapper();
+        private readonly ClassMapper _radioClassMapper = new();
+        private readonly ClassMapper _inputClassMapper = new();
+        private readonly ClassMapper _innerClassMapper = new();
 
         private ElementReference _inputRef;
-
-        private bool IsChecked => _checked ?? this.Checked;
 
         private bool? _checked;
 
@@ -69,18 +71,18 @@ namespace AntDesign
             ClassMapper
                 .If($"{prefixCls}-wrapper", () => !RadioButton)
                 .If($"{prefixCls}-button-wrapper", () => RadioButton)
-                .If($"{prefixCls}-wrapper-checked", () => IsChecked && !RadioButton)
-                .If($"{prefixCls}-button-wrapper-checked", () => IsChecked && RadioButton)
+                .If($"{prefixCls}-wrapper-checked", () => Checked && !RadioButton)
+                .If($"{prefixCls}-button-wrapper-checked", () => Checked && RadioButton)
                 .If($"{prefixCls}-wrapper-disabled", () => Disabled && !RadioButton)
                 .If($"{prefixCls}-button-wrapper-disabled", () => Disabled && RadioButton)
                 .If($"{prefixCls}-button-wrapper-rtl", () => RTL);
 
             _radioClassMapper
                 .If(prefixCls, () => !RadioButton)
-                .If($"{prefixCls}-checked", () => IsChecked && !RadioButton)
+                .If($"{prefixCls}-checked", () => Checked && !RadioButton)
                 .If($"{prefixCls}-disabled", () => Disabled && !RadioButton)
                 .If($"{prefixCls}-button", () => RadioButton)
-                .If($"{prefixCls}-button-checked", () => IsChecked && RadioButton)
+                .If($"{prefixCls}-button-checked", () => Checked && RadioButton)
                 .If($"{prefixCls}-button-disabled", () => Disabled && RadioButton)
                 .If($"{prefixCls}-rtl", () => RTL);
 
@@ -135,7 +137,7 @@ namespace AntDesign
 
         internal async Task Select()
         {
-            if (!Disabled && !IsChecked)
+            if (!Checked)
             {
                 this._checked = true;
                 await CheckedChange.InvokeAsync(true);
@@ -145,7 +147,7 @@ namespace AntDesign
 
         internal async Task UnSelect()
         {
-            if (!Disabled && this.IsChecked)
+            if (Checked)
             {
                 this._checked = false;
                 await CheckedChange.InvokeAsync(false);

--- a/tests/AntDesign.Tests/Radio/RadioGroupTests.razor
+++ b/tests/AntDesign.Tests/Radio/RadioGroupTests.razor
@@ -91,9 +91,55 @@
             <Radio Value="2">B</Radio>
             <Radio Value="3">C</Radio>
             <Radio Value="4">D</Radio>
-        </RadioGroup>);
+    </RadioGroup>
+    );
 
         //Assert
         cut.Instance.Value.Should().Be(2);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Sync_Disabled_basic_radioGroup(bool initGroupDisabled)
+    {
+        //Arrange
+        int value = 1;
+        IRenderedComponent<RadioGroup<int>> radioGroup = Render<RadioGroup<int>>(
+            @<RadioGroup @bind-Value=@value Disabled=@initGroupDisabled>
+                    <Radio Value="1">A</Radio>
+                    <Radio Value="2">B</Radio>
+    </RadioGroup>
+    );
+        var members = radioGroup.FindComponents<Radio<int>>();
+        //Act
+#pragma warning disable BL0005
+        radioGroup.Instance.Disabled = !initGroupDisabled;
+#pragma warning restore BL0005
+        //Assert
+        Assert.All(members, e => Assert.Equal(!initGroupDisabled, e.Instance.Disabled));
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Sync_Disabled_exist_disabled_member_radioGroup(bool initGroupDisabled)
+    {
+        //Arrange
+        int value = 1;
+        IRenderedComponent<RadioGroup<int>> radioGroup = Render<RadioGroup<int>>(
+            @<RadioGroup @bind-Value=@value Disabled=@initGroupDisabled>
+                    <Radio Value="1" Disabled=true>A</Radio>
+                    <Radio Value="2">B</Radio>
+        </RadioGroup>
+        );
+        var members = radioGroup.FindComponents<Radio<int>>();
+        //Act
+#pragma warning disable BL0005
+        radioGroup.Instance.Disabled = !initGroupDisabled;
+#pragma warning restore BL0005
+        //Assert
+        members[0].Instance.Disabled.Should().BeTrue();
+        members[1].Instance.Disabled.Should().Be(!initGroupDisabled);
     }
 }


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [x] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

Now if a radio is in a group, its `Disabled` will be always the same as `RadioGroup`. However, sometimes people may want to keep some radio disabled, so we should ignore the sync for a disabled radio when it becomes a child of group.

Also, BTW, this PR has fixed some other problems.

* Remove `IsChecked` which is duplicated of `Checked` in `Radio`
* Remove check of `Disabled` in `Select` and `UnSelect`, which should be checked before the method calls
* Use `EqualityComparer` in `EqualsValue`
* Fix extra `ValueChanged` invoking in `OnRadioChange`
* Add some test cases about `Disabled` sync of `RadioGroup`

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Improve sync logic about `Disabled` between `RadioGroup` and `Radio`s    |
| 🇨🇳 Chinese |     完善RadioGroup和Radio之间Disabled状态的同步逻辑   |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
