### PR TITLE
fix:(module:datepicker): RangePicker has incorrect start/end panels

### DIFF
--- a/components/date-picker/RangePicker.razor
+++ b/components/date-picker/RangePicker.razor
@@ -19,7 +19,7 @@
             <div class="@(PrefixCls)-range-arrow" style="@_rangeArrowStyle" />
             <div class="@(PrefixCls)-panel-container" @onclick="@PickerClicked">
                 <div class="@(PrefixCls)-panels">
-                    <div class="@_panelClassMapper.Class" style="@(Picker == DatePickerType.Date && IsShowTime && GetOnFocusPickerIndex() == 1 ? "display: none;": "")">
+                    <div class="@_panelClassMapper.Class" style="@(Picker == DatePickerType.Date && IsShowTime && GetOnFocusPickerIndex() == (RTL ? 0 : 1) ? "display: none;": "")">
                         <DatePickerPanelChooser TValue="TValue" DatePicker="@this" PickerIndex="@(RTL ? 1 : 0)" OnSelect="async (date, index) => await OnSelect(date, index)" />
                     </div>
                     <div class="@_panelClassMapper.Class">

--- a/components/date-picker/RangePicker.razor.cs
+++ b/components/date-picker/RangePicker.razor.cs
@@ -65,7 +65,7 @@ namespace AntDesign
 
         private bool ShowFooter => !IsShowTime && (RenderExtraFooter != null || ShowRanges);
 
-        private bool ShowRanges => Ranges != null;
+        private bool ShowRanges => Ranges?.Count > 0;
 
         public RangePicker()
         {

--- a/components/date-picker/RangePicker.razor.cs
+++ b/components/date-picker/RangePicker.razor.cs
@@ -133,10 +133,29 @@ namespace AntDesign
             //Reset Picker to default in case the picker value was changed
             //but no value was selected (for example when a user clicks next
             //month but does not select any value)
-            if (UseDefaultPickerValue[index] && DefaultPickerValue != null)
+
+            var currentValue = GetIndexValue(index);
+
+            if (currentValue is not null)
+            {
+                if (IsShowTime)
+                {
+                    PickerValues[index] = currentValue.Value;
+                }
+                else
+                {
+                    PickerValues[index] = index == 0 ? currentValue.Value : GetClosingDate(currentValue.Value, -1);
+                }
+            }
+            else if (UseDefaultPickerValue[index] && DefaultPickerValue is not null)
+            {
+                PickerValues[index] = Convert.ToDateTime(DefaultPickerValue, CultureInfo);
+            }
+            else
             {
                 PickerValues[index] = _pickerValuesAfterInit[index];
             }
+
             await _dropDown.Show();
 
             if (index == 0)

--- a/components/date-picker/internal/DatePickerBase.cs
+++ b/components/date-picker/internal/DatePickerBase.cs
@@ -907,53 +907,52 @@ namespace AntDesign
 
         protected void InvokeInternalOverlayVisibleChanged(bool visible)
         {
-            if (IsShowTime || Picker == DatePickerType.Time)
-                if (IsRange)
+            if (IsRange)
+            {
+                if (!visible && (!_pickerStatus[0].IsNewValueSelected || !_pickerStatus[1].IsNewValueSelected))
                 {
-                    if (!visible && (!_pickerStatus[0].IsNewValueSelected || !_pickerStatus[1].IsNewValueSelected))
+                    if (_pickerStatus[0].OldValue.HasValue && _pickerStatus[1].OldValue.HasValue)
                     {
-                        if (_pickerStatus[0].OldValue.HasValue && _pickerStatus[1].OldValue.HasValue)
+                        if (GetIndexValue(0) != _pickerStatus[0].OldValue)
                         {
-                            if (GetIndexValue(0) != _pickerStatus[0].OldValue)
-                            {
-                                ChangeValue(_pickerStatus[0].OldValue.Value, 0);
-                            }
-                            if (GetIndexValue(1) != _pickerStatus[1].OldValue)
-                            {
-                                ChangeValue(_pickerStatus[1].OldValue.Value, 1);
-                            }
+                            ChangeValue(_pickerStatus[0].OldValue.Value, 0);
                         }
-                        else if (_pickerStatus[0].IsValueSelected || _pickerStatus[1].IsValueSelected)
+                        if (GetIndexValue(1) != _pickerStatus[1].OldValue)
                         {
-                            ClearValue(-1);
+                            ChangeValue(_pickerStatus[1].OldValue.Value, 1);
                         }
                     }
-                    else if (visible)
+                    else if (_pickerStatus[0].IsValueSelected || _pickerStatus[1].IsValueSelected)
                     {
-                        _pickerStatus[0].OldValue = GetIndexValue(0);
-                        _pickerStatus[1].OldValue = GetIndexValue(1);
+                        ClearValue(-1);
                     }
                 }
-                else
+                else if (visible)
                 {
-                    var index = GetOnFocusPickerIndex();
+                    _pickerStatus[0].OldValue = GetIndexValue(0);
+                    _pickerStatus[1].OldValue = GetIndexValue(1);
+                }
+            }
+            else if (IsShowTime || Picker == DatePickerType.Time)
+            {
+                var index = GetOnFocusPickerIndex();
 
-                    if (!_pickerStatus[index].IsNewValueSelected && !visible)
+                if (!_pickerStatus[index].IsNewValueSelected && !visible)
+                {
+                    if (_pickerStatus[index].OldValue.HasValue)
                     {
-                        if (_pickerStatus[index].OldValue.HasValue)
-                        {
-                            ChangeValue(_pickerStatus[index].OldValue.Value, index);
-                        }
-                        else
-                        {
-                            ClearValue(index);
-                        }
+                        ChangeValue(_pickerStatus[index].OldValue.Value, index);
                     }
-                    else if (visible)
+                    else
                     {
-                        _pickerStatus[index].OldValue = GetIndexValue(index);
+                        ClearValue(index);
                     }
                 }
+                else if (visible)
+                {
+                    _pickerStatus[index].OldValue = GetIndexValue(index);
+                }
+            }
             if (visible)
             {
                 _pickerStatus[0].IsNewValueSelected = false;

--- a/components/date-picker/internal/DatePickerBase.cs
+++ b/components/date-picker/internal/DatePickerBase.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -905,11 +905,14 @@ namespace AntDesign
                 {
                     if (_pickerStatus[0].OldValue.HasValue && _pickerStatus[1].OldValue.HasValue)
                     {
-                        if (GetIndexValue(0) != _pickerStatus[0].OldValue)
+                        var startDate = GetIndexValue(0);
+                        var endDate = GetIndexValue(1);
+
+                        if (startDate is not null && startDate != _pickerStatus[0].OldValue)
                         {
                             ChangeValue(_pickerStatus[0].OldValue.Value, 0);
                         }
-                        if (GetIndexValue(1) != _pickerStatus[1].OldValue)
+                        if (endDate is not null && endDate != _pickerStatus[1].OldValue)
                         {
                             ChangeValue(_pickerStatus[1].OldValue.Value, 1);
                         }

--- a/components/date-picker/internal/DatePickerBase.cs
+++ b/components/date-picker/internal/DatePickerBase.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -512,30 +512,22 @@ namespace AntDesign
             }
         }
 
-        public async Task OnRangeItemOver(DateTime?[] range)
+        internal void OnRangeItemOver(DateTime?[] range)
         {
-            if (IsRange)
-            {
-                _swpValue = Value;
-                Value = DataConvertionExtensions.Convert<DateTime?[], TValue>(new DateTime?[] { range[0], range[1] });
-            }
+            _swpValue = Value;
+            Value = DataConvertionExtensions.Convert<DateTime?[], TValue>(new DateTime?[] { range[0], range[1] });
         }
 
-        public async Task OnRangeItemOut(DateTime?[] range)
-        {
-            if (IsRange)
-            {
-                Value = _swpValue;
-            }
-        }
+        internal void OnRangeItemOut(DateTime?[] range) => Value = _swpValue;
 
-        public async Task OnRangeItemClicked(DateTime?[] range)
+        internal void OnRangeItemClicked(DateTime?[] range)
         {
             _swpValue = DataConvertionExtensions.Convert<DateTime?[], TValue>(new DateTime?[] { range[0], range[1] });
             ChangeValue((DateTime)range[0], 0);
             ChangeValue((DateTime)range[1], 1);
+            _pickerStatus[0].IsNewValueSelected = true;
+            _pickerStatus[1].IsNewValueSelected = true;
             Close();
-            return;
         }
 
         private async Task<bool> SwitchFocus(int index)

--- a/components/date-picker/internal/DatePickerBase.cs
+++ b/components/date-picker/internal/DatePickerBase.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -921,6 +921,8 @@ namespace AntDesign
                     {
                         ClearValue(-1);
                     }
+
+                    AutoFocus = false;
                 }
                 else if (visible)
                 {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

#1259

### 💡 Background and solution

This also fixes:
RangePicker end panel not shown in RTL mode
RangePicker range preset value resets when time input is enabled
RangePicker keeps focus when input canceled
RangePicker cannot clear value when one of the inputs has a focus

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
