### PR TITLE
fix:(module:rangepicker): now button

### DIFF
--- a/components/date-picker/internal/DatePickerDatetimePanel.razor
+++ b/components/date-picker/internal/DatePickerDatetimePanel.razor
@@ -220,7 +220,9 @@
         {
             <li class="@(PrefixCls)-now">
                 <a class="@(PrefixCls)-now-btn"
-                @onclick="e => { OnSelectTime(DateTime.Now); Close(); }">
+                @onclick="e => { 
+                    OnSelectTime(DateTime.Now); 
+                    if(!IsShowTime && Picker != DatePickerType.Time) Close(); }">
                     @Locale.Lang.Now
                 </a>
             </li>            


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

In `RangePicker` when time input is enabled, the Now button closes the input panel and resets the value.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
