### PR TITLE
fix:(module:datepicker): timepicker value resets to default

### DIFF
--- a/components/date-picker/internal/DatePickerBase.cs
+++ b/components/date-picker/internal/DatePickerBase.cs
@@ -1000,5 +1000,13 @@ namespace AntDesign
                    _minutesSeconds.Where(s => s < startValue?.Second).ToArray() : Array.Empty<int>();
             }
         }
+
+        internal async Task OnNowClick()
+        {
+            var pickerIndex = GetOnFocusPickerIndex();
+            await OnSelect(DateTime.Now, GetOnFocusPickerIndex());
+            _pickerStatus[pickerIndex].IsNewValueSelected = true;
+            Close();
+        }
     }
 }

--- a/components/date-picker/internal/DatePickerDatetimePanel.razor
+++ b/components/date-picker/internal/DatePickerDatetimePanel.razor
@@ -226,12 +226,12 @@
           }
         }
 
-        @if (IsShowTime)
+        @if (IsShowTime || Picker == DatePickerType.Time)
         {
-          @if (Ranges == null)
+          @if (ShowNow)
           {
             <li class="@(PrefixCls)-now">
-              <a class="@(PrefixCls)-now-btn" @onclick="e => { OnSelectTime(DateTime.Now); Close(); }">
+              <a class="@(PrefixCls)-now-btn" @onclick="OnNowClick">
                 @Locale.Lang.Now
               </a>
             </li>
@@ -245,7 +245,7 @@
       </ul>
     }
 
-    @if (!IsShowTime && ShowToday)
+    @if (!IsShowTime && ShowToday && Picker != DatePickerType.Time)
     {
       <a class="@(PrefixCls)-today-btn" @onclick="e => { OnSelectTime(DateTime.Today); Close(); }">
         @Locale.Lang.Today

--- a/components/date-picker/internal/DatePickerDatetimePanel.razor.cs
+++ b/components/date-picker/internal/DatePickerDatetimePanel.razor.cs
@@ -35,6 +35,9 @@ namespace AntDesign.Internal
         public EventCallback OnOkClick { get; set; }
 
         [Parameter]
+        public EventCallback OnNowClick { get; set; }
+
+        [Parameter]
         public EventCallback<DateTime?[]> OnRangeItemOver { get; set; }
 
         [Parameter]
@@ -47,7 +50,7 @@ namespace AntDesign.Internal
         public EventCallback<bool> OnOpenChange { get; set; }
 
         private bool ShowFooter => RenderExtraFooter != null || ShowRanges || ShowToday;
-
+        private bool ShowNow => !IsRange && (Ranges is null || Ranges.Count == 0) || Picker == DatePickerType.Time;
         private bool ShowRanges => IsShowTime || Ranges != null;
 
         private Dictionary<int, ElementReference> _hours = new();

--- a/components/date-picker/internal/DatePickerPanelChooser.razor
+++ b/components/date-picker/internal/DatePickerPanelChooser.razor
@@ -51,7 +51,7 @@
     {
         @if (DatePicker.IsShowTime)
         {
-            <DatePickerDatetimePanel Ranges="DatePicker.Ranges" TValue="TValue" OnRangeItemOver="DatePicker.OnRangeItemOver" OnRangeItemOut="DatePicker.OnRangeItemOut" OnRangeItemClicked="DatePicker.OnRangeItemClicked" OnOkClick="DatePicker.OnOkClick" @attributes="dateTimeAttributes" />
+            <DatePickerDatetimePanel Ranges="DatePicker.Ranges" TValue="TValue" OnRangeItemOver="DatePicker.OnRangeItemOver" OnRangeItemOut="DatePicker.OnRangeItemOut" OnRangeItemClicked="DatePicker.OnRangeItemClicked" OnOkClick="DatePicker.OnOkClick" OnNowClick="DatePicker.OnNowClick" @attributes="dateTimeAttributes" />
         }
         else
         {
@@ -81,6 +81,6 @@
     }
     else if (IsShowTimePanel())
     {
-        <DatePickerDatetimePanel TValue="TValue" OnOkClick="DatePicker.OnOkClick" @attributes="dateTimeAttributes" />
+        <DatePickerDatetimePanel TValue="TValue" OnOkClick="DatePicker.OnOkClick" OnNowClick="DatePicker.OnNowClick" @attributes="dateTimeAttributes" />
     }
 </CascadingValue>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
#2637 
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

The Ok button should be preset in the TimePicker or DatePicker with time, as well as the Now button. The Today button should not be shown in the TimePicker. This pull request fixes this.

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
