### PR TITLE
修复TreeNode的Disable和Checked属性共存不生效的问题

### DIFF
--- a/components/tree/Tree.razor.cs
+++ b/components/tree/Tree.razor.cs
@@ -629,7 +629,7 @@ namespace AntDesign
             {
                 var node = this._allNodes.FirstOrDefault(x => x.Key == k);
                 if (node != null)
-                    node.SetChecked(true);
+                    node.SetCheckedDefault(true);
             });
 
             this.DefaultSelectedKeys?.ForEach(k =>

--- a/components/tree/TreeNode.razor.cs
+++ b/components/tree/TreeNode.razor.cs
@@ -455,6 +455,24 @@ namespace AntDesign
                 TreeComponent.AddOrRemoveCheckNode(this);
             StateHasChanged();
         }
+        /// <summary>
+        /// Set the checkbox state when ini
+        /// </summary>
+        /// <param name="check"></param>
+        public void SetCheckedDefault(bool check)
+        {
+            if (TreeComponent.CheckStrictly)
+            {
+                this.Checked = check;
+            }
+            else
+            {
+                SetChildCheckedDefault(this, check);
+                if (ParentNode != null)
+                    ParentNode.UpdateCheckStateDefault();
+            }
+            StateHasChanged();
+        }
 
         /// <summary>
         /// Sets the checkbox status of child nodes
@@ -471,6 +489,20 @@ namespace AntDesign
                 foreach (var child in subnode.ChildNodes)
                     child?.SetChildChecked(child, check);
         }
+        /// <summary>
+        /// Sets the checkbox status of child nodes whern bind default
+        /// </summary>
+        /// <param name="subnode"></param>
+        /// <param name="check"></param>
+        private void SetChildCheckedDefault(TreeNode<TItem> subnode, bool check)
+        {
+            this.Checked = check;
+            this.Indeterminate = false;
+            TreeComponent.AddOrRemoveCheckNode(this);
+            if (subnode.HasChildNodes)
+                foreach (var child in subnode.ChildNodes)
+                    child?.SetChildCheckedDefault(child, check);
+        }        
 
         /// <summary>
         /// Update check status
@@ -531,6 +563,66 @@ namespace AntDesign
 
             if (ParentNode != null)
                 ParentNode.UpdateCheckState(this.Indeterminate);
+
+            if (ParentNode == null)
+                StateHasChanged();
+        }
+        /// <summary>
+        /// Update check status when bind default
+        /// </summary>
+        /// <param name="halfChecked"></param>
+        private void UpdateCheckStateDefault(bool? halfChecked = null)
+        {
+            if (halfChecked == true)
+            {
+                //If the child node is indeterminate, the parent node must is indeterminate.
+                this.Checked = false;
+                this.Indeterminate = true;
+            }
+            else if (HasChildNodes == true && !DisableCheckbox)
+            {
+                //Determines the selection status of the current node
+                bool hasChecked = false;
+                bool hasUnchecked = false;
+
+                foreach (var item in ChildNodes)
+                {
+                    if (item.Indeterminate)
+                    {
+                        hasChecked = true;
+                        hasUnchecked = true;
+                        break;
+                    }
+                    else if (item.Checked)
+                    {
+                        hasChecked = true;
+                    }
+                    else if (!item.Checked)
+                    {
+                        hasUnchecked = true;
+                    }
+                }
+
+                if (hasChecked && !hasUnchecked)
+                {
+                    this.Checked = true;
+                    this.Indeterminate = false;
+                }
+                else if (!hasChecked && hasUnchecked)
+                {
+                    this.Checked = false;
+                    this.Indeterminate = false;
+                }
+                else if (hasChecked && hasUnchecked)
+                {
+                    this.Checked = false;
+                    this.Indeterminate = true;
+                }
+            }
+            TreeComponent.AddOrRemoveCheckNode(this);
+
+            if (ParentNode != null)
+                ParentNode.UpdateCheckStateDefault(this.Indeterminate);
 
             if (ParentNode == null)
                 StateHasChanged();


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix the problem that the coexistence of Disable and Checked attributes of TreeNode does not take effect     |
| 🇨🇳 Chinese |      修复TreeNode的Disable和Checked属性共存不生效的问题     |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
