### PR TITLE
Select search debounce

### DIFF
--- a/components/select/Select.razor
+++ b/components/select/Select.razor
@@ -123,6 +123,7 @@
                                                        TItemValue="TItemValue"
                                                        TItem="TItem"
                                                        SearchValue="@_searchValue"
+													   SearchDebounceMilliseconds="@SearchDebounceMilliseconds"
                                                        IsOverlayShow="@_dropDown.IsOverlayShow()"
 													   MaxTagCount="@_maxTagCountAsInt"
                                                        OnInput="@OnInputAsync"
@@ -130,7 +131,7 @@
                                                        OnKeyDown="@OnKeyDownAsync"
                                                        OnFocus="@OnInputFocusAsync"
                                                        OnBlur="@OnInputBlurAsync"
-                                                       OnClearClick="@OnInputClearClickAsync"                                                      
+                                                       OnClearClick="@OnInputClearClickAsync"
                                                        OnRemoveSelected="@OnRemoveSelectedAsync"
                                                        Placeholder="@Placeholder"
                                                        ShowPlaceholder="@ShowPlaceholder"/>

--- a/components/select/SelectBase.cs
+++ b/components/select/SelectBase.cs
@@ -78,6 +78,12 @@ namespace AntDesign
         /// </summary>
         [Parameter] public bool EnableSearch { get; set; }
         /// <summary>
+        /// Delays the processing of the search input event until the user has stopped 
+        /// typing for a predetermined amount of time
+        /// </summary>
+        [Parameter]
+        public int SearchDebounceMilliseconds { get; set; }
+        /// <summary>
         /// Show loading indicator. You have to write the loading logic on your own.
         /// </summary>
         [Parameter] public bool Loading { get; set; }

--- a/components/select/internal/SelectContent.razor
+++ b/components/select/internal/SelectContent.razor
@@ -249,7 +249,7 @@ else //ParentSelect.SelectMode != SelectMode.Default
             <div class="@Prefix-selection-overflow-item @Prefix-selection-overflow-item-suffix" style="opacity: 1; order: @(ParentSelect.IsResponsive?_calculatedMaxCount-1:ParentSelect.SelectedOptionItems.Count)">
                 <div class="@Prefix-selection-search" style="@_inputWidth">
                     <input @ref="ParentSelect._inputRef"
-                           @oninput="OnInput"
+                           @oninput="OnInputChange"
                            @onkeyup="OnKeyUp"
                            @onkeydown="OnKeyDown"
                            @attributes=@AdditonalAttributes()

--- a/components/select/internal/SelectContent.razor
+++ b/components/select/internal/SelectContent.razor
@@ -14,7 +14,7 @@
         }
         <span class="@Prefix-selection-search" style="@_inputWidth">
             <input @ref="ParentSelect._inputRef"
-                   @oninput="OnInput"
+                   @oninput="@OnInputChange"
                    @onkeyup="OnKeyUp"
                    @onkeydown="OnKeyDown"
                    @attributes=@AdditonalAttributes()

--- a/components/select/internal/SelectContent.razor.cs
+++ b/components/select/internal/SelectContent.razor.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using AntDesign.Core.Extensions;
 using AntDesign.Core.JsInterop.ObservableApi;
@@ -56,6 +57,7 @@ namespace AntDesign.Select.Internal
         [Parameter] public EventCallback<SelectOptionItem<TItemValue, TItem>> OnRemoveSelected { get; set; }
         [Parameter] public string SearchValue { get; set; }
         [Parameter] public ForwardRef RefBack { get; set; } = new ForwardRef();
+        [Parameter] public int SearchDebounceMilliseconds { get; set; }
         [Inject] protected IJSRuntime Js { get; set; }
         [Inject] private IDomEventListener DomEventListener { get; set; }
         protected ElementReference Ref
@@ -90,6 +92,7 @@ namespace AntDesign.Select.Internal
         private int _currentItemCount;
         private Guid _internalId = Guid.NewGuid();
         private bool _refocus;
+        private Timer _debounceTimer;
 
         protected override void OnInitialized()
         {
@@ -225,6 +228,46 @@ namespace AntDesign.Select.Internal
                     await Js.FocusAsync(ParentSelect._inputRef);
                 }
             }
+        }
+
+        private async Task OnInputChange(ChangeEventArgs e)
+        {
+            if (SearchDebounceMilliseconds == 0)
+            {
+                await OnInput.InvokeAsync(e);
+                return;
+            }
+
+            await DebounceInputChange(e);
+        }
+
+        private async Task DebounceInputChange(ChangeEventArgs e, bool ignoreDebounce = false)
+        {
+            if (ignoreDebounce is false)
+            {
+                DebounceInput(e);
+                return;
+            }
+
+            if (_debounceTimer != null)
+            {
+                await _debounceTimer.DisposeAsync();
+
+                _debounceTimer = null;
+            }
+
+            await OnInput.InvokeAsync(e);
+        }
+
+        private void DebounceInput(ChangeEventArgs e)
+        {
+            _debounceTimer?.Dispose();
+            _debounceTimer = new Timer(DebounceTimerIntervalOnTick, e, SearchDebounceMilliseconds, SearchDebounceMilliseconds);
+        }
+
+        private void DebounceTimerIntervalOnTick(object state)
+        {
+            InvokeAsync(async () => await DebounceInputChange((ChangeEventArgs)state, true));
         }
 
         private void SetInputWidth()

--- a/components/tree-select/TreeSelect.razor
+++ b/components/tree-select/TreeSelect.razor
@@ -56,6 +56,7 @@
                                                    TItemValue="string"
                                                    TItem="TItem"
                                                    SearchValue="@_searchValue"
+												   SearchDebounceMilliseconds="@SearchDebounceMilliseconds"
                                                    IsOverlayShow="@_dropDown.IsOverlayShow()"
                                                    OnInput="@OnInputAsync"
                                                    OnKeyUp="@OnKeyUpAsync"

--- a/site/AntDesign.Docs/Demos/Components/Select/demo/SearchBox.razor
+++ b/site/AntDesign.Docs/Demos/Components/Select/demo/SearchBox.razor
@@ -9,6 +9,7 @@
         Placeholder="input search text"
         ShowArrowIcon="false"
 		HideNotFoundContent="true"
+        SearchDebounceMilliseconds="350"
         OnSearch="@(async (value) => await OnSearch(value))"
 		OnSelectedItemChanged="OnSelectedItemChangedHandler">
 </Select>

--- a/site/AntDesign.Docs/Demos/Components/Select/doc/index.en-US.md
+++ b/site/AntDesign.Docs/Demos/Components/Select/doc/index.en-US.md
@@ -34,6 +34,7 @@ Select component to select value from options.
 | DropdownMatchSelectWidth |  Will match drowdown width: <br/>- for boolean: `true` - with widest item in the dropdown list <br/> - for string: with value (e.g.: `256px`). | OneOf<bool, string> | true |  |
 | DropdownMaxWidth | Will not allow dropdown width to grow above stated in here value (eg. "768px"). | string | "auto" |  |
 | DropdownRender | Customize dropdown content. | Renderfragment | - |  |
+| SearchDebounceMilliseconds | Delays the processing of the search input event until the user has stopped typing for a predetermined amount of time | int        | 0         |
 | EnableSearch | Indicates whether the search function is active or not. Always `true` for mode `tags`. | bool | false |  |
 | GroupName | The name of the property to be used as a group indicator. If the value is set, the entries are displayed in groups. Use additional `SortByGroup` and `SortByLabel`. | string | - |  |
 | HideSelected | Hides the selected items when they are selected. | bool | false |  |

--- a/site/AntDesign.Docs/Demos/Components/Select/doc/index.zh-CN.md
+++ b/site/AntDesign.Docs/Demos/Components/Select/doc/index.zh-CN.md
@@ -35,6 +35,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/_0XzgOis7/Select.svg
 | DropdownMatchSelectWidth |  Will match drowdown width: <br/>- for boolean: `true` - with widest item in the dropdown list <br/> - for string: with value (e.g.: `256px`). | OneOf<bool, string> | true |  |
 | DropdownMaxWidth | Will not allow dropdown width to grow above stated in here value (eg. "768px"). | string | "auto" |  |
 | DropdownRender | 自定义下拉框内容 | Renderfragment | - |  |
+| SearchDebounceMilliseconds |推迟对搜索输入事件的处理，直到用户停止输入一个预定的时间。 | int        | 0         |
 | EnableSearch | Indicates whether the search function is active or not. Always `true` for mode `tags`. | bool | false |  |
 | GroupName | The name of the property to be used as a group indicator. If the value is set, the entries are displayed in groups. Use additional `SortByGroup` and `SortByLabel`. | string | - |  |
 | HideSelected | Hides the selected items when they are selected. | bool | false |  |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [x] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
https://github.com/ant-design-blazor/ant-design-blazor/issues/1965

In select control when we have EnableSearch set to true with DataSource counting few thousand of items we are facing pretty huge lag on typing search text. This problem occurs when running app locally and the lag is even bigger when app is deployed.

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

1. Problem: lag when typing on search input when select DataSource has few thousand of items. The lag is observed as visual glitch when we hold backspace or type very fast (the effect may not be that visible on the gif):
![2022-02-07_12h34_24](https://user-images.githubusercontent.com/52210724/152780969-c0dd1320-b3e0-41f8-9eec-c629c80c0275.gif)

2. Solution: Added SearchDebounceMilliseconds property following the example of debounce implementation in Input.razor. Example of the same data source as above, but with SearchDebounceMilliseconds set to 350:
![2022-02-07_12h42_54](https://user-images.githubusercontent.com/52210724/152782000-e2d1e66c-e01e-4221-955d-eaaaee7b66eb.gif)


### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->
Added SearchDebounceMilliseconds property. Default value is set to 0 becouse the issue occurs in big DataSource scenario and on more often on blazor-server-side apps becouse of additional latency.
One drawback of this solution is that with debounce placeholder text is visible as long as user is typing which results of overlapping texts sometimes. On the other hand - IMO this is still better user experience :)

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
