### PR TITLE
fix(module:table): trigger PageSizeChanged event before PageIndexChanged event

### DIFF
--- a/components/table/Table.razor.Pagination.cs
+++ b/components/table/Table.razor.Pagination.cs
@@ -87,14 +87,25 @@ namespace AntDesign
 
         private async Task HandlePageChange(PaginationEventArgs args)
         {
-            if (_pageIndex != args.Page)
-            {
-                await HandlePageIndexChange(args);
-            }
+            bool shouldInvokeChange = false;
 
             if (_pageSize != args.PageSize)
             {
+                shouldInvokeChange = true;
                 await HandlePageSizeChange(args);
+            }
+
+            if (_pageIndex != args.Page)
+            {
+                shouldInvokeChange = true;
+                await HandlePageIndexChange(args);
+            }
+
+            if (shouldInvokeChange)
+            {
+                ReloadAndInvokeChange();
+
+                StateHasChanged();
             }
         }
 
@@ -111,10 +122,6 @@ namespace AntDesign
             {
                 await OnPageIndexChange.InvokeAsync(args);
             }
-
-            ReloadAndInvokeChange();
-
-            StateHasChanged();
         }
 
         private async Task HandlePageSizeChange(PaginationEventArgs args)
@@ -130,10 +137,6 @@ namespace AntDesign
             {
                 await OnPageSizeChange.InvokeAsync(args);
             }
-
-            ReloadAndInvokeChange();
-
-            StateHasChanged();
         }
 
         private void ChangePageSize(int pageSize)


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
Fixes #2236

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | when pageIndex and pageSize change together, trigger PageSizeChanged event before PageIndexChanged event, and trigger OnChange event only one time |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
