### PR TITLE
Enable deterministic builds for CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,9 +42,9 @@ jobs:
           echo "Publishing Version: ${VERSION}"
           npm install
           dotnet build
-          dotnet pack components/AntDesign.csproj /p:PackageVersion=$VERSION -c Release -o publish
-          dotnet pack tests/AntDesign.TestKit/AntDesign.TestKit.csproj /p:PackageVersion=$VERSION -c Release -o publish
-          dotnet pack src/AntDesign.Components.Authentication/AntDesign.Components.Authentication.csproj /p:PackageVersion=$VERSION -c Release -o publish
+          dotnet pack components/AntDesign.csproj /p:PackageVersion=$VERSION /p:ContinuousIntegrationBuild=true -c Release -o publish
+          dotnet pack tests/AntDesign.TestKit/AntDesign.TestKit.csproj /p:PackageVersion=$VERSION /p:ContinuousIntegrationBuild=true -c Release -o publish
+          dotnet pack src/AntDesign.Components.Authentication/AntDesign.Components.Authentication.csproj /p:PackageVersion=$VERSION /p:ContinuousIntegrationBuild=true -c Release -o publish
           dotnet nuget push 'publish/*.nupkg' -s https://api.nuget.org/v3/index.json -k $NUGET_API_KEY --skip-duplicate
 
       - name: Upload package artifact


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [x] Other: GitHub Workflow fix

### 💡 Background and solution

While debugging through the code of AntDesign from a consuming project I noticed that SourceLink is not working properly and I got the output of the IL decompilation. Upon verification I noticed that AntBlazor includes SourceLink as a package, however it was not a deterministic build. SourceLink requires that deterministic builds are enabled.

[NuGet package explorer](https://github.com/NuGetPackageExplorer/NuGetPackageExplorer) gives me the following output:

![image](https://user-images.githubusercontent.com/6552521/154812088-09d7e40d-5f26-4a06-859d-5eb2d5e6fa16.png)

I added the required compiler flag to the release workflow.

Further resources about the prerequisites regarding SourceLink:

https://devblogs.microsoft.com/dotnet/producing-packages-with-source-link/
https://github.com/dotnet/sourcelink/blob/main/docs/README.md#continuousintegrationbuild


### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
