### PR TITLE
Use TitleTemplate in Tooltip

### DIFF
--- a/components/menu/MenuItem.razor
+++ b/components/menu/MenuItem.razor
@@ -2,11 +2,11 @@
 @inherits AntDomComponentBase
 
 <CascadingValue Value="this" IsFixed>
-	@* There is no need to render the tooltip if there is no inline mode. Tooltip will be only showing menu content if menu is collapsed to icon version && only for root menu  *@
-	@if (RootMenu.Mode == MenuMode.Inline && ParentMenu is null)
-	{
-		<Tooltip Title="@content(this)" Placement="@Placement.Right" Disabled="TooltipDisabled">
-			<Unbound Context="tooltip">
+    @* There is no need to render the tooltip if there is no inline mode. Tooltip will be only showing menu content if menu is collapsed to icon version && only for root menu  *@
+    @if (RootMenu.Mode == MenuMode.Inline && ParentMenu is null)
+    {
+        <Tooltip TitleTemplate="@content(this)" Placement="@Placement.Right" Disabled="TooltipDisabled">
+            <Unbound Context="tooltip">
                 <li class="@ClassMapper.Class" role="menuitem" style="@((PaddingLeft>0? $"padding-left:{PaddingLeft}px;":"")+@Style)" @onclick="HandleOnClick" @key="Key" @ref="tooltip.Current">
                     @icon(this)
                     <span class="ant-menu-title-content">
@@ -20,38 +20,38 @@
                         }
                     </span>
                 </li>
-			</Unbound>
-		</Tooltip>
-	}
-	else
-	{
-		<li class="@ClassMapper.Class" role="menuitem" style="@((PaddingLeft>0? $"padding-left:{PaddingLeft}px;":"")+@Style)" @onclick="HandleOnClick" @key="Key">
-			  @icon(this)
-			<span class="ant-menu-title-content">
-				@if (RouterLink == null)
-				{
-					@content(this)
-				}
-				else
-				{
-					<MenuLink Href="@RouterLink" Match="@RouterMatch">@content(this)</MenuLink>
-				}
-			</span>
-		</li>
-	}
+            </Unbound>
+        </Tooltip>
+    }
+    else
+    {
+        <li class="@ClassMapper.Class" role="menuitem" style="@((PaddingLeft>0? $"padding-left:{PaddingLeft}px;":"")+@Style)" @onclick="HandleOnClick" @key="Key">
+            @icon(this)
+            <span class="ant-menu-title-content">
+                @if (RouterLink == null)
+                {
+                    @content(this)
+                }
+                else
+                {
+                    <MenuLink Href="@RouterLink" Match="@RouterMatch">@content(this)</MenuLink>
+                }
+            </span>
+        </li>
+    }
 </CascadingValue>
 
 @code {
-	RenderFragment<MenuItem> content = item =>
-	@<Template>
-		@if (item.Title != null)
-		{
-			@item.Title
-		}
-		else
-		{
-			@item.ChildContent
-		}
+  RenderFragment<MenuItem> content = item =>
+  @<Template>
+    @if (item.Title != null)
+    {
+        @item.Title
+    }
+    else
+    {
+      @item.ChildContent
+    }
     </Template>
   ;
 

--- a/components/tooltip/Tooltip.razor
+++ b/components/tooltip/Tooltip.razor
@@ -5,7 +5,7 @@
 
 @if (ChildContent != null)
 {
-<div class="@ClassMapper.Class" @ref="@Ref" Id="@Id" style="display: inline-block; @Style"
+    <div class="@ClassMapper.Class" @ref="@Ref" Id="@Id" style="display: inline-block; @Style"
      @onclick="OnClickDiv"
      @onmouseenter="OnTriggerMouseEnter"
      @onmouseleave="OnTriggerMouseLeave"
@@ -14,8 +14,8 @@
      @onfocusout="OnTriggerFocusOut"
      @oncontextmenu:preventDefault
      tabindex="@TabIndex">
-    @ChildContent
-</div>
+        @ChildContent
+    </div>
 }
 @if (Unbound != null)
 {
@@ -30,24 +30,20 @@
                  OnOverlayMouseEnter="OnOverlayMouseEnter"
                  OnOverlayMouseLeave="OnOverlayMouseLeave"
                  OnOverlayMouseUp="OnOverlayMouseUp">
-            @if (Title.Value != null)
+            @if (TitleTemplate != null || !string.IsNullOrWhiteSpace(Title))
             {
                 <div class="ant-tooltip-content">
                     <div class="ant-tooltip-arrow">
                         <span class="ant-tooltip-arrow-content"></span>
                     </div>
                     <div class="ant-tooltip-inner" role="tooltip">
-                        @if (Title.IsT0 && !string.IsNullOrWhiteSpace(Title.AsT0))
+                        @if (TitleTemplate != null)
                         {
-                            @Title.AsT0
+                            @TitleTemplate
                         }
-                        else if (Title.IsT1)
+                        else
                         {
-                            @Title.AsT1
-                        }
-                        else if (Title.IsT2)
-                        {
-                            @Title.AsT2
+                            @Title
                         }
                     </div>
                 </div>

--- a/components/tooltip/Tooltip.razor.cs
+++ b/components/tooltip/Tooltip.razor.cs
@@ -9,8 +9,9 @@ namespace AntDesign
     public partial class Tooltip : OverlayTrigger
     {
         [Parameter]
-        public OneOf<string, RenderFragment, MarkupString> Title { get; set; } = string.Empty;
-
+        public string Title { get; set; } = string.Empty;
+        [Parameter]
+        public RenderFragment TitleTemplate { get; set; }
         [Parameter]
         public bool ArrowPointAtCenter { get; set; } = false;
 

--- a/site/AntDesign.Docs/Demos/Components/Avatar/demo/Group.razor
+++ b/site/AntDesign.Docs/Demos/Components/Avatar/demo/Group.razor
@@ -1,7 +1,7 @@
 ﻿<AvatarGroup>
     <Avatar Src="https://zos.alipayobjects.com/rmsportal/ODTLcjxAfvqbxHnVXCYX.png" />
     <Avatar Style="background-color: #f56a00">K</Avatar>
-    <Tooltip Title=@("Ant User") Placement="Placement.Top">
+    <Tooltip Title="Ant User" Placement="Placement.Top">
         <Unbound>
             <Avatar Style="background-color: #87d068;" Icon="user" RefBack="@context"/>
         </Unbound>
@@ -12,7 +12,7 @@
 <AvatarGroup MaxCount="2" MaxStyle="color: #f56a00; background-color:#fde3cf;">
     <Avatar Src="https://zos.alipayobjects.com/rmsportal/ODTLcjxAfvqbxHnVXCYX.png" />
     <Avatar Style="background-color: #f56a00">K</Avatar>
-    <Tooltip Title=@("Ant User") Placement="Placement.Top" >
+    <Tooltip Title="Ant User" Placement="Placement.Top" >
         <Unbound>
             <Avatar Style="background-color: #87d068;" Icon="user" RefBack="@context"/>
         </Unbound>

--- a/site/AntDesign.Docs/Demos/Components/Comment/demo/Basic.razor
+++ b/site/AntDesign.Docs/Demos/Components/Comment/demo/Basic.razor
@@ -12,7 +12,7 @@
 
     RenderFragment likeAction=>
         @<span>
-            <Tooltip Title="@("Like")">
+            <Tooltip Title="Like">
                 <Icon Type="like" Theme="@(like ? "fill" : "outline")" OnClick="SetLike" />
             </Tooltip>
             <span>@(like ? 1 : 0)</span>
@@ -20,7 +20,7 @@
 
     RenderFragment dislikeAction=>
         @<span>
-            <Tooltip Title="@("Dislike")">
+            <Tooltip Title="Dislike">
                 <Icon Type="dislike" Theme="@(dislike ? "fill" : "outline")" OnClick="SetDislike" />
             </Tooltip>
             <span>@(dislike ? 1:0)</span>

--- a/site/AntDesign.Docs/Demos/Components/Drawer/demo/DropdownInDrawer.razor
+++ b/site/AntDesign.Docs/Demos/Components/Drawer/demo/DropdownInDrawer.razor
@@ -56,7 +56,7 @@
         <div style="margin: 64px" />
 
         <b>Tooltip:</b><br />
-        <Tooltip Title="@("prompt text")">
+        <Tooltip Title="prompt text">
             <span>Tooltip will show on mouse enter.</span>
         </Tooltip>
 

--- a/site/AntDesign.Docs/Demos/Components/Dropdown/demo/DropdownButtonDemo.razor
+++ b/site/AntDesign.Docs/Demos/Components/Dropdown/demo/DropdownButtonDemo.razor
@@ -68,7 +68,7 @@
                         @_overlayMenu
                     </Overlay>
                     <ChildContent>
-                        <Tooltip Title="@("tooltip")">
+                        <Tooltip Title="tooltip">
                             <Unbound>
                                 <span @ref="@context.Current">With ToolTip</span>
                             </Unbound>
@@ -129,7 +129,7 @@
                         @_overlayMenu
                     </Overlay>
                     <Unbound>
-                        <Tooltip Title="@("tooltip")">
+                        <Tooltip Title="tooltip">
                             <Unbound Context="tooltip">
                                 <span @ref="@tooltip.Current">With ToolTip</span>
                             </Unbound>
@@ -143,7 +143,7 @@
                         @_overlayMenu
                     </Overlay>
                     <Unbound>
-                        <Tooltip Title="@("tooltip")">
+                        <Tooltip Title="tooltip">
                             <Unbound Context="tooltip">
                                 <span @ref="@tooltip.Current">ButtonsRender</span>
                             </Unbound>

--- a/site/AntDesign.Docs/Demos/Components/Form/demo/ComplexFormControl.razor
+++ b/site/AntDesign.Docs/Demos/Components/Form/demo/ComplexFormControl.razor
@@ -8,7 +8,7 @@
       WrapperColSpan="16">
     <FormItem Label="Username">
         <Input @bind-Value="context.Username" Style="width: 160px" Placeholder="Please input" />
-        <Tooltip Title=@("Useful information")>
+        <Tooltip Title="Useful information">
             <a href="#API" Style="margin: 0 8px" }>
                 Need Help?
             </a>

--- a/site/AntDesign.Docs/Demos/Components/Form/demo/CustomizedLabel.razor
+++ b/site/AntDesign.Docs/Demos/Components/Form/demo/CustomizedLabel.razor
@@ -6,7 +6,7 @@
     <FormItem>
         <LabelTemplate>
             <label class="ant-form-item-required" for="username">
-                <Tooltip Title="@("Enter your username")">Username</Tooltip>
+                <Tooltip Title="Enter your username">Username</Tooltip>
             </label>
         </LabelTemplate>
         <ChildContent>

--- a/site/AntDesign.Docs/Demos/Components/Modal/demo/DropdownInModal.razor
+++ b/site/AntDesign.Docs/Demos/Components/Modal/demo/DropdownInModal.razor
@@ -58,7 +58,7 @@
     <div style="margin: 64px" />
 
     <b>Tooltip:</b><br />
-    <Tooltip Title="@("prompt text")">
+    <Tooltip Title="prompt text">
         <span>Tooltip will show on mouse enter.</span>
     </Tooltip>
 

--- a/site/AntDesign.Docs/Demos/Components/Tooltip/demo/ArrowPointAtCenter.razor
+++ b/site/AntDesign.Docs/Demos/Components/Tooltip/demo/ArrowPointAtCenter.razor
@@ -1,8 +1,8 @@
 ﻿<div>
-    <Tooltip Placement="Placement.TopLeft" Title="@("Prompt Text")">
+    <Tooltip Placement="Placement.TopLeft" Title="Prompt Text">
         <Button>Align edge / 边缘对齐</Button>
     </Tooltip>
-    <Tooltip Placement="Placement.TopLeft" Title="@("Prompt Text")" ArrowPointAtCenter="true">
+    <Tooltip Placement="Placement.TopLeft" Title="Prompt Text" ArrowPointAtCenter="true">
         <Button>Arrow points to center / 箭头指向中心</Button>
     </Tooltip>
 </div>

--- a/site/AntDesign.Docs/Demos/Components/Tooltip/demo/AutoAdjustOverflow.razor
+++ b/site/AntDesign.Docs/Demos/Components/Tooltip/demo/AutoAdjustOverflow.razor
@@ -1,3 +1,3 @@
-﻿<Tooltip Title="@("prompt text")">
+﻿<Tooltip Title="prompt text">
     <span>Tooltip will show on mouse enter.</span>
 </Tooltip>

--- a/site/AntDesign.Docs/Demos/Components/Tooltip/demo/Basic.razor
+++ b/site/AntDesign.Docs/Demos/Components/Tooltip/demo/Basic.razor
@@ -1,14 +1,14 @@
-﻿<Tooltip Title="@("prompt text (wrapped with div element)")">
+﻿<Tooltip Title="prompt text (wrapped with div element)">
     <span>Tooltip will show on mouse enter.</span>
 </Tooltip>
 <br/>
-<Tooltip Title="@("prompt text (not wrapped)")">
+<Tooltip Title="prompt text (not wrapped)">
     <Unbound>
         <span @ref="@context.Current">Tooltip (unbounded) will show on mouse enter.</span>
     </Unbound>
 </Tooltip>
 <br/>
-<Tooltip Title="@("Triggered by focusing on element")" Trigger="_triggerTypes">
+<Tooltip Title="Triggered by focusing on element" Trigger="_triggerTypes">
     <span>Tooltip will show on focused.</span>
 </Tooltip>
 

--- a/site/AntDesign.Docs/Demos/Components/Tooltip/demo/Icon_.razor
+++ b/site/AntDesign.Docs/Demos/Components/Tooltip/demo/Icon_.razor
@@ -1,0 +1,8 @@
+﻿<Tooltip>
+    <TitleTemplate>
+        <Icon Type="@IconType.Outline.Warning"/> error
+    </TitleTemplate>
+    <ChildContent>
+        <span>Tooltip with icon.</span>
+    </ChildContent>
+</Tooltip>

--- a/site/AntDesign.Docs/Demos/Components/Tooltip/demo/Icon_.razor
+++ b/site/AntDesign.Docs/Demos/Components/Tooltip/demo/Icon_.razor
@@ -1,6 +1,6 @@
 ﻿<Tooltip>
     <TitleTemplate>
-        <Icon Type="@IconType.Outline.Warning"/> error
+        <Icon Type="@IconType.Outline.Smile"/> Good day!
     </TitleTemplate>
     <ChildContent>
         <span>Tooltip with icon.</span>

--- a/site/AntDesign.Docs/Demos/Components/Tooltip/demo/PlacementType.razor
+++ b/site/AntDesign.Docs/Demos/Components/Tooltip/demo/PlacementType.razor
@@ -1,45 +1,45 @@
 ﻿<div class="demo">
     <div style="margin-left: @($"{ButtonWidth}px"); white-space: nowrap;">
-        <Tooltip Placement="@Placement.TopLeft" Title="Text">
+        <Tooltip Placement="@Placement.TopLeft" Title="@Text">
             <Button>TL</Button>
         </Tooltip>
-        <Tooltip Placement="@Placement.Top" Title="Text">
+        <Tooltip Placement="@Placement.Top" Title="@Text">
             <Button>Top</Button>
         </Tooltip>
-        <Tooltip Placement="@Placement.TopRight" Title="Text">
+        <Tooltip Placement="@Placement.TopRight" Title="@Text">
             <Button>TR</Button>
         </Tooltip>
     </div>
     <div style="width: @($"{ButtonWidth}px"); float: left;">
-        <Tooltip Placement="@Placement.LeftTop" Title="Text">
+        <Tooltip Placement="@Placement.LeftTop" Title="@Text">
             <Button>LT</Button>
         </Tooltip>
-        <Tooltip Placement="@Placement.Left" Title="Text">
+        <Tooltip Placement="@Placement.Left" Title="@Text">
             <Button>Left</Button>
         </Tooltip>
-        <Tooltip Placement="@Placement.LeftBottom" Title="Text">
+        <Tooltip Placement="@Placement.LeftBottom" Title="@Text">
             <Button>LB</Button>
         </Tooltip>
     </div>
     <div style="width: @($"{ButtonWidth}px"); margin-left: @($"{ButtonWidth * 4 + 24}px");">
-        <Tooltip Placement="@Placement.RightTop" Title="Text">
+        <Tooltip Placement="@Placement.RightTop" Title="@Text">
             <Button>RT</Button>
         </Tooltip>
-        <Tooltip Placement="@Placement.Right" Title="Text">
+        <Tooltip Placement="@Placement.Right" Title="@Text">
             <Button>Right</Button>
         </Tooltip>
-        <Tooltip Placement="@Placement.RightBottom" Title="Text">
+        <Tooltip Placement="@Placement.RightBottom" Title="@Text">
             <Button>RB</Button>
         </Tooltip>
     </div>
     <div style="margin-left: @($"{ButtonWidth}px"); clear: both; white-space: nowrap;">
-        <Tooltip Placement="@Placement.BottomLeft" Title="Text">
+        <Tooltip Placement="@Placement.BottomLeft" Title="@Text">
             <Button>BL</Button>
         </Tooltip>
-        <Tooltip Placement="@Placement.Bottom" Title="Text">
+        <Tooltip Placement="@Placement.Bottom" Title="@Text">
             <Button>Bottom</Button>
         </Tooltip>
-        <Tooltip Placement="@Placement.BottomRight" Title="Text">
+        <Tooltip Placement="@Placement.BottomRight" Title="@Text">
             <Button>BR</Button>
         </Tooltip>
     </div>

--- a/site/AntDesign.Docs/Demos/Components/Tooltip/demo/icon.md
+++ b/site/AntDesign.Docs/Demos/Components/Tooltip/demo/icon.md
@@ -1,14 +1,14 @@
 ---
 order: 4
 title:
-  zh-CN: 图标
-  en-US: Icon
+  zh-CN: 复杂标题
+  en-US: Title Template
 ---
 
 ## zh-CN
 
-TODO: translate
+在提示中显示图标等复杂的组件，可以使用 `TitleTemplate`。
 
 ## en-US
 
-The Tooltip with Icon.
+The Tooltip with Icon using `TitleTemplate`.

--- a/site/AntDesign.Docs/Demos/Components/Tooltip/demo/icon.md
+++ b/site/AntDesign.Docs/Demos/Components/Tooltip/demo/icon.md
@@ -1,0 +1,14 @@
+---
+order: 4
+title:
+  zh-CN: 图标
+  en-US: Icon
+---
+
+## zh-CN
+
+TODO: translate
+
+## en-US
+
+The Tooltip with Icon.

--- a/site/AntDesign.Docs/Demos/Components/Tooltip/doc/index.en-US.md
+++ b/site/AntDesign.Docs/Demos/Components/Tooltip/doc/index.en-US.md
@@ -24,7 +24,8 @@ There are 2 rendering approaches for `Tooltip`:
 
 | Property | Description                   | Type                               | Default |
 | -------- | ----------------------------- | ---------------------------------- | ------- |
-| Title    | The text shown in the tooltip | string\|RenderFragment | string.Empty      |
+| Title    | The text shown in the tooltip | string | string.Empty |
+| TitleTemplate | The content shown in the tooltip | RenderFragment | - |
 
 ### Common API
 

--- a/site/AntDesign.Docs/Demos/Components/Tooltip/doc/index.zh-CN.md
+++ b/site/AntDesign.Docs/Demos/Components/Tooltip/doc/index.zh-CN.md
@@ -19,7 +19,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/Vyyeu8jq2/Tooltp.svg
 | 参数  | 说明     | 类型                               | 默认值 |
 | ----- | -------- | ---------------------------------- | ------ |
 | Title | 提示文字 | string | string.Empty |
-| TitleTemplate | TODO: Translate | RenderFragment | - |
+| TitleTemplate | 标题模板 | RenderFragment | - |
 
 ### 共同的 API
 

--- a/site/AntDesign.Docs/Demos/Components/Tooltip/doc/index.zh-CN.md
+++ b/site/AntDesign.Docs/Demos/Components/Tooltip/doc/index.zh-CN.md
@@ -18,7 +18,8 @@ cover: https://gw.alipayobjects.com/zos/alicdn/Vyyeu8jq2/Tooltp.svg
 
 | 参数  | 说明     | 类型                               | 默认值 |
 | ----- | -------- | ---------------------------------- | ------ |
-| Title | 提示文字 | string\|RenderFragment | string.Empty     |
+| Title | 提示文字 | string | string.Empty |
+| TitleTemplate | TODO: Translate | RenderFragment | - |
 
 ### 共同的 API
 


### PR DESCRIPTION
> I can't be sure of the correctness of the translation into Chinese with the help of a translator, I left places for the Chinese text as `TODO: Translate`

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [x] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
Tooltip component uses OneOf Title instead separated Title and TitleTemplate
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

Users will have to use TitleTemplate if used RenderFragment to Title

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Tooltip component uses `RenderFragment TitleTeplate` instead `OneOf Title` |
| 🇨🇳 Chinese | TODO: Translate |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
