### PR TITLE
FIXES #2250: Use ASCII C instead of Cyrillic

### DIFF
--- a/components/table/FilterExpression/StringFilterExpression.cs
+++ b/components/table/FilterExpression/StringFilterExpression.cs
@@ -19,10 +19,10 @@ namespace AntDesign.FilterExpression
 
         public Expression GetFilterExpression(TableFilterCompareOperator compareOperator, Expression leftExpr, Expression rightExpr)
         {
-            return GetCaseInsensitiveСomparation(compareOperator, leftExpr, rightExpr);
+            return GetCaseInsensitiveComparation(compareOperator, leftExpr, rightExpr);
         }
 
-        private Expression GetCaseInsensitiveСomparation(TableFilterCompareOperator compareOperator, Expression leftExpr, Expression rightExpr)
+        private Expression GetCaseInsensitiveComparation(TableFilterCompareOperator compareOperator, Expression leftExpr, Expression rightExpr)
         {
             MethodInfo miLower = typeof(string).GetMethod("ToLower", Array.Empty<Type>());
             Expression notNull = Expression.NotEqual(leftExpr, Expression.Constant(null));


### PR DESCRIPTION

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)


### 💡 Background and solution

The code used a cyrillic Es (looks like a C) mistakenly. Changed to use ASCII C.


### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed


FIXES #2250.
