### PR TITLE
fix(module: Pagination): Pager 3 and 5 may be invisible when window width is small and there're many pages

### DIFF
--- a/components/pagination/Pagination.razor
+++ b/components/pagination/Pagination.razor
@@ -209,6 +209,7 @@
                          Page="@key"
                          Active="@(_current == key)"
                          ShowTitle="ShowTitle"
+                         Class=""
                          ItemRender="@ItemRender"/>
                     );
             }
@@ -239,7 +240,7 @@
                          Page="@right"
                          Active="@(_current == right)"
                          ShowTitle="ShowTitle"
-                         Class="@($"{PrefixCls}-item-after-jump-prev")"
+                         Class="@($"{PrefixCls}-item-before-jump-next")"
                          ItemRender="@ItemRender"/>;
                 pagerList.AddLast(jumpNext);
             }

--- a/components/pagination/PaginationPager.razor
+++ b/components/pagination/PaginationPager.razor
@@ -46,7 +46,6 @@
         var prefixCls = $"{RootPrefixCls}-item";
         ClassMapper.Add(prefixCls).Add($"{prefixCls}-{Page}")
                    .If($"{prefixCls}-active", () => Active)
-                   .If(Class, () => !string.IsNullOrWhiteSpace(Class))
                    .If($"{prefixCls}-disabled", () => Page == 0);
 
         base.OnInitialized();


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

Fixes #2124 

### 💡 Background and solution

There're several issues with Pagination component, some are invisible, while some are affecting user experience under small screens

1. Immediately after the component is loaded, the class attribute of PaginationPager 5 is not properly set:
`class="ant-pagination-item-after-jump-prev ant-pagination-item ant-pagination-item-5 ant-pagination-item-after-jump-prev"`
 - Should be `before-jump-next` instead of `after-jump-prev`
 - There're 2 `ant-pagination-item-after-jump-prev`, which is redundant
![image](https://user-images.githubusercontent.com/11327414/184835940-d9f37d64-004d-49d6-9f31-f375448417b4.png)

2. Click Page 5, we can see that PaginationPager 5 still holds `ant-pagination-item-after-jump-prev` class, which is  unexpected
![image](https://user-images.githubusercontent.com/11327414/184837216-7f2ffada-13a5-4547-961d-6d2e027086d5.png)

3. Then click Page 3, both PaginationPager 3 and 5 holds `ant-pagination-item-after-jump-prev` class, so they'll disappear when the screen width is small.
![image](https://user-images.githubusercontent.com/11327414/184837615-eb2e054a-0f73-490c-9620-514a7afaa36d.png)

So, fixes:
1. `if (itemBeforeJumpNext)` `Class="@($"{PrefixCls}-item-before-jump-next")"`
2. In `PaginationPager.OnInitialized()`, remove redundant adding of class itself to `ClassMapper` again
3. For each normal pager in `pagerList`, explicitly set `Class=""`

Tested locally, class for each pager is set properly,
and we can see pager 5 when it's selected on small screen width now.

![image](https://user-images.githubusercontent.com/11327414/184839596-81409e5e-47cd-482a-a3f1-8c7059e681b5.png)


### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix: Pagination won't show certain current page block when window width is small after a specific sequence of operation |
| 🇨🇳 Chinese | 修复 Pagination 在较小的屏幕宽度下，特定操作后，不会显示当前选中页的问题 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
