### PR TITLE
feat(module: tooltip): enable setting TabIndex via parameter

### DIFF
--- a/components/tooltip/Tooltip.razor
+++ b/components/tooltip/Tooltip.razor
@@ -13,7 +13,7 @@
      @onfocusin="OnTriggerFocusIn"
      @onfocusout="OnTriggerFocusOut"
      @oncontextmenu:preventDefault
-     tabindex="0">
+     tabindex="@TabIndex">
     @ChildContent
 </div>
 }

--- a/components/tooltip/Tooltip.razor.cs
+++ b/components/tooltip/Tooltip.razor.cs
@@ -20,6 +20,9 @@ namespace AntDesign
         [Parameter]
         public double MouseLeaveDelay { get; set; } = 0.1;
 
+        [Parameter]
+        public int TabIndex { get; set; } = 0;
+
         public Tooltip()
         {
             PrefixCls = "ant-tooltip";


### PR DESCRIPTION
### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/ant-design-blazor/ant-design-blazor/issues/2566

### 💡 Background and solution

In the current shape, tooltip component is stealing focus (when user is jumping through elements on the page using Tab key) even if children elements of the tooltip have `tabindex` set to `-1`.  Enabling customization of tooltip's tabindex via parameter allows developer to alter this behavior if needed. The default behavior (`tabindex="0"`) required for proper functioning of the focus trigger (https://github.com/ant-design-blazor/ant-design-blazor/pull/2404) remains the same, so we are on the safe side - it's up to the user to consciously opt-out.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Tooltip: enable setting TabIndex via parameter. |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
