### PR TITLE
fix:(module:rangepicker): date selection

### DIFF
--- a/components/date-picker/RangePicker.razor.cs
+++ b/components/date-picker/RangePicker.razor.cs
@@ -58,34 +58,49 @@ namespace AntDesign
             {
                 var array = Value as Array;
 
+                int? index = null;
+
                 if (_pickerStatus[0].IsValueSelected && _inputEnd.IsOnFocused)
                 {
-                    DateTime? value = null;
-                    GetIfNotNull(Value, 0, notNullValue =>
-                    {
-                        value = notNullValue;
-                    });
-
-                    if (value != null)
-                    {
-                        return DateHelper.FormatDateByPicker(date.Date, Picker) < DateHelper.FormatDateByPicker(((DateTime)value).Date, Picker);
-                    }
+                    index = 0;
                 }
-                if (_pickerStatus[1].IsValueSelected && _inputStart.IsOnFocused)
+                else if (_pickerStatus[1].IsValueSelected && _inputStart.IsOnFocused)
                 {
-                    DateTime? value = null;
-                    GetIfNotNull(Value, 1, notNullValue =>
-                    {
-                        value = notNullValue;
-                    });
-
-                    if (value != null)
-                    {
-                        return DateHelper.FormatDateByPicker(date.Date, Picker) > DateHelper.FormatDateByPicker(((DateTime)value).Date, Picker);
-                    }
+                    index = 1;
                 }
 
-                return false;
+                if (index is null)
+                {
+                    return false;
+                }
+
+                DateTime? value = null;
+
+                GetIfNotNull(Value, index.Value, notNullValue =>
+                {
+                    value = notNullValue;
+                });
+
+                if (value is null)
+                {
+                    return false;
+                }
+
+                var date1 = date.Date;
+                var date2 = ((DateTime)value).Date;
+
+                if (Picker == DatePickerType.Week)
+                {
+                    var date1Week = DateHelper.GetWeekOfYear(date1, Locale.FirstDayOfWeek);
+                    var date2Week = DateHelper.GetWeekOfYear(date2, Locale.FirstDayOfWeek);
+                    return index == 0 ? date1Week < date2Week : date1Week > date2Week;
+                }
+                else
+                {
+                    var formattedDate1 = DateHelper.FormatDateByPicker(date1, Picker);
+                    var formattedDate2 = DateHelper.FormatDateByPicker(date2, Picker);
+                    return index == 0 ? formattedDate1 < formattedDate2 : formattedDate1 > formattedDate2;
+                }
             };
         }
 

--- a/components/date-picker/RangePicker.razor.cs
+++ b/components/date-picker/RangePicker.razor.cs
@@ -166,7 +166,8 @@ namespace AntDesign
                 _cacheDuringInput = array.GetValue(index) as DateTime?;
                 _pickerValueCache = PickerValues[index];
             }
-            if (FormatAnalyzer.TryPickerStringConvert(args.Value.ToString(), out DateTime changeValue, false))
+            if (FormatAnalyzer.TryPickerStringConvert(args.Value.ToString(), out DateTime changeValue, false)
+                && IsValidRange(changeValue, index, array))
             {
                 array.SetValue(changeValue, index);
                 _cacheDuringInput = changeValue;
@@ -598,6 +599,16 @@ namespace AntDesign
         {
             await Focus();
             await OnInputClick(0);
+        }
+
+        private bool IsValidRange(DateTime newValue, int newValueIndex, Array rangeValues)
+        {
+            return newValueIndex switch
+            {
+                0 when newValue > (rangeValues.GetValue(1) as DateTime?) => false,
+                1 when newValue < (rangeValues.GetValue(0) as DateTime?) => false,
+                _ => true
+            };
         }
     }
 }

--- a/components/date-picker/internal/DatePickerTemplate.razor.cs
+++ b/components/date-picker/internal/DatePickerTemplate.razor.cs
@@ -402,9 +402,7 @@ namespace AntDesign.Internal
         {
             string disabledCls = "";
 
-            var nextStartDate = GetNextStartDate(currentColDate);
-
-            if (DisabledDate?.Invoke(DateHelper.AddDaysSafely(nextStartDate, -1)) == true)
+            if (DisabledDate?.Invoke(currentColDate) == true)
             {
                 disabledCls = $"{PrefixCls}-cell-disabled";
             }
@@ -450,21 +448,6 @@ namespace AntDesign.Internal
                 DatePickerType.Month => DateHelper.AddMonthsSafely(dateTime, 1),
                 DatePickerType.Quarter => DateHelper.AddMonthsSafely(dateTime, 3),
                 _ => dateTime,
-            };
-        }
-
-        private DateTime GetNextStartDate(DateTime currentDateTime)
-        {
-            return Picker switch
-            {
-                DatePickerType.Decade => DateHelper.GetNextStartDateOfDecade(currentDateTime),
-                DatePickerType.Year => DateHelper.GetNextStartDateOfYear(currentDateTime),
-                DatePickerType.Quarter => DateHelper.GetNextStartDateOfQuarter(currentDateTime),
-                DatePickerType.Month => DateHelper.GetNextStartDateOfMonth(currentDateTime),
-                DatePickerType.Week => DateHelper.GetNextStartDateOfDay(currentDateTime),
-                DatePickerType.Date => DateHelper.GetNextStartDateOfDay(currentDateTime),
-                DatePickerType.Time => DateHelper.GetNextStartDateOfDay(currentDateTime),
-                _ => currentDateTime,
             };
         }
 

--- a/tests/AntDesign.Tests/DatePicker/RangePickerTests.razor
+++ b/tests/AntDesign.Tests/DatePicker/RangePickerTests.razor
@@ -35,7 +35,7 @@
 
         //Act
         var cut = Render<AntDesign.RangePicker<DateTime?[]>>
-                  (@<RangePicker @bind-Value="rangeValue" Placeholder="@(placeholders)"/>);
+                  (@<RangePicker @bind-Value="rangeValue" Placeholder="@(placeholders)" />);
 
         cut.Instance.ClearValue();
 
@@ -47,6 +47,79 @@
         {
             var input = inputs[i];
             input.GetAttribute("placeholder").Should().Be(placeholders[i]);
+        }
+    }
+
+    [Fact]
+    public async Task Sets_disabled_time_when_range_dates_are_the_same()
+    {
+        //Arrange
+        JSInterop.SetupVoid(JSInteropConstants.AddPreventKeys, _ => true);
+        JSInterop.SetupVoid(JSInteropConstants.Blur, _ => true);
+        JSInterop.Setup<OverlayPosition>(JSInteropConstants.OverlayComponentHelper.AddOverlayToContainer, _ => true)
+            .SetResult(new OverlayPosition());
+        JSInterop.Setup<HtmlElement>(JSInteropConstants.DomInfoHelper.GetInfo, _ => true);
+
+        var startValue = new DateTime(2022, 6, 8, 20, 20, 0);
+        var endValue = new DateTime(2022, 6, 8, 20, 20, 30);
+        var rangeValue = new DateTime?[] { startValue, endValue };
+
+        var expectedDisabledStartHours = new int[] { 21, 22, 23 };
+        var expectedDisabledStartMinutes = Enumerable.Range(21, 39).ToArray();
+        var expectedDisabledStartSeconds = Enumerable.Range(31, 29).ToArray();
+
+        var expectedDisabledEndHours = Enumerable.Range(0, 20);
+        var expectedDisabledEndMinutes = Enumerable.Range(0, 20).ToArray();
+        var expectedDisabledEndSeconds = Enumerable.Range(31, 29).ToArray();
+
+        //Act
+        var cut = Render<AntDesign.RangePicker<DateTime?[]>>
+                  (@<RangePicker @bind-Value="rangeValue" ShowTime="true" />);
+
+        var inputs = cut.FindAll("input").ToList();
+
+        //Assert
+
+        await inputs[0].ClickAsync(new MouseEventArgs());
+        cut.Instance.DisabledHours.Invoke(startValue).Should().BeEquivalentTo(expectedDisabledStartHours);
+        cut.Instance.DisabledMinutes.Invoke(startValue).Should().BeEquivalentTo(expectedDisabledStartMinutes);
+        cut.Instance.DisabledSeconds.Invoke(startValue).Should().BeEquivalentTo(expectedDisabledStartSeconds);
+
+        await inputs[1].ClickAsync(new MouseEventArgs());
+        cut.Instance.DisabledHours.Invoke(endValue).Should().BeEquivalentTo(expectedDisabledEndHours);
+        cut.Instance.DisabledMinutes.Invoke(endValue).Should().BeEquivalentTo(expectedDisabledEndMinutes);
+        cut.Instance.DisabledSeconds.Invoke(endValue).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Sets_empty_disabled_time_when_range_dates_are_not_the_same()
+    {
+        //Arrange
+        JSInterop.SetupVoid(JSInteropConstants.AddPreventKeys, _ => true);
+        JSInterop.SetupVoid(JSInteropConstants.Blur, _ => true);
+        JSInterop.Setup<OverlayPosition>(JSInteropConstants.OverlayComponentHelper.AddOverlayToContainer, _ => true)
+            .SetResult(new OverlayPosition());
+        JSInterop.Setup<HtmlElement>(JSInteropConstants.DomInfoHelper.GetInfo, _ => true);
+
+        var rangeValue = new DateTime?[]
+        {
+            new DateTime(2022, 6, 8, 20, 20, 0),
+            new DateTime(2022, 6, 9, 20, 20, 30)
+        };
+
+        //Act
+        var cut = Render<AntDesign.RangePicker<DateTime?[]>>
+                  (@<RangePicker @bind-Value="rangeValue" ShowTime="true" /> );
+
+        var inputs = cut.FindAll("input").ToList();
+
+        //Assert
+        for (var i = 0; i < inputs.Count; i++)
+        {
+            await inputs[i].ClickAsync(new MouseEventArgs());
+            cut.Instance.DisabledHours.Invoke(rangeValue[i]!.Value).Should().BeEmpty();
+            cut.Instance.DisabledMinutes.Invoke(rangeValue[i]!.Value).Should().BeEmpty();
+            cut.Instance.DisabledSeconds.Invoke(rangeValue[i]!.Value).Should().BeEmpty();
         }
     }
 }

--- a/tests/AntDesign.Tests/DatePicker/RangePickerTests.razor
+++ b/tests/AntDesign.Tests/DatePicker/RangePickerTests.razor
@@ -122,4 +122,82 @@
             cut.Instance.DisabledSeconds.Invoke(rangeValue[i]!.Value).Should().BeEmpty();
         }
     }
+
+    [Fact]
+    public void Ignores_keyboard_input_when_start_is_later_than_end()
+    {
+        //Arrange
+        JSInterop.SetupVoid(JSInteropConstants.AddPreventKeys, _ => true);
+        JSInterop.SetupVoid(JSInteropConstants.InvokeTabKey, _ => true);
+
+        var range = new DateTime[]
+        {
+            new DateTime(2022, 6, 8, 20, 20, 0),
+            new DateTime(2022, 6, 8, 20, 20, 30)
+        };
+         
+        var expectedStart = range[0];
+        var expectedEnd = range[1];
+
+        var format = "yyyy-MM-dd HH:mm:ss";
+        string startValueAsString = expectedStart.ToString(format);
+        string endValueAsString = expectedEnd.ToString(format);
+
+        string keyboardInput = "2022-06-08 20:25:35";
+
+        //Act
+        var cut = Render<AntDesign.RangePicker<DateTime[]>>
+                  (@<RangePicker @bind-Value="range" ShowTime="true" />);
+ 
+        //Act
+        var input = cut.FindAll("input");
+        input[0].Input(keyboardInput);
+        input[0].KeyDown("ENTER");
+
+        //Assert
+        cut.Instance.Value[0].Should().Be(expectedStart);
+        input[0].GetAttribute("value").Should().Be(startValueAsString);
+
+        cut.Instance.Value[1].Should().Be(expectedEnd);
+        input[1].GetAttribute("value").Should().Be(endValueAsString);
+    }
+
+    [Fact]
+    public void Ignores_keyboard_input_when_end_is_earlier_than_start()
+    {
+        //Arrange
+        JSInterop.SetupVoid(JSInteropConstants.AddPreventKeys, _ => true);
+        JSInterop.SetupVoid(JSInteropConstants.InvokeTabKey, _ => true);
+
+        var range = new DateTime[]
+       {
+            new DateTime(2022, 6, 8, 20, 20, 0),
+            new DateTime(2022, 6, 8, 20, 20, 30)
+       };
+
+        var expectedStart = range[0];
+        var expectedEnd = range[1];
+
+        var format = "yyyy-MM-dd HH:mm:ss";
+        string startValueAsString = expectedStart.ToString(format);
+        string endValueAsString = expectedEnd.ToString(format);
+
+        string keyboardInput = "2022-06-07 12:25:35";
+
+        //Act
+        var cut = Render<AntDesign.RangePicker<DateTime[]>>
+                  (@<RangePicker @bind-Value="range" ShowTime="true" />);
+
+        //Act
+        var input = cut.FindAll("input");
+        input[1].Input(keyboardInput);
+        input[1].KeyDown("ENTER");
+
+        //Assert
+        cut.Instance.Value[0].Should().Be(expectedStart);
+        input[0].GetAttribute("value").Should().Be(startValueAsString);
+
+        cut.Instance.Value[1].Should().Be(expectedEnd);
+        input[1].GetAttribute("value").Should().Be(endValueAsString);
+    }
 }


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/ant-design-blazor/ant-design-blazor/issues/1429

### 💡 Background and solution

Fixes quarter/week range selection when the end value is set first.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
