### PR TITLE
Add OnClick parameter to BreadcrumbItem, Add Tests, Remove unusable code

### DIFF
--- a/components/breadcrumb/Breadcrumb.razor
+++ b/components/breadcrumb/Breadcrumb.razor
@@ -4,15 +4,6 @@
 <CascadingValue Value="this" IsFixed="@true">
     <div class="@ClassMapper.Class" style="@Style" id="@Id" @ref="Ref">
         @ChildContent
-        @if (AutoGenerate)
-        {
-            foreach (var breadcrumb in _breadcrumbs)
-            {
-                <BreadcrumbItem>
-                    <a href="@breadcrumb.Url" @onclick="(e)=>Navigate(breadcrumb.Url.ToString())">@breadcrumb.Label</a>
-                </BreadcrumbItem>
-            }
-        }
     </div>
 </CascadingValue>
 

--- a/components/breadcrumb/Breadcrumb.razor
+++ b/components/breadcrumb/Breadcrumb.razor
@@ -2,8 +2,10 @@
 @inherits AntDomComponentBase
 
 <CascadingValue Value="this" IsFixed="@true">
-    <div class="@ClassMapper.Class" style="@Style" id="@Id" @ref="Ref">
-        @ChildContent
-    </div>
+    <nav class="@ClassMapper.Class" id="@Id" @ref="Ref" style="@Style">
+        <ol>
+            @ChildContent
+        </ol>
+    </nav>
 </CascadingValue>
 

--- a/components/breadcrumb/Breadcrumb.razor.cs
+++ b/components/breadcrumb/Breadcrumb.razor.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using Microsoft.AspNetCore.Components;
+﻿using Microsoft.AspNetCore.Components;
 
 namespace AntDesign
 {
@@ -9,47 +7,30 @@ namespace AntDesign
         [Parameter]
         public RenderFragment ChildContent { get; set; }
 
+        /// <summary>
+        /// Not currently used. Planned for future development.
+        /// </summary>
         [Parameter]
         public bool AutoGenerate { get; set; } = false;
 
         [Parameter]
         public string Separator { get; set; } = "/";
 
+        /// <summary>
+        /// Not currently used. Planned for future development.
+        /// </summary>
         [Parameter]
         public string RouteLabel { get; set; } = "breadcrumb";
 
-        [Inject]
-        public NavigationManager NavigationManager { get; set; }
-
-        private readonly BreadcrumbOption[] _breadcrumbs = Array.Empty<BreadcrumbOption>();
-
-        private void Navigate(string url)
-        {
-            NavigationManager.NavigateTo(url);
-        }
-
         protected override void OnInitialized()
         {
-            string prefixCls = "ant-breadcrumb";
+            var prefixCls = "ant-breadcrumb";
 
-            this.ClassMapper
+            ClassMapper
                 .Add(prefixCls)
                 .If($"{prefixCls}-rtl", () => RTL);
 
             base.OnInitialized();
         }
-
-        private void RegisterRouterChange()
-        {
-        }
-    }
-
-    public class BreadcrumbOption
-    {
-        public string Label { get; set; }
-
-        public Dictionary<string, object> Params { get; set; }
-
-        public Uri Url { get; set; }
     }
 }

--- a/components/breadcrumb/BreadcrumbItem.razor
+++ b/components/breadcrumb/BreadcrumbItem.razor
@@ -1,8 +1,7 @@
 @namespace AntDesign
 @inherits AntDomComponentBase
 
-<span @ref="Ref" @onclick="@_onClick">
-
+<li @ref="Ref">
 	@if (Overlay != null)
 	{
 		<Dropdown Placement="@Placement.Bottom">
@@ -21,7 +20,7 @@
 	}
 	else
 	{
-		<span class="ant-breadcrumb-link">
+        <span class="ant-breadcrumb-link" @onclick="@_onClick">
 			@FormattedChildContent
 		</span>
 	}
@@ -32,8 +31,7 @@
 			@BreadCrumb.Separator
 		</span>
 	}
-
-</span>
+</li>
 
 @code {
     [Parameter]

--- a/components/breadcrumb/BreadcrumbItem.razor
+++ b/components/breadcrumb/BreadcrumbItem.razor
@@ -52,8 +52,7 @@
     [CascadingParameter]
     public Breadcrumb BreadCrumb { get; set; }
 
-	private RenderFragment FormattedChildContent => Href is null 
+    private RenderFragment FormattedChildContent => Href is null 
         ? ChildContent 
-        : @<a href="@Href">@ChildContent</a>
-	;
+        : @<a href="@Href">@ChildContent</a>;
 }

--- a/components/breadcrumb/BreadcrumbItem.razor
+++ b/components/breadcrumb/BreadcrumbItem.razor
@@ -1,7 +1,7 @@
 @namespace AntDesign
 @inherits AntDomComponentBase
 
-<span @ref="Ref">
+<span @ref="Ref" onclick="@OnClick">
 
 	@if (Overlay != null)
 	{
@@ -37,20 +37,23 @@
 
 @code {
 
-	[Parameter]
-	public RenderFragment ChildContent { get; set; }
+    [Parameter]
+    public RenderFragment ChildContent { get; set; }
 
-	[Parameter]
-	public RenderFragment Overlay { get; set; }
+    [Parameter]
+    public RenderFragment Overlay { get; set; }
 
-	[Parameter]
-	public string Href { get; set; }
+    [Parameter]
+    public string Href { get; set; }
 
-	[CascadingParameter]
-	public Breadcrumb BreadCrumb { get; set; }
+    [Parameter]
+    public EventCallback<MouseEventArgs> OnClick { get; set; }
+    
+    [CascadingParameter]
+    public Breadcrumb BreadCrumb { get; set; }
 
-
-	private RenderFragment FormattedChildContent => Href is null ?
-		ChildContent :@<a href="@Href">@ChildContent</a>
+	private RenderFragment FormattedChildContent => Href is null 
+        ? ChildContent 
+        : @<a href="@Href">@ChildContent</a>
 	;
 }

--- a/components/breadcrumb/BreadcrumbItem.razor
+++ b/components/breadcrumb/BreadcrumbItem.razor
@@ -7,7 +7,7 @@
 		<Dropdown Placement="@Placement.Bottom">
 			<Unbound>
 				<span @ref="context.Current" class="ant-breadcrumb-overlay-link">
-					<span class="ant-breadcrumb-link">
+                    <span class="ant-breadcrumb-link" @onclick="@HandleClick">
 						@FormattedChildContent
 					</span>
 					<Icon Type="down"></Icon>
@@ -20,7 +20,7 @@
 	}
 	else
 	{
-        <span class="ant-breadcrumb-link" @onclick="@_onClick">
+        <span class="ant-breadcrumb-link" @onclick="@HandleClick">
 			@FormattedChildContent
 		</span>
 	}
@@ -44,19 +44,18 @@
     public string Href { get; set; }
 
     [Parameter]
-    public EventCallback<Tuple<MouseEventArgs, BreadcrumbItem>> OnClick { get; set; }
+    public EventCallback<MouseEventArgs> OnClick { get; set; }
 
     [CascadingParameter]
     public Breadcrumb BreadCrumb { get; set; }
 
-    private async void _onClick(MouseEventArgs args)
+    private async void HandleClick(MouseEventArgs args)
     {
-        if(OnClick.HasDelegate){
-            await OnClick.InvokeAsync(new Tuple<MouseEventArgs, BreadcrumbItem>(args, this));
+        if(OnClick.HasDelegate)
+        {
+            await OnClick.InvokeAsync(args);
         }
     }
 
-    private RenderFragment FormattedChildContent => Href is null 
-        ? ChildContent 
-        : @<a href="@Href">@ChildContent</a>;
+    private RenderFragment FormattedChildContent => Href is null ? ChildContent :@<a href="@Href">@ChildContent</a>;
 }

--- a/components/breadcrumb/BreadcrumbItem.razor
+++ b/components/breadcrumb/BreadcrumbItem.razor
@@ -7,7 +7,7 @@
 		<Dropdown Placement="@Placement.Bottom">
 			<Unbound>
 				<span @ref="context.Current" class="ant-breadcrumb-overlay-link">
-                    <span class="ant-breadcrumb-link" @onclick="@HandleClick">
+                    <span class="ant-breadcrumb-link" @onclick="@OnClick">
 						@FormattedChildContent
 					</span>
 					<Icon Type="down"></Icon>
@@ -20,7 +20,7 @@
 	}
 	else
 	{
-        <span class="ant-breadcrumb-link" @onclick="@HandleClick">
+        <span class="ant-breadcrumb-link" @onclick="@OnClick">
 			@FormattedChildContent
 		</span>
 	}
@@ -48,14 +48,6 @@
 
     [CascadingParameter]
     public Breadcrumb BreadCrumb { get; set; }
-
-    private async void HandleClick(MouseEventArgs args)
-    {
-        if(OnClick.HasDelegate)
-        {
-            await OnClick.InvokeAsync(args);
-        }
-    }
 
     private RenderFragment FormattedChildContent => Href is null ? ChildContent :@<a href="@Href">@ChildContent</a>;
 }

--- a/components/breadcrumb/BreadcrumbItem.razor
+++ b/components/breadcrumb/BreadcrumbItem.razor
@@ -1,7 +1,7 @@
 @namespace AntDesign
 @inherits AntDomComponentBase
 
-<span @ref="Ref" onclick="@OnClick">
+<span @ref="Ref" @onclick="@_onClick">
 
 	@if (Overlay != null)
 	{
@@ -36,7 +36,6 @@
 </span>
 
 @code {
-
     [Parameter]
     public RenderFragment ChildContent { get; set; }
 
@@ -47,10 +46,17 @@
     public string Href { get; set; }
 
     [Parameter]
-    public EventCallback<MouseEventArgs> OnClick { get; set; }
-    
+    public EventCallback<Tuple<MouseEventArgs, BreadcrumbItem>> OnClick { get; set; }
+
     [CascadingParameter]
     public Breadcrumb BreadCrumb { get; set; }
+
+    private async void _onClick(MouseEventArgs args)
+    {
+        if(OnClick.HasDelegate){
+            await OnClick.InvokeAsync(new Tuple<MouseEventArgs, BreadcrumbItem>(args, this));
+        }
+    }
 
     private RenderFragment FormattedChildContent => Href is null 
         ? ChildContent 

--- a/components/breadcrumb/BreadcrumbOption.cs
+++ b/components/breadcrumb/BreadcrumbOption.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace AntDesign
+{
+    /// <summary>
+    /// Not currently used. Planned for future development.
+    /// </summary>
+    public class BreadcrumbOption
+    {
+        public string Label { get; set; }
+
+        public Dictionary<string, object> Params { get; set; }
+
+        public Uri Url { get; set; }
+    }
+}

--- a/components/breadcrumb/BreadcrumbOption.cs
+++ b/components/breadcrumb/BreadcrumbOption.cs
@@ -1,11 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace AntDesign
 {
     /// <summary>
     /// Not currently used. Planned for future development.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     public class BreadcrumbOption
     {
         public string Label { get; set; }

--- a/site/AntDesign.Docs/Demos/Components/Breadcrumb/demo/Basic.razor
+++ b/site/AntDesign.Docs/Demos/Components/Breadcrumb/demo/Basic.razor
@@ -3,13 +3,16 @@
 <Breadcrumb>
 	<BreadcrumbItem>Home</BreadcrumbItem>
 	<BreadcrumbItem Href="">Application Center</BreadcrumbItem>
-    <BreadcrumbItem OnClick="@OnClickItem" Href="">Application List</BreadcrumbItem>
+    <BreadcrumbItem Id="BreadcrumbItem3" OnClick="@OnClickItem" Href="">Application List</BreadcrumbItem>
     <BreadcrumbItem>An Application</BreadcrumbItem>
     <BreadcrumbItem OnClick="@OnClickItem">A Page</BreadcrumbItem>
 </Breadcrumb>
 
 @code{
-    public void OnClickItem(MouseEventArgs args){
-        _message.Success("You clicked the breadcrumb item!");
+    public void OnClickItem(Tuple<MouseEventArgs, BreadcrumbItem> callbackArgs)
+    {
+        (MouseEventArgs args, BreadcrumbItem item) = callbackArgs;
+
+        _message.Success($"You clicked the breadcrumb item: {item.Id}");
     }
 }

--- a/site/AntDesign.Docs/Demos/Components/Breadcrumb/demo/Basic.razor
+++ b/site/AntDesign.Docs/Demos/Components/Breadcrumb/demo/Basic.razor
@@ -3,16 +3,14 @@
 <Breadcrumb>
 	<BreadcrumbItem>Home</BreadcrumbItem>
 	<BreadcrumbItem Href="">Application Center</BreadcrumbItem>
-    <BreadcrumbItem Id="BreadcrumbItem3" OnClick="@OnClickItem" Href="">Application List</BreadcrumbItem>
+    <BreadcrumbItem OnClick="@OnClickItem" Href="">Application List</BreadcrumbItem>
     <BreadcrumbItem>An Application</BreadcrumbItem>
     <BreadcrumbItem OnClick="@OnClickItem">A Page</BreadcrumbItem>
 </Breadcrumb>
 
 @code{
-    public void OnClickItem(Tuple<MouseEventArgs, BreadcrumbItem> callbackArgs)
+    public void OnClickItem(MouseEventArgs args)
     {
-        (MouseEventArgs args, BreadcrumbItem item) = callbackArgs;
-
-        _message.Success($"You clicked the breadcrumb item: {item.Id}");
+        _message.Success($"You clicked the breadcrumb.");
     }
 }

--- a/site/AntDesign.Docs/Demos/Components/Breadcrumb/demo/Basic.razor
+++ b/site/AntDesign.Docs/Demos/Components/Breadcrumb/demo/Basic.razor
@@ -1,6 +1,15 @@
+@inject IMessageService _message;
+
 <Breadcrumb>
 	<BreadcrumbItem>Home</BreadcrumbItem>
 	<BreadcrumbItem Href="">Application Center</BreadcrumbItem>
-	<BreadcrumbItem Href="">Application List</BreadcrumbItem>
-	<BreadcrumbItem>An Application</BreadcrumbItem>
+    <BreadcrumbItem OnClick="@OnClickItem" Href="">Application List</BreadcrumbItem>
+    <BreadcrumbItem>An Application</BreadcrumbItem>
+    <BreadcrumbItem OnClick="@OnClickItem">A Page</BreadcrumbItem>
 </Breadcrumb>
+
+@code{
+    public void OnClickItem(MouseEventArgs args){
+        _message.Success("You clicked the breadcrumb item!");
+    }
+}

--- a/site/AntDesign.Docs/Demos/Components/Breadcrumb/doc/index.en-US.md
+++ b/site/AntDesign.Docs/Demos/Components/Breadcrumb/doc/index.en-US.md
@@ -33,6 +33,6 @@ BreadcrumbItem
 | --- | --- | --- | --- |
 | Href | Target of hyperlink | int         | -         |
 | Overlay   | The dropdown menu| int         |-         |
-| OnClick | Set the handler to handle click event | function(e)         |-       |
+| OnClick | Set the handler to handle click event | EventCallback<MouseEventArgs>         |-       |
 | DropdownProps |The dropdown props| string  | -  |
 

--- a/site/AntDesign.Docs/Demos/Components/Breadcrumb/doc/index.en-US.md
+++ b/site/AntDesign.Docs/Demos/Components/Breadcrumb/doc/index.en-US.md
@@ -33,6 +33,6 @@ BreadcrumbItem
 | --- | --- | --- | --- |
 | Href | Target of hyperlink | int         | -         |
 | Overlay   | The dropdown menu| int         |-         |
-| OnClick | Set the handler to handle click event | EventCallback<MouseEventArgs>         |-       |
+| OnClick | Set the handler to handle click event | EventCallback<Tuple<MouseEventArgs, BreadcrumbItem>>         |-       |
 | DropdownProps |The dropdown props| string  | -  |
 

--- a/site/AntDesign.Docs/Demos/Components/Breadcrumb/doc/index.zh-CN.md
+++ b/site/AntDesign.Docs/Demos/Components/Breadcrumb/doc/index.zh-CN.md
@@ -33,7 +33,7 @@ BreadcrumbItem
 | ---------------- | -------------------------------------------- | ------------- | --------- |
 | Href | 链接的目的地 | int         | -         |
 | Overlay   | 下拉菜单的内容 | int         |-         |
-| OnClick | 单击事件 | EventCallback<MouseEventArgs>  |-       |
+| OnClick | 单击事件 | EventCallback<Tuple<MouseEventArgs, BreadcrumbItem>>  |-       |
 | DropdownProps |弹出下拉菜单的自定义配置 | string  | -  |
 
 

--- a/site/AntDesign.Docs/Demos/Components/Breadcrumb/doc/index.zh-CN.md
+++ b/site/AntDesign.Docs/Demos/Components/Breadcrumb/doc/index.zh-CN.md
@@ -33,7 +33,7 @@ BreadcrumbItem
 | ---------------- | -------------------------------------------- | ------------- | --------- |
 | Href | 链接的目的地 | int         | -         |
 | Overlay   | 下拉菜单的内容 | int         |-         |
-| OnClick | 单击事件 | function(e)  |-       |
+| OnClick | 单击事件 | EventCallback<MouseEventArgs>  |-       |
 | DropdownProps |弹出下拉菜单的自定义配置 | string  | -  |
 
 

--- a/tests/AntDesign.TestKit/AntDesign.TestKit.csproj
+++ b/tests/AntDesign.TestKit/AntDesign.TestKit.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5;net6</TargetFrameworks>
     <OutputType>Library</OutputType>
     <IsPackable>true</IsPackable>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/AntDesign.Tests/AntDesign.Tests.csproj
+++ b/tests/AntDesign.Tests/AntDesign.Tests.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFrameworks>net5;</TargetFrameworks>
+    <TargetFrameworks>net5;net6</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <UseDataCollector>true</UseDataCollector>
     <Nullable>enable</Nullable>
+    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/AntDesign.Tests/Breadcrumb/BreadcrumbItemTests.cs
+++ b/tests/AntDesign.Tests/Breadcrumb/BreadcrumbItemTests.cs
@@ -1,5 +1,6 @@
 ﻿using Bunit;
 using FluentAssertions;
+using Microsoft.AspNetCore.Components.Web;
 using Xunit;
 
 namespace AntDesign.Tests.Breadcrumb
@@ -50,18 +51,18 @@ namespace AntDesign.Tests.Breadcrumb
         }
 
         [Fact]
-        public void ItShouldCallOnClickWhenProvidedAndClicked()
+        public void ItShouldCallOnClickWithItemReferenceWhenProvidedAndClicked()
         {
-            var onClickCalled = false;
+            BreadcrumbItem? onClickItem = null;
 
             var systemUnderTest = RenderComponent<BreadcrumbItem>(parameters => parameters
                 .Add(x => x.ChildContent, "Child Content")
-                .Add(x => x.OnClick, () => { onClickCalled = true; })
+                .Add(x => x.OnClick, (args) => { onClickItem = args.Item2; })
             );
 
             systemUnderTest.Find("span").Click();
 
-            onClickCalled.Should().BeTrue();
+            onClickItem.Should().Be(systemUnderTest.Instance);
         }
 
         [Fact]

--- a/tests/AntDesign.Tests/Breadcrumb/BreadcrumbItemTests.cs
+++ b/tests/AntDesign.Tests/Breadcrumb/BreadcrumbItemTests.cs
@@ -53,16 +53,16 @@ namespace AntDesign.Tests.Breadcrumb
         [Fact]
         public void ItShouldCallOnClickWithItemReferenceWhenProvidedAndClicked()
         {
-            BreadcrumbItem? onClickItem = null;
+            string value = "";
 
             var systemUnderTest = RenderComponent<BreadcrumbItem>(parameters => parameters
                 .Add(x => x.ChildContent, "Child Content")
-                .Add(x => x.OnClick, (args) => { onClickItem = args.Item2; })
+                .Add(x => x.OnClick, (args) => value = "clicked!")
             );
 
             systemUnderTest.Find("li span.ant-breadcrumb-link").Click();
 
-            onClickItem.Should().Be(systemUnderTest.Instance);
+            value.Should().Be("clicked!");
         }
 
         [Fact]

--- a/tests/AntDesign.Tests/Breadcrumb/BreadcrumbItemTests.cs
+++ b/tests/AntDesign.Tests/Breadcrumb/BreadcrumbItemTests.cs
@@ -17,11 +17,11 @@ namespace AntDesign.Tests.Breadcrumb
                 .Add(x => x.ChildContent, "Child Content")
             );
 
-            systemUnderTest.MarkupMatches($@"<span>
+            systemUnderTest.MarkupMatches($@"<li>
                 <span class=""ant-breadcrumb-link"">
                     <a href=""{Href}"">Child Content</a>
                 </span>
-            </span>");
+            </li>");
         }
 
         [Fact]
@@ -31,9 +31,9 @@ namespace AntDesign.Tests.Breadcrumb
                 .Add(x => x.ChildContent, "Child Content")
             );
 
-            systemUnderTest.MarkupMatches($@"<span>
+            systemUnderTest.MarkupMatches($@"<li>
                 <span class=""ant-breadcrumb-link"">Child Content</span>
-            </span>");
+            </li>");
         }
 
         [Fact]
@@ -44,10 +44,10 @@ namespace AntDesign.Tests.Breadcrumb
                 .AddChildContent<BreadcrumbItem>(itemParameters => itemParameters.Add(x => x.ChildContent, "Link Item"))
             );
 
-            systemUnderTest.Find("div > span").MarkupMatches($@"<span>
+            systemUnderTest.Find("ol > li").MarkupMatches($@"<li>
                 <span class=""ant-breadcrumb-link"">Link Item</span>
 		        <span class=""ant-breadcrumb-separator"">-</span>
-            </span>");
+            </li>");
         }
 
         [Fact]
@@ -60,7 +60,7 @@ namespace AntDesign.Tests.Breadcrumb
                 .Add(x => x.OnClick, (args) => { onClickItem = args.Item2; })
             );
 
-            systemUnderTest.Find("span").Click();
+            systemUnderTest.Find("li span.ant-breadcrumb-link").Click();
 
             onClickItem.Should().Be(systemUnderTest.Instance);
         }
@@ -75,7 +75,7 @@ namespace AntDesign.Tests.Breadcrumb
                 .Add(x => x.Overlay, "")
             );
 
-            systemUnderTest.MarkupMatches($@"<span>
+            systemUnderTest.MarkupMatches($@"<li>
                 <span class=""ant-breadcrumb-overlay-link"">
 	                <span class=""ant-breadcrumb-link"">Child Content</span>
                     <span role=""img"" class="" anticon anticon-down"" id:ignore>
@@ -84,7 +84,7 @@ namespace AntDesign.Tests.Breadcrumb
                       </svg>
                     </span>
                 </span>
-            </span>");
+            </li>");
         }
     }
 }

--- a/tests/AntDesign.Tests/Breadcrumb/BreadcrumbItemTests.cs
+++ b/tests/AntDesign.Tests/Breadcrumb/BreadcrumbItemTests.cs
@@ -1,0 +1,89 @@
+﻿using Bunit;
+using FluentAssertions;
+using Xunit;
+
+namespace AntDesign.Tests.Breadcrumb
+{
+    public class BreadcrumbItemTests : AntDesignTestBase
+    {
+        [Fact]
+        public void ItShouldRenderLinkWhenHrefGiven()
+        {
+            const string Href = "#SomeAnchor";
+
+            var systemUnderTest = RenderComponent<BreadcrumbItem>(parameters => parameters
+                .Add(x => x.Href, Href)
+                .Add(x => x.ChildContent, "Child Content")
+            );
+
+            systemUnderTest.MarkupMatches($@"<span>
+                <span class=""ant-breadcrumb-link"">
+                    <a href=""{Href}"">Child Content</a>
+                </span>
+            </span>");
+        }
+
+        [Fact]
+        public void ItShouldNotRenderLInkWhenHrefNotGiven()
+        {
+            var systemUnderTest = RenderComponent<BreadcrumbItem>(parameters => parameters
+                .Add(x => x.ChildContent, "Child Content")
+            );
+
+            systemUnderTest.MarkupMatches($@"<span>
+                <span class=""ant-breadcrumb-link"">Child Content</span>
+            </span>");
+        }
+
+        [Fact]
+        public void ItemShouldGetBreadcrumbSeparatorAndRenderProperly()
+        {
+            var systemUnderTest = RenderComponent<AntDesign.Breadcrumb>(parameters => parameters
+                .Add(x => x.Separator, "-")
+                .AddChildContent<BreadcrumbItem>(itemParameters => itemParameters.Add(x => x.ChildContent, "Link Item"))
+            );
+
+            systemUnderTest.Find("div > span").MarkupMatches($@"<span>
+                <span class=""ant-breadcrumb-link"">Link Item</span>
+		        <span class=""ant-breadcrumb-separator"">-</span>
+            </span>");
+        }
+
+        [Fact]
+        public void ItShouldCallOnClickWhenProvidedAndClicked()
+        {
+            var onClickCalled = false;
+
+            var systemUnderTest = RenderComponent<BreadcrumbItem>(parameters => parameters
+                .Add(x => x.ChildContent, "Child Content")
+                .Add(x => x.OnClick, () => { onClickCalled = true; })
+            );
+
+            systemUnderTest.Find("span").Click();
+
+            onClickCalled.Should().BeTrue();
+        }
+
+        [Fact]
+        public void ItShouldRenderDropdownWhenOverlayProvided()
+        {
+            JSInterop.SetupVoid("AntDesign.interop.styleHelper.addCls", _ => true);
+
+            var systemUnderTest = RenderComponent<BreadcrumbItem>(parameters => parameters
+                .Add(x => x.ChildContent, "Child Content")
+                .Add(x => x.Overlay, "")
+            );
+
+            systemUnderTest.MarkupMatches($@"<span>
+                <span class=""ant-breadcrumb-overlay-link"">
+	                <span class=""ant-breadcrumb-link"">Child Content</span>
+                    <span role=""img"" class="" anticon anticon-down"" id:ignore>
+                      <svg focusable=""false"" width=""1em"" height=""1em"" fill=""currentColor"" style=""pointer-events: none;"" xmlns=""http://www.w3.org/2000/svg"" class=""icon"" viewBox=""0 0 1024 1024"">
+                        <path d=""M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z""></path>
+                      </svg>
+                    </span>
+                </span>
+            </span>");
+        }
+    }
+}

--- a/tests/AntDesign.Tests/Breadcrumb/BreadcrumbTests.cs
+++ b/tests/AntDesign.Tests/Breadcrumb/BreadcrumbTests.cs
@@ -14,11 +14,11 @@ namespace AntDesign.Tests.Breadcrumb
         {
             var systemUnderTest = RenderComponent<AntDesign.Breadcrumb>();
 
-            systemUnderTest.MarkupMatches("<div class=\"ant-breadcrumb\" id:ignore></div>");
+            systemUnderTest.MarkupMatches("<nav class=\"ant-breadcrumb\" id:ignore><ol></ol></nav>");
         }
 
         [Fact]
-        public void ItShouldRenderChildCOntent()
+        public void ItShouldRenderChildContent()
         {
             var systemUnderTest = RenderComponent<AntDesign.Breadcrumb>(p => p.AddChildContent("<span>Test</span>"));
 

--- a/tests/AntDesign.Tests/Breadcrumb/BreadcrumbTests.cs
+++ b/tests/AntDesign.Tests/Breadcrumb/BreadcrumbTests.cs
@@ -1,0 +1,28 @@
+﻿using System.Threading.Tasks;
+using AntDesign.JsInterop;
+using Bunit;
+using FluentAssertions;
+using Microsoft.AspNetCore.Components;
+using Xunit;
+
+namespace AntDesign.Tests.Breadcrumb
+{
+    public class BreadcrumbTests : AntDesignTestBase
+    {
+        [Fact]
+        public void ItShouldRenderWrapperProperly()
+        {
+            var systemUnderTest = RenderComponent<AntDesign.Breadcrumb>();
+
+            systemUnderTest.MarkupMatches("<div class=\"ant-breadcrumb\" id:ignore></div>");
+        }
+
+        [Fact]
+        public void ItShouldRenderChildCOntent()
+        {
+            var systemUnderTest = RenderComponent<AntDesign.Breadcrumb>(p => p.AddChildContent("<span>Test</span>"));
+
+            systemUnderTest.Find("span").MarkupMatches("<span>Test</span>");
+        }
+    }
+}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [X] New feature
- [X] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [X] Refactoring
- [ ] Code style optimization
- [X] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
#2540 - OnClick
#2649 - Remove unusable code
#2644 - Test coverage
#2658 - Wrong HTML markup causing last separator to display

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
- A user discovered we document an OnClick parameter for BreadcrumbItem, but it was not implemented. Now it is. Also added to the demo.
- Discovered when testing there is unreachable/unusable code for future features. Removed for now. Left public API alone but added comments about currently not being used.
- Test coverage for Breadcrumb/Item
- Update the markup of Breadcrumb/BreadcrumItem to match Ant.Design React
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add OnClick parameter to BreadcrumbItem. Markup of Breadcrumb updated to match Ant.Design React. This could break custom CSS targeting this component's resulting markup. |
| 🇨🇳 Chinese | 将 OnClick 参数添加到 BreadcrumbItem. Breadcrumb 的标记已更新以匹配 Ant.Design React。这可能会破坏针对此组件生成标记的自定义 CSS |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] Changelog is provided or not needed
