### PR TITLE
fix(module: input): OnChange will invoke twice when paste data to Input 

### DIFF
--- a/components/input/Input.cs
+++ b/components/input/Input.cs
@@ -333,6 +333,7 @@ namespace AntDesign
         {
             if (CurrentValueAsString != args?.Value?.ToString())
             {
+                CurrentValueAsString = args?.Value?.ToString();
                 if (OnChange.HasDelegate)
                 {
                     await OnChange.InvokeAsync(Value);

--- a/components/input/Input.cs
+++ b/components/input/Input.cs
@@ -637,11 +637,12 @@ namespace AntDesign
                 }
 
                 // onchange 和 onblur 事件会导致点击 OnSearch 按钮时不触发 Click 事件，暂时取消这两个事件
-                if (!IgnoreOnChangeAndBlur)
-                {
+                //2022-8-3 去掉if后，search也能正常工作
+                //if (!IgnoreOnChangeAndBlur)
+                //{
                     builder.AddAttribute(70, "onchange", CallbackFactory.Create(this, OnChangeAsync));
                     builder.AddAttribute(71, "onblur", CallbackFactory.Create(this, OnBlurAsync));
-                }
+                //}
 
                 builder.AddAttribute(72, "onkeypress", CallbackFactory.Create(this, OnKeyPressAsync));
                 builder.AddAttribute(73, "onkeydown", CallbackFactory.Create(this, OnkeyDownAsync));


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   fix bug that OnChange will invoke twice when paste data to Input #2591    |
| 🇨🇳 Chinese |     修复将数据粘贴到Input时OnChange将调用两次的错误   #2591   |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
