### PR TITLE
Fix FieldIdentifier equality check in Rules Mode OnFieldChanged

### DIFF
--- a/components/form/Form.razor.cs
+++ b/components/form/Form.razor.cs
@@ -237,7 +237,7 @@ namespace AntDesign
             _rulesValidator.ClearError(args.FieldIdentifier);
 
             var formItem = _formItems
-                .Single(t => t.GetFieldIdentifier().FieldName == args.FieldIdentifier.FieldName);
+                .Single(t => t.GetFieldIdentifier().Equals(args.FieldIdentifier));
 
             var result = formItem.ValidateField();
 

--- a/tests/AntDesign.Tests/Form/EditContext/Form.EditContext.ValidationTests.razor
+++ b/tests/AntDesign.Tests/Form/EditContext/Form.EditContext.ValidationTests.razor
@@ -1,0 +1,56 @@
+﻿@inherits AntDesignTestBase
+@code {
+
+    class Model
+    {
+        public string Name { get; set; } = "";
+    }
+
+    class CompositeModel
+    {
+        public Model First { get; set; } = new Model { };
+        public Model Second { get; set; } = new Model { };
+    }
+
+    FormValidationRule _validateStringValueMaxThreeCharacters = new FormValidationRule {
+        Type = FormFieldType.String, 
+        Max = 3, 
+        Message = "This field cannot be longer than 3 characters." 
+    };
+
+
+#if NET6_0
+	[Fact]
+	public void Form_EditContext_with_RulesModeValidation_and_CompositeModel_should_validate_properly()
+	{
+	    //Arrange
+	    JSInterop.Setup<AntDesign.JsInterop.Window>(JSInteropConstants.GetWindow)
+		    .SetResult(new AntDesign.JsInterop.Window());
+
+        var rules = new [] { _validateStringValueMaxThreeCharacters };
+        CompositeModel model = new CompositeModel();
+        Form<CompositeModel>? form = null;
+		var cut = Render<Form<CompositeModel>>(
+			@<AntDesign.Form @ref="@form" Model="@model"
+				ValidateOnChange="@true" ValidateMode=@FormValidateMode.Rules>
+				<AntDesign.FormItem Label="Name of First" Rules=rules>
+					<AntDesign.Input Id="firstInput" @bind-Value=@context.First.Name DebounceMilliseconds="0"/>
+				</AntDesign.FormItem>    
+				<AntDesign.FormItem  Label="Name of Second" Rules=rules>
+					<AntDesign.Input Id="secondInput" @bind-Value=@context.Second.Name DebounceMilliseconds="0"/>
+				</AntDesign.FormItem>    
+			</AntDesign.Form>
+			);		
+		//Act
+		var secondInput = cut.Find("#secondInput");
+		secondInput.Input("1234");
+		secondInput.KeyUp(String.Empty);
+        
+        var firstInputValidationMessages = form!.EditContext.GetValidationMessages(() => model.First.Name);
+        var secondInputValidationMessages = form!.EditContext.GetValidationMessages(() => model.Second.Name);
+		//Assert
+        firstInputValidationMessages.Should().BeEmpty();
+        secondInputValidationMessages.Should().HaveCount(1).And.Contain(_validateStringValueMaxThreeCharacters.Message);
+	}
+#endif
+}

--- a/tests/AntDesign.Tests/Form/EditContext/Form.EditContext.ValidationTests.razor
+++ b/tests/AntDesign.Tests/Form/EditContext/Form.EditContext.ValidationTests.razor
@@ -20,37 +20,37 @@
 
 
 #if NET6_0
-	[Fact]
-	public void Form_EditContext_with_RulesModeValidation_and_CompositeModel_should_validate_properly()
-	{
-	    //Arrange
-	    JSInterop.Setup<AntDesign.JsInterop.Window>(JSInteropConstants.GetWindow)
-		    .SetResult(new AntDesign.JsInterop.Window());
+    [Fact]
+    public void Form_EditContext_with_RulesModeValidation_and_CompositeModel_should_validate_properly()
+    {
+        //Arrange
+        JSInterop.Setup<AntDesign.JsInterop.Window>(JSInteropConstants.GetWindow)
+            .SetResult(new AntDesign.JsInterop.Window());
 
         var rules = new [] { _validateStringValueMaxThreeCharacters };
         CompositeModel model = new CompositeModel();
         Form<CompositeModel>? form = null;
-		var cut = Render<Form<CompositeModel>>(
-			@<AntDesign.Form @ref="@form" Model="@model"
-				ValidateOnChange="@true" ValidateMode=@FormValidateMode.Rules>
-				<AntDesign.FormItem Label="Name of First" Rules=rules>
-					<AntDesign.Input Id="firstInput" @bind-Value=@context.First.Name DebounceMilliseconds="0"/>
-				</AntDesign.FormItem>    
-				<AntDesign.FormItem  Label="Name of Second" Rules=rules>
-					<AntDesign.Input Id="secondInput" @bind-Value=@context.Second.Name DebounceMilliseconds="0"/>
-				</AntDesign.FormItem>    
-			</AntDesign.Form>
-			);		
-		//Act
-		var secondInput = cut.Find("#secondInput");
-		secondInput.Input("1234");
-		secondInput.KeyUp(String.Empty);
+        var cut = Render<Form<CompositeModel>>(
+            @<AntDesign.Form @ref="@form" Model="@model"
+                ValidateOnChange="@true" ValidateMode=@FormValidateMode.Rules>
+                <AntDesign.FormItem Label="Name of First" Rules=rules>
+                    <AntDesign.Input Id="firstInput" @bind-Value=@context.First.Name DebounceMilliseconds="0"/>
+                </AntDesign.FormItem>    
+                <AntDesign.FormItem  Label="Name of Second" Rules=rules>
+                    <AntDesign.Input Id="secondInput" @bind-Value=@context.Second.Name DebounceMilliseconds="0"/>
+                </AntDesign.FormItem>    
+            </AntDesign.Form>
+            );        
+        //Act
+        var secondInput = cut.Find("#secondInput");
+        secondInput.Input("1234");
+        secondInput.KeyUp(String.Empty);
         
         var firstInputValidationMessages = form!.EditContext.GetValidationMessages(() => model.First.Name);
         var secondInputValidationMessages = form!.EditContext.GetValidationMessages(() => model.Second.Name);
-		//Assert
+        //Assert
         firstInputValidationMessages.Should().BeEmpty();
         secondInputValidationMessages.Should().HaveCount(1).And.Contain(_validateStringValueMaxThreeCharacters.Message);
-	}
+    }
 #endif
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

### 💡 Background and solution

An InvalidOperationException is thrown when more than one input of a given form is bound to a property with the same name and we want rules based validation, even if they belong to a different instance.
This can happen in a couple of ways, for example we can have a view model that has two properties: *Player1* and *Player2*, both of type *Player*. Currently, we cannot add an input field for *model.Player1.Name* and *model.Player2.Name* both because we would have two fields with *FieldName* *Name*.
Similarly, if our view model had a *Contacts* property of *List<ContactInformation>* type, we could not bind the properties of *ContactInformation* to input fields, because they would clash.

The problem seems to be caused by the way equality is checked for fields in the line below:

https://github.com/ant-design-blazor/ant-design-blazor/blob/bb1030a5a4026c6fac379253db34a1fad5fea33a/components/form/Form.razor.cs#L240

Since FieldIdentifier provides its own implementation to check equality and that takes the underlying model instance into account, we can fix this by simply using that.

### 📝 Changelog

Rules and Complex form validation modes can now work properly with complex composite view models where the same field name is bound to different input elements. Not a breaking change, since the current behavior is more restrictive.

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    x      |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
