### PR TITLE
Update MessageService to implement and register as an interface

### DIFF
--- a/components/core/Extensions/ServiceCollectionExtensions.cs
+++ b/components/core/Extensions/ServiceCollectionExtensions.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.TryAddScoped<InteropService>();
             services.TryAddScoped<NotificationService>();
             services.TryAddScoped<MessageService>();
+            services.TryAddScoped<IMessageService>(provider => provider.GetRequiredService<MessageService>());
             services.TryAddScoped<ModalService>();
             services.TryAddScoped<DrawerService>();
             services.TryAddScoped<ConfirmService>();

--- a/components/message/IMessageService.cs
+++ b/components/message/IMessageService.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+using OneOf;
+
+namespace AntDesign;
+
+public interface IMessageService
+{
+    void Config(MessageGlobalConfig config);
+    void Destroy();
+    Task Error(OneOf<string, RenderFragment, MessageConfig> content, double? duration = null, Action onClose = null);
+    Task Info(OneOf<string, RenderFragment, MessageConfig> content, double? duration = null, Action onClose = null);
+    Task Loading(OneOf<string, RenderFragment, MessageConfig> content, double? duration = null, Action onClose = null);
+    Task Open([NotNull] MessageConfig config);
+    Task Success(OneOf<string, RenderFragment, MessageConfig> content, double? duration = null, Action onClose = null);
+    Task Warning(OneOf<string, RenderFragment, MessageConfig> content, double? duration = null, Action onClose = null);
+}

--- a/components/message/Message.razor.cs
+++ b/components/message/Message.razor.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;

--- a/components/message/MessageService.cs
+++ b/components/message/MessageService.cs
@@ -11,7 +11,7 @@ namespace AntDesign
     /// <summary>
     /// Message Service
     /// </summary>
-    public class MessageService
+    public class MessageService: IMessageService
     {
         internal event Action<MessageGlobalConfig> OnConfig;
         internal event Func<MessageConfig, Task> OnOpening;

--- a/site/AntDesign.Docs/Demos/Components/Drawer/demo/DropdownInDrawer.razor
+++ b/site/AntDesign.Docs/Demos/Components/Drawer/demo/DropdownInDrawer.razor
@@ -1,4 +1,4 @@
-﻿@inject MessageService _message
+﻿@inject IMessageService _message
 
 <div>
     <Button Type="primary" @onclick="_=>open()">Open</Button>

--- a/site/AntDesign.Docs/Demos/Components/Icon/demo/List.razor
+++ b/site/AntDesign.Docs/Demos/Components/Icon/demo/List.razor
@@ -47,7 +47,7 @@ else
 @inject AntDesign.Docs.Services.IconListService iconListService
 @inject IconService IconService
 @inject ILanguageService LanguageService
-@inject MessageService messageService
+@inject IMessageService messageService
 @inject IJSRuntime JsRuntime
 
 @code{

--- a/site/AntDesign.Docs/Demos/Components/Input/demo/SearchLoading.razor
+++ b/site/AntDesign.Docs/Demos/Components/Input/demo/SearchLoading.razor
@@ -8,7 +8,7 @@
     <Search Placeholder="input search text" Size="@InputSize.Large" EnterButton="@("Search")" @bind-Value="@txtValue" OnSearch="OnSearch"/>
 </div>
 
-@inject MessageService message;
+@inject IMessageService message;
 
 @code{
     private string txtValue { get; set; }

--- a/site/AntDesign.Docs/Demos/Components/Message/demo/ContinueWith.razor
+++ b/site/AntDesign.Docs/Demos/Components/Message/demo/ContinueWith.razor
@@ -1,4 +1,4 @@
-﻿@inject MessageService _message
+﻿@inject IMessageService _message
 
 <Button Type="default" OnClick="OnClick">
     Display normal message

--- a/site/AntDesign.Docs/Demos/Components/Message/demo/Duration.razor
+++ b/site/AntDesign.Docs/Demos/Components/Message/demo/Duration.razor
@@ -1,4 +1,4 @@
-﻿@inject MessageService _message
+﻿@inject IMessageService _message
 
 <Button Type="default" OnClick="OnClick">
     Customized display duration

--- a/site/AntDesign.Docs/Demos/Components/Message/demo/Info.razor
+++ b/site/AntDesign.Docs/Demos/Components/Message/demo/Info.razor
@@ -1,4 +1,4 @@
-﻿@inject MessageService _message
+﻿@inject IMessageService _message
 
 <Button Type="primary" OnClick="OnClick">
     Display normal message

--- a/site/AntDesign.Docs/Demos/Components/Message/demo/Loading.razor
+++ b/site/AntDesign.Docs/Demos/Components/Message/demo/Loading.razor
@@ -1,4 +1,4 @@
-﻿@inject MessageService _message
+﻿@inject IMessageService _message
 
     <Button Type="default" OnClick="OnClick">
         Display a loading indicator

--- a/site/AntDesign.Docs/Demos/Components/Message/demo/Other.razor
+++ b/site/AntDesign.Docs/Demos/Components/Message/demo/Other.razor
@@ -1,4 +1,4 @@
-﻿@inject MessageService _message
+﻿@inject IMessageService _message
 
 <Space>
     <SpaceItem>

--- a/site/AntDesign.Docs/Demos/Components/Message/demo/Update.razor
+++ b/site/AntDesign.Docs/Demos/Components/Message/demo/Update.razor
@@ -1,4 +1,4 @@
-﻿@inject MessageService _message
+﻿@inject IMessageService _message
 
 <Button Type="primary" OnClick="OnClick">
     Display normal message

--- a/site/AntDesign.Docs/Demos/Components/Message/doc/index.en-US.md
+++ b/site/AntDesign.Docs/Demos/Components/Message/doc/index.en-US.md
@@ -16,14 +16,14 @@ Display global messages as feedback in response to user operations.
 
 > Please confirm that the `<AntContainer />` component has been added to `App.Razor`.
 
-This components provides some static methods, with usage and arguments as following:
+This components provides some methods, with usage and arguments as following:
 
-- `MessageService.Success(content, [duration], onClose)`
-- `MessageService.Error(content, [duration], onClose)`
-- `MessageService.Info(content, [duration], onClose)`
-- `MessageService.Warning(content, [duration], onClose)`
-- `MessageService.Warn(content, [duration], onClose)` // alias of warning
-- `MessageService.Loading(content, [duration], onClose)`
+- `IMessageService.Success(content, [duration], onClose)`
+- `IMessageService.Error(content, [duration], onClose)`
+- `IMessageService.Info(content, [duration], onClose)`
+- `IMessageService.Warning(content, [duration], onClose)`
+- `IMessageService.Warn(content, [duration], onClose)` // alias of warning
+- `IMessageService.Loading(content, [duration], onClose)`
 
 | Argument | Description | Type | Default |
 | --- | --- | --- | --- |
@@ -33,20 +33,20 @@ This components provides some static methods, with usage and arguments as follow
 
 `afterClose` can be called in thenable interface:
 
-- `MessageService.[level](content, [duration]).ContinueWith(afterClose)`
-- `MessageService.[level](content, [duration], onClose).ContinueWith(afterClose)`
+- `IMessageService.[level](content, [duration]).ContinueWith(afterClose)`
+- `IMessageService.[level](content, [duration], onClose).ContinueWith(afterClose)`
 
-where `level` refers one static methods of `Message`. The result of `ContinueWith` method will be a Task.
+where `level` refers a method of `IMessageService`. The result of `ContinueWith` method will be a Task.
 
 Supports passing parameters wrapped in an object:
 
-- `MessageService.Open(config:MessageConfig)`
-- `MessageService.Success(config:MessageConfig)`
-- `MessageService.Error(config:MessageConfig)`
-- `MessageService.Info(config:MessageConfig)`
-- `MessageService.Warning(config:MessageConfig)`
-- `MessageService.Warn(config:MessageConfig)` // alias of warning
-- `MessageService.Loading(config:MessageConfig)`
+- `IMessageService.Open(config:MessageConfig)`
+- `IMessageService.Success(config:MessageConfig)`
+- `IMessageService.Error(config:MessageConfig)`
+- `IMessageService.Info(config:MessageConfig)`
+- `IMessageService.Warning(config:MessageConfig)`
+- `IMessageService.Warn(config:MessageConfig)` // alias of warning
+- `IMessageService.Loading(config:MessageConfig)`
 
 The properties of config are as follows:
 
@@ -62,12 +62,14 @@ The properties of config are as follows:
 
 Methods for global configuration and destruction are also provided:
 
-- `MessageService.Config(options:MessageGlobalConfig)`
-- `MessageService.Destroy()`
+- `IMessageService.Config(options:MessageGlobalConfig)`
+- `IMessageService.Destroy()`
 
 #### message.config
 
 ```c#
+@inject IMessageService MessageService;
+
 MessageService.Config(new MessageGlobalConfig{
   Top: 100,
   Duration: 2,

--- a/site/AntDesign.Docs/Demos/Components/Message/doc/index.zh-CN.md
+++ b/site/AntDesign.Docs/Demos/Components/Message/doc/index.zh-CN.md
@@ -17,14 +17,14 @@ cover: https://gw.alipayobjects.com/zos/alicdn/hAkKTIW0K/Message.svg
 
 > 请确认已经在 `App.Razor` 中添加了 `<AntContainer />` 组件。
 
-组件提供了一些静态方法，使用方式和参数如下：
+该组件提供了一些方法，用法和参数如下：
 
-- `MessageService.Success(content, [duration], onClose)`
-- `MessageService.Error(content, [duration], onClose)`
-- `MessageService.Info(content, [duration], onClose)`
-- `MessageService.Warning(content, [duration], onClose)`
-- `MessageService.Warn(content, [duration], onClose)` // alias of warning
-- `MessageService.Loading(content, [duration], onClose)`
+- `IMessageService.Success(content, [duration], onClose)`
+- `IMessageService.Error(content, [duration], onClose)`
+- `IMessageService.Info(content, [duration], onClose)`
+- `IMessageService.Warning(content, [duration], onClose)`
+- `IMessageService.Warn(content, [duration], onClose)` // alias of warning
+- `IMessageService.Loading(content, [duration], onClose)`
 
 | 参数     | 说明                                          | 类型                      | 默认值 |
 | -------- | --------------------------------------------- | ------------------------- | ------ |
@@ -34,20 +34,20 @@ cover: https://gw.alipayobjects.com/zos/alicdn/hAkKTIW0K/Message.svg
 
 组件同时提供 ContinueWith 接口。
 
-- `MessageService.[level](content, [duration]).ContinueWith(afterClose)`
-- `MessageService.[level](content, [duration], onClose).ContinueWith(afterClose)`
+- `IMessageService.[level](content, [duration]).ContinueWith(afterClose)`
+- `IMessageService.[level](content, [duration], onClose).ContinueWith(afterClose)`
 
-其中`MessageService.[level]` 是组件已经提供的静态方法。`ContinueWith` 接口返回值是 Task。
+其中 `[level]` 是组件已经提供的方法。 `ContinueWith` 接口的返回值为Task。
 
 也可以对象的形式传递参数：
 
-- `MessageService.Open(config:MessageConfig)`
-- `MessageService.Success(config:MessageConfig)`
-- `MessageService.Error(config:MessageConfig)`
-- `MessageService.Info(config:MessageConfig)`
-- `MessageService.Warning(config:MessageConfig)`
-- `MessageService.Warn(config:MessageConfig)` // alias of warning
-- `MessageService.Loading(config:MessageConfig)`
+- `IMessageService.Open(config:MessageConfig)`
+- `IMessageService.Success(config:MessageConfig)`
+- `IMessageService.Error(config:MessageConfig)`
+- `IMessageService.Info(config:MessageConfig)`
+- `IMessageService.Warning(config:MessageConfig)`
+- `IMessageService.Warn(config:MessageConfig)` // alias of warning
+- `IMessageService.Loading(config:MessageConfig)`
 
 `config` 对象属性如下：
 
@@ -63,12 +63,14 @@ cover: https://gw.alipayobjects.com/zos/alicdn/hAkKTIW0K/Message.svg
 
 还提供了全局配置和全局销毁方法：
 
-- `MessageService.Config(options:MessageGlobalConfig)`
-- `MessageService.Destroy()`
+- `IMessageService.Config(options:MessageGlobalConfig)`
+- `IMessageService.Destroy()`
 
-#### MessageService.Config
+#### IMessageService.Config
 
 ```c#
+@inject IMessageService MessageService;
+
 MessageService.Config(new MessageGlobalConfig{
   Top: 100,
   Duration: 2,

--- a/site/AntDesign.Docs/Demos/Components/Modal/demo/Confirm.razor
+++ b/site/AntDesign.Docs/Demos/Components/Modal/demo/Confirm.razor
@@ -1,5 +1,5 @@
 ﻿@inject ModalService _modalService
-@inject MessageService _message
+@inject IMessageService _message
 <Space>
     <SpaceItem>
         <Button OnClick="@ShowConfirm">Confirm</Button>

--- a/site/AntDesign.Docs/Demos/Components/Modal/demo/Confirm_Service.razor
+++ b/site/AntDesign.Docs/Demos/Components/Modal/demo/Confirm_Service.razor
@@ -1,4 +1,4 @@
-﻿@inject MessageService _message
+﻿@inject IMessageService _message
 @inject ConfirmService _confirmService
 
 

--- a/site/AntDesign.Docs/Demos/Components/Modal/demo/DropdownInModal.razor
+++ b/site/AntDesign.Docs/Demos/Components/Modal/demo/DropdownInModal.razor
@@ -1,4 +1,4 @@
-﻿@inject MessageService _message
+﻿@inject IMessageService _message
 
 <Button Type="primary" OnClick="@(()=>{ _visible = true; })">
     Open Modal

--- a/site/AntDesign.Docs/Demos/Components/Popconfirm/demo/Basic.razor
+++ b/site/AntDesign.Docs/Demos/Components/Popconfirm/demo/Basic.razor
@@ -1,4 +1,4 @@
-@inject MessageService _message
+@inject IMessageService _message
 
 <Popconfirm Title="Are you sure delete this task?"
             OnConfirm="Confirm"

--- a/site/AntDesign.Docs/Demos/Components/Popconfirm/demo/DynamicTrigger.razor
+++ b/site/AntDesign.Docs/Demos/Components/Popconfirm/demo/DynamicTrigger.razor
@@ -1,4 +1,4 @@
-@inject MessageService _message
+@inject IMessageService _message
 
 <div>
     <Popconfirm Title="Are you sure delete this task?"

--- a/site/AntDesign.Docs/Demos/Components/Popconfirm/demo/PlacementType.razor
+++ b/site/AntDesign.Docs/Demos/Components/Popconfirm/demo/PlacementType.razor
@@ -1,4 +1,4 @@
-@inject MessageService _message
+@inject IMessageService _message
 
 <div class="demo">
     <div style="margin-left: @($"{ButtonWidth}px"); white-space: nowrap;">

--- a/site/AntDesign.Docs/Demos/Components/Steps/demo/StepNext.razor
+++ b/site/AntDesign.Docs/Demos/Components/Steps/demo/StepNext.razor
@@ -44,7 +44,7 @@
     }
 </style>
 
-@inject MessageService message
+@inject IMessageService message
 @code {
 
     public class StepItem

--- a/site/AntDesign.Docs/Demos/Components/Upload/demo/Avatar.razor
+++ b/site/AntDesign.Docs/Demos/Components/Upload/demo/Avatar.razor
@@ -1,4 +1,4 @@
-@inject MessageService _message
+@inject IMessageService _message
 
     <Upload Action="https://www.mocky.io/v2/5cc8019d300000980a055e76"
             Name="avatar"

--- a/site/AntDesign.Docs/Demos/Components/Upload/demo/DefaultFileList.razor
+++ b/site/AntDesign.Docs/Demos/Components/Upload/demo/DefaultFileList.razor
@@ -1,4 +1,4 @@
-﻿@inject MessageService _message
+﻿@inject IMessageService _message
 
 <Upload @attributes="attrs"
         OnSingleCompleted="OnSingleCompleted">

--- a/site/AntDesign.Docs/Demos/Components/Upload/demo/FileList.razor
+++ b/site/AntDesign.Docs/Demos/Components/Upload/demo/FileList.razor
@@ -1,4 +1,4 @@
-﻿@inject MessageService _message
+﻿@inject IMessageService _message
 
 <Upload @attributes="attrs"
         FileList="fileList"

--- a/site/AntDesign.Docs/Demos/Components/Upload/demo/PictureCard.razor
+++ b/site/AntDesign.Docs/Demos/Components/Upload/demo/PictureCard.razor
@@ -1,4 +1,4 @@
-@inject MessageService _message
+@inject IMessageService _message
 
 <Upload Action="https://www.mocky.io/v2/5cc8019d300000980a055e76"
         Name="avatar"

--- a/site/AntDesign.Docs/Demos/Components/Upload/demo/PictureStyle.razor
+++ b/site/AntDesign.Docs/Demos/Components/Upload/demo/PictureStyle.razor
@@ -1,4 +1,4 @@
-@inject MessageService _message
+@inject IMessageService _message
 
 <Upload @attributes="attrs"
          OnSingleCompleted="OnSingleCompleted"

--- a/site/AntDesign.Docs/Shared/MainFooter.razor.cs
+++ b/site/AntDesign.Docs/Shared/MainFooter.razor.cs
@@ -11,7 +11,7 @@ namespace AntDesign.Docs.Shared
         private static string _colorHex = "#1890ff";
 
         [Inject] private IJSRuntime JS { get; set; }
-        [Inject] private MessageService Message { get; set; }
+        [Inject] private IMessageService Message { get; set; }
 
         [Inject] private ILanguageService Language { get; set; }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [X] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
#2631

### 💡 Background and solution
Testing that an application triggers an AntDesign.Message is not currently possible because it is defined only as a concrete class. Refactoring it to be a class implementing an interface allows us to inject the interface into code and thus allows unit testing.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Changed MessageCenter to be used through an interface IMessageCenter. Existing code will continue to function, but new code should inject IMessageCenter. |
| 🇨🇳 Chinese | 将 MessageCenter 更改为通过接口 IMessageCenter 使用。 现有代码将继续运行，但新代码应注入 IMessageCenter。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] Changelog is provided or not needed
