### PR TITLE
feat(module:form) Show icon feedback on error

### DIFF
--- a/components/form/FormItem.razor
+++ b/components/form/FormItem.razor
@@ -24,7 +24,7 @@
                     @ChildContent
                 </CascadingValue>
             </div>
-            @if (IsShowIcon || IsShowFeedbackOnError)
+            @if (IsShowFeedback)
             {
                 <span class=@($"{_prefixCls}-children-icon")><Icon Type="@(_iconMap[ValidateStatus].type)" Theme="@(_iconMap[ValidateStatus].theme)" /></span>
             }

--- a/components/form/FormItem.razor
+++ b/components/form/FormItem.razor
@@ -24,7 +24,7 @@
                     @ChildContent
                 </CascadingValue>
             </div>
-            @if (IsShowIcon)
+            @if (IsShowIcon || IsShowFeedbackOnError)
             {
                 <span class=@($"{_prefixCls}-children-icon")><Icon Type="@(_iconMap[ValidateStatus].type)" Theme="@(_iconMap[ValidateStatus].theme)" /></span>
             }

--- a/components/form/FormItem.razor.cs
+++ b/components/form/FormItem.razor.cs
@@ -113,7 +113,7 @@ namespace AntDesign
         public bool HasFeedback { get; set; }
 
         [Parameter] 
-        public bool ShowFeedbackOnError { get; set; }
+        public bool ShowFeedbackOn { get; set; }
 
         [Parameter]
         public FormValidateStatus ValidateStatus { get; set; }
@@ -131,7 +131,10 @@ namespace AntDesign
 
         private bool IsShowIcon => (HasFeedback && _iconMap.ContainsKey(ValidateStatus));
 
-        private bool IsShowFeedbackOnError => (ShowFeedbackOnError && !_isValid);
+        private bool IsShowFeedbackOnError => (ShowFeedbackOn && !_isValid);
+        private bool IsShowFeedbackOnSuccess => (ShowFeedbackOn && _isValid);
+
+        private bool IsShowFeedback => HasFeedback || IsShowFeedbackOnSuccess || IsShowFeedbackOnError;
 
         private EditContext EditContext => Form?.EditContext;
 
@@ -172,7 +175,7 @@ namespace AntDesign
                 _validationMessages = new[] { Help };
             }
 
-            if (ShowFeedbackOnError && ValidateStatus == FormValidateStatus.Default)
+            if (ShowFeedbackOn && ValidateStatus == FormValidateStatus.Default)
             {
                 ValidateStatus = FormValidateStatus.Error;
             }
@@ -186,7 +189,7 @@ namespace AntDesign
                 .If($"{_prefixCls}-rtl", () => RTL)
                 .If($"{_prefixCls}-has-feedback", () => HasFeedback || IsShowFeedbackOnError)
                 .If($"{_prefixCls}-is-validating", () => ValidateStatus == FormValidateStatus.Validating)
-                .GetIf(() => $"{_prefixCls}-has-{ValidateStatus.ToString().ToLower()}", () => (HasFeedback || IsShowFeedbackOnError) && ValidateStatus.IsIn(FormValidateStatus.Success, FormValidateStatus.Error, FormValidateStatus.Warning))
+                .GetIf(() => $"{_prefixCls}-has-{ValidateStatus.ToString().ToLower()}", () => IsShowFeedback && ValidateStatus.IsIn(FormValidateStatus.Success, FormValidateStatus.Error, FormValidateStatus.Warning))
                 .If($"{_prefixCls}-with-help", () => !string.IsNullOrEmpty(Help))
                ;
 

--- a/components/form/FormItem.razor.cs
+++ b/components/form/FormItem.razor.cs
@@ -112,6 +112,9 @@ namespace AntDesign
         [Parameter]
         public bool HasFeedback { get; set; }
 
+        [Parameter] 
+        public bool ShowFeedbackOnError { get; set; }
+
         [Parameter]
         public FormValidateStatus ValidateStatus { get; set; }
 
@@ -126,7 +129,9 @@ namespace AntDesign
                 { FormValidateStatus.Validating, (IconThemeType.Outline, Outline.Loading) }
             };
 
-        private bool IsShowIcon => HasFeedback && _iconMap.ContainsKey(ValidateStatus);
+        private bool IsShowIcon => (HasFeedback && _iconMap.ContainsKey(ValidateStatus));
+
+        private bool IsShowFeedbackOnError => (ShowFeedbackOnError && !_isValid);
 
         private EditContext EditContext => Form?.EditContext;
 
@@ -166,6 +171,11 @@ namespace AntDesign
             {
                 _validationMessages = new[] { Help };
             }
+
+            if (ShowFeedbackOnError && ValidateStatus == FormValidateStatus.Default)
+            {
+                ValidateStatus = FormValidateStatus.Error;
+            }
         }
 
         protected void SetClass()
@@ -174,9 +184,9 @@ namespace AntDesign
                 .Add(_prefixCls)
                 .If($"{_prefixCls}-with-help {_prefixCls}-has-error", () => _isValid == false)
                 .If($"{_prefixCls}-rtl", () => RTL)
-                .If($"{_prefixCls}-has-feedback", () => HasFeedback)
+                .If($"{_prefixCls}-has-feedback", () => HasFeedback || IsShowFeedbackOnError)
                 .If($"{_prefixCls}-is-validating", () => ValidateStatus == FormValidateStatus.Validating)
-                .GetIf(() => $"{_prefixCls}-has-{ValidateStatus.ToString().ToLower()}", () => ValidateStatus.IsIn(FormValidateStatus.Success, FormValidateStatus.Error, FormValidateStatus.Warning))
+                .GetIf(() => $"{_prefixCls}-has-{ValidateStatus.ToString().ToLower()}", () => (HasFeedback || IsShowFeedbackOnError) && ValidateStatus.IsIn(FormValidateStatus.Success, FormValidateStatus.Error, FormValidateStatus.Warning))
                 .If($"{_prefixCls}-with-help", () => !string.IsNullOrEmpty(Help))
                ;
 
@@ -351,8 +361,7 @@ namespace AntDesign
                         ValidateMessages = validateMessages,
                     };
 
-                    var result = FormValidateHelper.GetValidationResult(validationContext);
-
+                    var result = FormValidateHelper.GetValidationResult(validationContext);                   
                     if (result != null)
                     {
                         results.Add(result);

--- a/components/form/FormItem.razor.cs
+++ b/components/form/FormItem.razor.cs
@@ -187,9 +187,11 @@ namespace AntDesign
                 .Add(_prefixCls)
                 .If($"{_prefixCls}-with-help {_prefixCls}-has-error", () => _isValid == false)
                 .If($"{_prefixCls}-rtl", () => RTL)
-                .If($"{_prefixCls}-has-feedback", () => HasFeedback || IsShowFeedbackOnError)
+                .If($"{_prefixCls}-has-feedback", () => IsShowFeedback)
                 .If($"{_prefixCls}-is-validating", () => ValidateStatus == FormValidateStatus.Validating)
-                .GetIf(() => $"{_prefixCls}-has-{ValidateStatus.ToString().ToLower()}", () => IsShowFeedback && ValidateStatus.IsIn(FormValidateStatus.Success, FormValidateStatus.Error, FormValidateStatus.Warning))
+                .GetIf(() => $"{_prefixCls}-has-{ValidateStatus.ToString().ToLower()}", () => HasFeedback && ValidateStatus.IsIn(FormValidateStatus.Success, FormValidateStatus.Error, FormValidateStatus.Warning))
+                .GetIf(() => $"{_prefixCls}-has-{ValidateStatus.ToString().ToLower()}", () => IsShowFeedbackOnError && ValidateStatus == FormValidateStatus.Error)
+                .GetIf(() => $"{_prefixCls}-has-{ValidateStatus.ToString().ToLower()}", () => IsShowFeedbackOnSuccess && ValidateStatus == FormValidateStatus.Success)
                 .If($"{_prefixCls}-with-help", () => !string.IsNullOrEmpty(Help))
                ;
 

--- a/site/AntDesign.Docs/Demos/Components/Form/demo/ValidateWithFeedback.razor
+++ b/site/AntDesign.Docs/Demos/Components/Form/demo/ValidateWithFeedback.razor
@@ -1,0 +1,47 @@
+﻿@using System.ComponentModel.DataAnnotations;
+
+<Switch @bind-Value="@auto" CheckedChildren="True" UnCheckedChildren="False" />
+<Form @ref="form"
+      ValidateOnChange="@auto"
+      Model="@model"
+      LabelColSpan="8"
+      WrapperColSpan="16">
+    <FormItem Label="Username" ShowFeedbackOnError="true">
+        <Input @bind-Value="@context.Username" />
+    </FormItem>
+    <FormItem Label="Password" ShowFeedbackOnError="true">
+        <InputPassword @bind-Value="@context.Password" />
+    </FormItem>
+    <FormItem WrapperColOffset="8" WrapperColSpan="16">
+        <Checkbox @bind-Value="context.RememberMe">Remember me</Checkbox>
+    </FormItem>
+    <FormItem WrapperColOffset="8" WrapperColSpan="16">
+        <Button Type="@ButtonType.Primary" OnClick="OnValidate">
+            Validate
+        </Button>
+    </FormItem>
+ 
+</Form>
+@code
+{
+    public class Model
+    {
+        [Required]
+        public string Username { get; set; }
+        [Required]
+        public string Password { get; set; }
+  
+        public bool RememberMe { get; set; } = true;
+    }
+
+    private Model model = new Model();
+
+    AntDesign.Form<Model> form;
+
+    private bool auto = false;
+
+    public void OnValidate()
+    {
+        form.Validate();
+    }
+}

--- a/site/AntDesign.Docs/Demos/Components/Form/demo/ValidateWithFeedback.razor
+++ b/site/AntDesign.Docs/Demos/Components/Form/demo/ValidateWithFeedback.razor
@@ -6,10 +6,10 @@
       Model="@model"
       LabelColSpan="8"
       WrapperColSpan="16">
-    <FormItem Label="Username" ShowFeedbackOnError="true">
+    <FormItem Label="Username" ShowFeedbackOn="true">
         <Input @bind-Value="@context.Username" />
     </FormItem>
-    <FormItem Label="Password" ShowFeedbackOnError="true">
+    <FormItem Label="Password" ShowFeedbackOn="true">
         <InputPassword @bind-Value="@context.Password" />
     </FormItem>
     <FormItem WrapperColOffset="8" WrapperColSpan="16">

--- a/site/AntDesign.Docs/Demos/Components/Form/demo/validate-with-feedback.md
+++ b/site/AntDesign.Docs/Demos/Components/Form/demo/validate-with-feedback.md
@@ -1,8 +1,8 @@
 ---
 order: 103
 title:
-zh-CN:
-en-US: Validate with Feedback
+  zh-CN:
+  en-US: Validate with Feedback
 ---
 
 ## zh-CN

--- a/site/AntDesign.Docs/Demos/Components/Form/demo/validate-with-feedback.md
+++ b/site/AntDesign.Docs/Demos/Components/Form/demo/validate-with-feedback.md
@@ -1,0 +1,13 @@
+---
+order: 103
+title:
+zh-CN:
+en-US: Validate with Feedback
+---
+
+## zh-CN
+
+
+## en-US
+
+Show field level error indicator if a field is invalid.  This indicator will show when the form validates.

--- a/site/AntDesign.Docs/Demos/Components/Form/doc/index.en-US.md
+++ b/site/AntDesign.Docs/Demos/Components/Form/doc/index.en-US.md
@@ -48,6 +48,7 @@ High performance Form component with data scope management. Including data colle
 | LabelStyle | **Label** Label Style | string |-|
 | Rules | Validation rules, set the validation logic of the field | [FormValidationRule[]](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/components/form/Validate/Rule/FormValidationRule.cs) |-|
 | HasFeedback | Used in conjunction with the **validateStatus** property to display the verification status icon. It is recommended to use it only with the Input component | bool | false |
+| ShowFeedbackOn | Used in conjunction with **ValidateStatus** property to display the verification status icon when the field is in error or valid. **ValidateStatus** defaults to Error if not set. It is recommended to use it only with the Input component. | bool | false |
 | ValidateStatus | Validation status, if not set, it will be automatically generated according to validation rules | [FormValidateStatus](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/components/form/FormValidateStatus.cs) | FormValidateStatus.Default |
 | Help | Prompt information | string | Automatically generated according to verification rules |
 

--- a/site/AntDesign.Docs/Demos/Components/Form/doc/index.zh-CN.md
+++ b/site/AntDesign.Docs/Demos/Components/Form/doc/index.zh-CN.md
@@ -49,6 +49,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/ORmcdeaoO/Form.svg
 | LabelStyle | **Label**标签的Style | string | - |
 | Rules | 校验规则,设置字段的校验逻辑 | [FormValidationRule[]](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/components/form/Validate/Rule/FormValidationRule.cs) | - |
 | HasFeedback | 配合 **validateStatus** 属性使用，展示校验状态图标，建议只配合 Input 组件使用 | bool | false |
+| ShowFeedbackOn | | bool | false |
 | ValidateStatus | 校验状态，如不设置，则会根据校验规则自动生成 | [FormValidateStatus](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/components/form/FormValidateStatus.cs) | FormValidateStatus.Default |
 | Help | 提示信息 | string | 根据校验规则自动生成 |
   


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

ADA. Visual indication beyond text and color of an error at the field level is helpful for disabled users when filling out forms.  

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

1. Currently, the only way to show an error icon on a field is if the developer is controlling the validation directly via `HasFeedback`.  But showing the error icon as visual feedback is also helpful when a FormItem is invalid based on the validations sets on the model object.  From an ADA perspective, users need a way to associate an error state to a form field without relying on color.  Though the descriptive text underneath is helpful, the icon helps them quickly distinguish between help text and validation text.
2. N/A
3. Allow the FormItems to opt-in to this visual indication.  Alternatively, consider setting this at the Form level and letting it cascade down, but fields would still have to opt-out if they didn't want to show any indication, mainly took the former approach since it was noted it's really meant for Input fields.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

Developers would just need to set the new parameters to true to opt-in to the visual indication.   There aren't any breaking changes, but it's not advised to use `HasFeedback` and `ShowFeedbackOnError` together as they're meant for two different types of validation flows.

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     x      |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
