### PR TITLE
Fix InputNumber automatic increase/decrease

### DIFF
--- a/components/input-number/InputNumber.razor.cs
+++ b/components/input-number/InputNumber.razor.cs
@@ -311,6 +311,7 @@ namespace AntDesign
             var num = _increaseFunc(Value, _step);
             await ChangeValueAsync(num);
 
+            _increaseTokenSource?.Cancel();
             _increaseTokenSource = new CancellationTokenSource();
             _ = Increase(_increaseTokenSource.Token).ConfigureAwait(false);
         }
@@ -347,6 +348,7 @@ namespace AntDesign
             var num = _decreaseFunc(Value, _step);
             await ChangeValueAsync(num);
 
+            _decreaseTokenSource?.Cancel();
             _decreaseTokenSource = new CancellationTokenSource();
             _ = Decrease(_decreaseTokenSource.Token).ConfigureAwait(false);
         }


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

In rare cases due to SignalR delay and async code when clicking on increase button to quickly, `IncreaseUp` may be called before `IncreaseDown` created new CancellationTokenSource and started new `Increase` routine. This causes that new Increase routine runs forever and cannot be canceled. If IncreaseDown in called again _increaseTokenSource is overwritten and previous one is lost.
This fix cancels existing Increase/Decrease routine before creating new CancellationTokenSource and starting new routine.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed possible nonstoppable increase/decrease in `InputNumber` component |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
