### PR TITLE
fix:(module:datepicker): OnChange event behavior is incorrect

### DIFF
--- a/components/core/EventCallbackArgs/DateTimeChangedEventArgs.cs
+++ b/components/core/EventCallbackArgs/DateTimeChangedEventArgs.cs
@@ -4,7 +4,7 @@ namespace AntDesign
 {
     public class DateTimeChangedEventArgs
     {
-        public DateTime Date { get; set; }
+        public DateTime? Date { get; set; }
         public string DateString { get; set; }
     }
 }

--- a/components/core/Helpers/DateHelper.cs
+++ b/components/core/Helpers/DateHelper.cs
@@ -268,5 +268,15 @@ namespace AntDesign
 
             return currentDate.AddDays(value);
         }
+
+        public static bool IsSameDecade(DateTime? date, DateTime? compareDate)
+        {
+            if (date is null || compareDate is null)
+                return false;
+
+            var num1 = Math.Floor(date.Value.Year / 10d);
+            var num2 = Math.Floor(compareDate.Value.Year / 10d);
+            return num1 == num2;
+        }
     }
 }

--- a/components/date-picker/RangePicker.razor.cs
+++ b/components/date-picker/RangePicker.razor.cs
@@ -58,7 +58,7 @@ namespace AntDesign
             }
         }
 
-        private DateTime[] _pickerValuesAfterInit = new DateTime[2];
+        private readonly DateTime[] _pickerValuesAfterInit = new DateTime[2];
 
         [Parameter]
         public EventCallback<DateRangeChangedEventArgs> OnChange { get; set; }
@@ -67,21 +67,22 @@ namespace AntDesign
 
         private bool ShowRanges => Ranges?.Count > 0;
 
+        private DateTime? _cacheDuringInput;
+        private DateTime _pickerValueCache;
+
         public RangePicker()
         {
             IsRange = true;
 
             DisabledDate = (date) =>
             {
-                var array = Value as Array;
-
                 int? index = null;
 
-                if (_pickerStatus[0].IsValueSelected && _inputEnd.IsOnFocused)
+                if (_inputEnd.IsOnFocused && GetIndexValue(0) is not null)
                 {
                     index = 0;
                 }
-                else if (_pickerStatus[1].IsValueSelected && _inputStart.IsOnFocused)
+                else if (_inputStart.IsOnFocused && GetIndexValue(1) is not null)
                 {
                     index = 1;
                 }
@@ -91,12 +92,7 @@ namespace AntDesign
                     return false;
                 }
 
-                DateTime? value = null;
-
-                GetIfNotNull(Value, index.Value, notNullValue =>
-                {
-                    value = notNullValue;
-                });
+                DateTime? value = GetIndexValue(index.Value);
 
                 if (value is null)
                 {
@@ -186,35 +182,25 @@ namespace AntDesign
             }
         }
 
-        private DateTime? _cacheDuringInput;
-        private DateTime _pickerValueCache;
-
         protected void OnInput(ChangeEventArgs args, int index = 0)
         {
             if (args == null)
             {
                 return;
             }
-            var array = Value as Array;
+
             if (!_duringManualInput)
             {
                 _duringManualInput = true;
-                _cacheDuringInput = array.GetValue(index) as DateTime?;
+                _cacheDuringInput = GetIndexValue(index);
                 _pickerValueCache = PickerValues[index];
             }
-            if (FormatAnalyzer.TryPickerStringConvert(args.Value.ToString(), out DateTime changeValue, false)
-                && IsValidRange(changeValue, index, array))
+
+            if (FormatAnalyzer.TryPickerStringConvert(args.Value.ToString(), out DateTime parsedValue, false)
+                && IsValidRange(parsedValue, index))
             {
-                array.SetValue(changeValue, index);
-                _cacheDuringInput = changeValue;
-                ChangePickerValue(changeValue, index);
-
-                if (_isNotifyFieldChanged && (Form?.ValidateOnChange == true))
-                {
-                    EditContext?.NotifyFieldChanged(FieldIdentifier);
-                }
-
-                StateHasChanged();
+                _pickerStatus[index].SelectedValue = parsedValue;
+                ChangePickerValue(parsedValue, index);
             }
         }
 
@@ -240,111 +226,66 @@ namespace AntDesign
                     _duringManualInput = false;
                 }
                 var input = (index == 0 ? _inputStart : _inputEnd);
-                if (string.IsNullOrWhiteSpace(input.Value))
-                {
-                    ClearValue(index, false);
-                }
-                else if (!await TryApplyInputValue(index, input.Value))
-                    return;
 
-                if (key == "ESCAPE" && _dropDown.IsOverlayShow())
+                if (key == "ENTER")
+                {
+                    if (string.IsNullOrEmpty(input.Value))
+                    {
+                        if (!_dropDown.IsOverlayShow())
+                            await _dropDown.Show();
+                    }
+                    else if (HasTimeInput && _pickerStatus[index].SelectedValue is not null)
+                    {
+                        await OnOkClick();
+                    }
+                    else if (_pickerStatus[index].SelectedValue is not null)
+                    {
+                        await OnSelect(_pickerStatus[index].SelectedValue.Value, index);
+                    }
+                    else
+                    {
+                        if (!_dropDown.IsOverlayShow())
+                            await _dropDown.Show();
+                        else
+                        {
+                            if (_pickerStatus[index].SelectedValue is null && _pickerStatus[index].IsValueSelected)
+                            {
+                                _pickerStatus[index].SelectedValue = GetIndexValue(index);
+                            }
+                            if (!await SwitchFocus(index))
+                                Close();
+                        }
+                    }
+                }
+                else if (key == "TAB" && index == 1)
+                {
+                    if (_dropDown.IsOverlayShow())
+                        Close();
+                    AutoFocus = false;
+                }
+                else if (key == "ESCAPE" && _dropDown.IsOverlayShow())
                 {
                     Close();
                     await Js.FocusAsync(input.Ref);
-                    return;
                 }
-
-                if (index == 1)
-                {
-                    if (key != "TAB")
-                    {
-                        //needed only in wasm, details: https://github.com/dotnet/aspnetcore/issues/30070
-                        await Task.Yield();
-                        await Js.InvokeVoidAsync(JSInteropConstants.InvokeTabKey);
-                        Close();
-                    }
-                    else if (!e.ShiftKey)
-                    {
-                        Close();
-                        AutoFocus = false;
-                    }
-                }
-                if (index == 0)
-                {
-                    if (key == "TAB" && e.ShiftKey)
-                    {
-                        Close();
-                        AutoFocus = false;
-                    }
-                    else if (key != "TAB")
-                    {
-                        await Blur(0);
-                        await Focus(1);
-                    }
-                }
-                return;
             }
-            if (key == "ARROWDOWN" && !_dropDown.IsOverlayShow())
+            else if (key == "ARROWDOWN")
             {
+                if (!_dropDown.IsOverlayShow())
+                    await _dropDown.Show();
+            }
+            else if (key == "ARROWUP")
+            {
+                if (_dropDown.IsOverlayShow())
+                {
+                    Close();
+                    AutoFocus = true;
+                }
+            }
+            else if (!_dropDown.IsOverlayShow())
                 await _dropDown.Show();
-                return;
-            }
-            if (key == "ARROWUP" && _dropDown.IsOverlayShow())
-            {
-                Close();
-                await Task.Yield();
-                AutoFocus = true;
-                return;
-            }
         }
 
-        private async Task<bool> TryApplyInputValue(int index, string inputValue)
-        {
-            if (FormatAnalyzer.TryPickerStringConvert(inputValue, out DateTime changeValue, false))
-            {
-                var array = Value as Array;
-                array.SetValue(changeValue, index);
-                var validationSuccess = await ValidateRange(index, changeValue, array);
-                if (OnChange.HasDelegate)
-                {
-                    await OnChange.InvokeAsync(new DateRangeChangedEventArgs
-                    {
-                        Dates = new DateTime?[] { array.GetValue(0) as DateTime?, array.GetValue(1) as DateTime? },
-                        DateStrings = new string[] { GetInputValue(0), GetInputValue(1) }
-                    });
-                }
-                return validationSuccess;
-            }
-            return false;
-        }
-
-        private async Task<bool> ValidateRange(int index, DateTime newDate, Array array)
-        {
-            if (index == 0 && array.GetValue(1) is not null && ((DateTime)array.GetValue(1)).CompareTo(newDate) < 0)
-            {
-                ClearValue(1, false);
-                await Blur(0);
-                await Focus(1);
-                return false;
-            }
-            else if (index == 1)
-            {
-                if (array.GetValue(0) is not null && newDate.CompareTo((DateTime)array.GetValue(0)) < 0)
-                {
-                    ClearValue(0, false);
-                    await Blur(1);
-                    await Focus(0);
-                    return false;
-                }
-                else if (array.GetValue(0) is null)
-                {
-                    await Blur(1);
-                    await Focus(0);
-                    return false;
-                }
-            }
-            return true;
-        }
 
         private async Task OnFocus(int index)
         {
@@ -389,16 +330,11 @@ namespace AntDesign
             {
                 var array = Value as Array;
 
-                if (!array.GetValue(index).Equals(_cacheDuringInput))
+                if (array.GetValue(index) is null && _pickerStatus[index].SelectedValue is not null ||
+                    !Convert.ToDateTime(array.GetValue(index), CultureInfo).Equals(_pickerStatus[index].SelectedValue))
                 {
-                    //reset picker to Value
-                    if (IsNullable)
-                        array.SetValue(_cacheDuringInput, index);
-                    else
-                        array.SetValue(_cacheDuringInput.GetValueOrDefault(), index);
-
-                    _pickerStatus[index].IsValueSelected = !(Value is null && (DefaultValue is not null || DefaultPickerValue is not null));
-                    ChangePickerValue(_pickerValueCache, index);
+                    _pickerStatus[index].SelectedValue = null;
+                    ChangePickerValue(_cacheDuringInput ?? _pickerValuesAfterInit[index]);
                 }
                 _duringManualInput = false;
             }
@@ -417,6 +353,7 @@ namespace AntDesign
                 _value = CreateInstance();
                 ValueChanged.InvokeAsync(_value);
             }
+            ResetPlaceholder();
         }
 
         /// <summary>
@@ -445,6 +382,11 @@ namespace AntDesign
         /// <returns></returns>
         public override DateTime? GetIndexValue(int index)
         {
+            if (_pickerStatus[index].SelectedValue is not null)
+            {
+                return _pickerStatus[index].SelectedValue;
+            }
+
             if (Value != null)
             {
                 var array = Value as Array;
@@ -470,7 +412,7 @@ namespace AntDesign
             return outValue == null;
         }
 
-        public override void ChangeValue(DateTime value, int index = 0)
+        public override void ChangeValue(DateTime value, int index = 0, bool closeDropdown = true)
         {
             bool isValueInstantiated = Value == null;
             if (isValueInstantiated)
@@ -478,12 +420,20 @@ namespace AntDesign
                 Value = CreateInstance();
             }
             UseDefaultPickerValue[index] = false;
+
             var array = Value as Array;
 
-            array.SetValue(value, index);
+            var currentValue = array.GetValue(index) as DateTime?;
+
+            var isValueChanged = currentValue != _pickerStatus[index].SelectedValue;
+
+            if (isValueChanged)
+            {
+                array.SetValue(value, index);
+            }
 
             //if Value was just now instantiated then set the other index to existing DefaultValue
-            if (isValueInstantiated && IsRange && DefaultValue != null)
+            if (isValueInstantiated && DefaultValue != null)
             {
                 var arrayDefault = DefaultValue as Array;
                 int oppositeIndex = index == 1 ? 0 : 1;
@@ -492,11 +442,10 @@ namespace AntDesign
 
             _pickerStatus[index].IsValueSelected = true;
 
-            if (!IsShowTime && Picker != DatePickerType.Time)
+            if (closeDropdown && !HasTimeInput)
             {
-                _pickerStatus[index].IsNewValueSelected = true;
-
-                if (_pickerStatus[0].IsNewValueSelected && _pickerStatus[1].IsNewValueSelected)
+                if (_pickerStatus[0].SelectedValue is not null
+                    && _pickerStatus[1].SelectedValue is not null)
                 {
                     Close();
                 }
@@ -507,13 +456,13 @@ namespace AntDesign
                 }
             }
 
-            if (OnChange.HasDelegate)
+            var startDate = array.GetValue(0) as DateTime?;
+            var endDate = array.GetValue(1) as DateTime?;
+
+            if (isValueChanged && startDate is not null
+                                    && endDate is not null)
             {
-                OnChange.InvokeAsync(new DateRangeChangedEventArgs
-                {
-                    Dates = new DateTime?[] { array.GetValue(0) as DateTime?, array.GetValue(1) as DateTime? },
-                    DateStrings = new string[] { GetInputValue(0), GetInputValue(1) }
-                });
+                InvokeOnChange();
             }
 
             if (_isNotifyFieldChanged && (Form?.ValidateOnChange == true))
@@ -540,17 +489,37 @@ namespace AntDesign
                 {
                     array.SetValue(default, i);
                 }
+
+                _pickerStatus[i].SelectedValue = null;
                 _pickerStatus[i].IsValueSelected = false;
                 PickerValues[i] = _pickerValuesAfterInit[i];
                 ResetPlaceholder(i);
             }
 
             if (closeDropdown)
+            {
                 Close();
+            }
+
+            if (array.GetValue(0) is null && array.GetValue(1) is null)
+            {
+                InvokeOnChange();
+            }
+
             if (OnClearClick.HasDelegate)
                 OnClearClick.InvokeAsync(null);
 
             _dropDown.SetShouldRender(true);
+        }
+
+        private void InvokeOnChange()
+        {
+            var array = Value as Array;
+            OnChange.InvokeAsync(new DateRangeChangedEventArgs
+            {
+                Dates = new DateTime?[] { array.GetValue(0) as DateTime?, array.GetValue(1) as DateTime? },
+                DateStrings = new string[] { GetInputValue(0), GetInputValue(1) }
+            });
         }
 
         private void GetIfNotNull(TValue value, int index, Action<DateTime> notNullAction)
@@ -638,12 +607,12 @@ namespace AntDesign
             await OnInputClick(0);
         }
 
-        private bool IsValidRange(DateTime newValue, int newValueIndex, Array rangeValues)
+        private bool IsValidRange(DateTime newValue, int newValueIndex)
         {
             return newValueIndex switch
             {
-                0 when newValue > (rangeValues.GetValue(1) as DateTime?) => false,
-                1 when newValue < (rangeValues.GetValue(0) as DateTime?) => false,
+                0 when newValue > GetIndexValue(1) => false,
+                1 when newValue < GetIndexValue(0) => false,
                 _ => true
             };
         }

--- a/components/date-picker/RangePicker.razor.cs
+++ b/components/date-picker/RangePicker.razor.cs
@@ -134,13 +134,21 @@ namespace AntDesign
 
             if (currentValue is not null)
             {
-                if (IsShowTime)
+                if (index == 0 || IsShowTime)
                 {
                     PickerValues[index] = currentValue.Value;
                 }
                 else
                 {
-                    PickerValues[index] = index == 0 ? currentValue.Value : GetClosingDate(currentValue.Value, -1);
+                    var otherValue = GetIndexValue(Math.Abs(index - 1));
+
+                    PickerValues[index] = Picker switch
+                    {
+                        DatePickerType.Year when DateHelper.IsSameDecade(currentValue, otherValue) => currentValue.Value,
+                        DatePickerType.Week or DatePickerType.Date when DateHelper.IsSameMonth(currentValue, otherValue) => currentValue.Value,
+                        DatePickerType.Quarter or DatePickerType.Month when DateHelper.IsSameYear(currentValue, otherValue) => currentValue.Value,
+                        _ => GetClosingDate(currentValue.Value, -1)
+                    };
                 }
             }
             else if (UseDefaultPickerValue[index] && DefaultPickerValue is not null)

--- a/components/date-picker/internal/DatePickerBase.cs
+++ b/components/date-picker/internal/DatePickerBase.cs
@@ -715,7 +715,7 @@ namespace AntDesign
             {
                 DatePickerType.Year => pickerValue.AddYears(offset * 10),
                 DatePickerType.Quarter or DatePickerType.Decade or DatePickerType.Month => pickerValue.AddYears(offset),
-                _ => pickerValue.AddMonths(offset),
+                _ => pickerValue.AddMonths(offset)
             };
         }
 

--- a/components/date-picker/internal/DatePickerBase.cs
+++ b/components/date-picker/internal/DatePickerBase.cs
@@ -458,8 +458,9 @@ namespace AntDesign
         {
             _duringManualInput = false;
 
-            // InitPicker is the finally value
-            if (_picker == _pickerStatus[index].InitPicker)
+            var isInitialPickerType = _picker == _pickerStatus[index].InitPicker;
+
+            if (isInitialPickerType)
             {
                 _pickerStatus[index].SelectedValue = date;
 
@@ -503,7 +504,7 @@ namespace AntDesign
                 _picker = _prePickerStack.Pop();
             }
 
-            if (!IsRange || IsShowTime)
+            if (!isInitialPickerType || !IsRange || IsShowTime)
             {
                 ChangePickerValue(date, index);
             }

--- a/components/date-picker/internal/DatePickerBase.cs
+++ b/components/date-picker/internal/DatePickerBase.cs
@@ -256,7 +256,7 @@ namespace AntDesign
 
         protected DateTime[] PickerValues { get; } = new DateTime[] { DateTime.Today, DateTime.Today };
 
-        public bool IsRange { get; set; }
+        public bool IsRange { get; protected set; }
 
         protected DatePickerInput _inputStart;
         protected DatePickerInput _inputEnd;
@@ -285,6 +285,8 @@ namespace AntDesign
         internal event EventHandler<bool> OverlayVisibleChanged;
 
         private readonly object _eventLock = new();
+
+        protected bool HasTimeInput => IsShowTime || Picker == DatePickerType.Time;
 
         event EventHandler<bool> IDatePicker.OverlayVisibleChanged
         {
@@ -421,6 +423,7 @@ namespace AntDesign
         protected string GetInputValue(int index = 0)
         {
             DateTime? tryGetValue = GetIndexValue(index);
+
             if (tryGetValue == null)
             {
                 return "";
@@ -451,23 +454,48 @@ namespace AntDesign
             return Task.CompletedTask;
         }
 
-        protected virtual async Task OnSelect(DateTime date, int index)
+        protected virtual async Task OnSelect(DateTime date, int index, bool switchFocus = true, bool closeDropdown = true)
         {
             _duringManualInput = false;
 
             // InitPicker is the finally value
             if (_picker == _pickerStatus[index].InitPicker)
             {
-                ChangeValue(date, index);
+                _pickerStatus[index].SelectedValue = date;
+
+                if (IsRange)
+                {
+                    var otherIndex = Math.Abs(index - 1);
+
+                    if (!HasTimeInput)
+                    {
+                        if (GetIndexValue(otherIndex) is not null)
+                        {
+                            if (_pickerStatus[otherIndex].SelectedValue is not null)
+                            {
+                                ChangeValue(_pickerStatus[otherIndex].SelectedValue.Value, otherIndex, closeDropdown);
+                            }
+
+                            ChangeValue(date, index, closeDropdown);
+                        }
+                    }
+                }
+                else if (!HasTimeInput)
+                {
+                    ChangeValue(date, index, closeDropdown);
+                }
 
                 // auto focus the other input
-                if (IsRange && (!IsShowTime || Picker == DatePickerType.Time))
+                if (switchFocus)
                 {
-                    await SwitchFocus(index);
-                }
-                else
-                {
-                    await Focus(index);
+                    if (IsRange && !HasTimeInput)
+                    {
+                        await SwitchFocus(index);
+                    }
+                    else
+                    {
+                        await Focus(index);
+                    }
                 }
             }
             else
@@ -487,27 +515,33 @@ namespace AntDesign
         {
             var index = GetOnFocusPickerIndex();
 
-            _pickerStatus[index].IsNewValueSelected = true;
-
             if (IsRange)
             {
                 var otherIndex = Math.Abs(index - 1);
+                var otherValue = GetIndexValue(otherIndex);
 
-                if (!_pickerStatus[otherIndex].IsNewValueSelected)
+                if (_pickerStatus[index].SelectedValue is not null && otherValue is not null)
                 {
-                    var otherValue = GetIndexValue(otherIndex);
-                    _pickerStatus[otherIndex].IsNewValueSelected = otherValue is not null
-                                                                    && otherValue != _pickerStatus[otherIndex].OldValue;
+                    if (_pickerStatus[otherIndex].SelectedValue is not null)
+                    {
+                        ChangeValue(_pickerStatus[otherIndex].SelectedValue.Value, otherIndex);
+                    }
+
+                    ChangeValue(_pickerStatus[index].SelectedValue.Value, index);
+                }
+
+                if (!(await SwitchFocus(index)))
+                {
+                    Close();
                 }
             }
             else
             {
-                Close();
-                return;
-            }
+                if (HasTimeInput && _pickerStatus[index].SelectedValue is not null)
+                {
+                    ChangeValue(_pickerStatus[index].SelectedValue.Value, index);
+                }
 
-            if (!(await SwitchFocus(index)))
-            {
                 Close();
             }
         }
@@ -525,19 +559,17 @@ namespace AntDesign
             _swpValue = DataConvertionExtensions.Convert<DateTime?[], TValue>(new DateTime?[] { range[0], range[1] });
             ChangeValue((DateTime)range[0], 0);
             ChangeValue((DateTime)range[1], 1);
-            _pickerStatus[0].IsNewValueSelected = true;
-            _pickerStatus[1].IsNewValueSelected = true;
             Close();
         }
 
-        private async Task<bool> SwitchFocus(int index)
+        protected async Task<bool> SwitchFocus(int index)
         {
-            if (index == 0 && (!_pickerStatus[1].IsNewValueSelected || Open) && !_inputEnd.IsOnFocused && !IsDisabled(1))
+            if (index == 0 && (_pickerStatus[1].SelectedValue is null || Open) && !_inputEnd.IsOnFocused && !IsDisabled(1))
             {
                 await Blur(0);
                 await Focus(1);
             }
-            else if (index == 1 && (!_pickerStatus[0].IsNewValueSelected || Open) && !_inputStart.IsOnFocused && !IsDisabled(0))
+            else if (index == 1 && (_pickerStatus[0].SelectedValue is null || Open) && !_inputStart.IsOnFocused && !IsDisabled(0))
             {
                 await Blur(1);
                 await Focus(0);
@@ -665,7 +697,7 @@ namespace AntDesign
 
             var pickerValue = PickerValues[tempIndex];
 
-            if (index == 0 || IsShowTime || Picker == DatePickerType.Time)
+            if (index == 0 || HasTimeInput)
             {
                 return pickerValue;
             }
@@ -694,7 +726,7 @@ namespace AntDesign
             StateHasChanged();
         }
 
-        public void ResetPlaceholder(int index = -1)
+        public void ResetPlaceholder(int rangePickerIndex = -1)
         {
             _placeholder.Switch(single =>
             {
@@ -703,18 +735,19 @@ namespace AntDesign
                 _placeholders[1] = placeholder;
             }, arr =>
             {
-                var rangePickerIndex = index >= 0 ? index : GetOnFocusPickerIndex();
+                var (startPlaceholder, endPlaceholder) = DatePickerPlaceholder.GetRangePlaceHolderByType(Picker, Locale);
 
-                var placeholder = arr.Length > rangePickerIndex ? arr[rangePickerIndex] : null;
-
-                if (placeholder is null)
+                if (rangePickerIndex >= 0)
                 {
-                    var (startPlaceholder, endPlaceholder) = DatePickerPlaceholder.GetRangePlaceHolderByType(Picker, Locale);
-
-                    placeholder = rangePickerIndex == 0 ? startPlaceholder : endPlaceholder;
+                    var placeholder = arr.Length > rangePickerIndex ? arr[rangePickerIndex] : null;
+                    placeholder ??= rangePickerIndex == 0 ? startPlaceholder : endPlaceholder;
+                    _placeholders[rangePickerIndex] = placeholder;
                 }
-
-                _placeholders[rangePickerIndex] = placeholder;
+                else
+                {
+                    _placeholders[0] = arr.Length > 0 ? arr[0] : startPlaceholder;
+                    _placeholders[1] = arr.Length > 1 ? arr[1] : endPlaceholder;
+                }
             });
         }
 
@@ -856,7 +889,7 @@ namespace AntDesign
         /// </summary>
         /// <param name="value"></param>
         /// <param name="index"></param>
-        public abstract void ChangeValue(DateTime value, int index = 0);
+        public abstract void ChangeValue(DateTime value, int index = 0, bool closeDropdown = true);
 
         public abstract void ClearValue(int index = 0, bool closeDropdown = true);
 
@@ -892,62 +925,21 @@ namespace AntDesign
 
         protected void InvokeInternalOverlayVisibleChanged(bool visible)
         {
+            var index = GetOnFocusPickerIndex();
+
+            _pickerStatus[index].SelectedValue = null;
+
             if (IsRange)
             {
-                if (!visible && (!_pickerStatus[0].IsNewValueSelected || !_pickerStatus[1].IsNewValueSelected))
-                {
-                    if (_pickerStatus[0].OldValue.HasValue && _pickerStatus[1].OldValue.HasValue)
-                    {
-                        var startDate = GetIndexValue(0);
-                        var endDate = GetIndexValue(1);
+                var otherIndex = Math.Abs(index - 1);
+                _pickerStatus[otherIndex].SelectedValue = null;
 
-                        if (startDate is not null && startDate != _pickerStatus[0].OldValue)
-                        {
-                            ChangeValue(_pickerStatus[0].OldValue.Value, 0);
-                        }
-                        if (endDate is not null && endDate != _pickerStatus[1].OldValue)
-                        {
-                            ChangeValue(_pickerStatus[1].OldValue.Value, 1);
-                        }
-                    }
-                    else if (_pickerStatus[0].IsValueSelected || _pickerStatus[1].IsValueSelected)
-                    {
-                        ClearValue(-1);
-                    }
-
-                    AutoFocus = false;
-                }
-                else if (visible)
+                if (!visible)
                 {
-                    _pickerStatus[0].OldValue = GetIndexValue(0);
-                    _pickerStatus[1].OldValue = GetIndexValue(1);
+                    ResetPlaceholder();
                 }
             }
-            else if (IsShowTime || Picker == DatePickerType.Time)
-            {
-                var index = GetOnFocusPickerIndex();
 
-                if (!_pickerStatus[index].IsNewValueSelected && !visible)
-                {
-                    if (_pickerStatus[index].OldValue.HasValue)
-                    {
-                        ChangeValue(_pickerStatus[index].OldValue.Value, index);
-                    }
-                    else
-                    {
-                        ClearValue(index);
-                    }
-                }
-                else if (visible)
-                {
-                    _pickerStatus[index].OldValue = GetIndexValue(index);
-                }
-            }
-            if (visible)
-            {
-                _pickerStatus[0].IsNewValueSelected = false;
-                _pickerStatus[1].IsNewValueSelected = false;
-            }
             OverlayVisibleChanged?.Invoke(this, visible);
         }
 
@@ -982,11 +974,9 @@ namespace AntDesign
             }
         }
 
-        internal async Task OnNowClick()
+        internal void OnNowClick()
         {
-            var pickerIndex = GetOnFocusPickerIndex();
-            await OnSelect(DateTime.Now, GetOnFocusPickerIndex());
-            _pickerStatus[pickerIndex].IsNewValueSelected = true;
+            ChangeValue(DateTime.Now, GetOnFocusPickerIndex());
             Close();
         }
     }

--- a/components/date-picker/internal/DatePickerBase.cs
+++ b/components/date-picker/internal/DatePickerBase.cs
@@ -13,7 +13,7 @@ using OneOf;
 
 namespace AntDesign
 {
-    public class DatePickerBase<TValue> : AntInputComponentBase<TValue>, IDatePicker
+    public abstract class DatePickerBase<TValue> : AntInputComponentBase<TValue>, IDatePicker
     {
         DateTime? IDatePicker.HoverDateTime { get; set; }
         private TValue _swpValue;
@@ -553,7 +553,7 @@ namespace AntDesign
             return true;
         }
 
-        protected virtual async Task OnBlur(int index) => await Task.Yield();
+        protected abstract Task OnBlur(int index);
 
         protected void InitPicker(string picker)
         {
@@ -856,18 +856,11 @@ namespace AntDesign
         /// </summary>
         /// <param name="value"></param>
         /// <param name="index"></param>
-        public virtual void ChangeValue(DateTime value, int index = 0)
-        {
-        }
+        public abstract void ChangeValue(DateTime value, int index = 0);
 
-        public virtual void ClearValue(int index = 0, bool closeDropdown = true)
-        {
-        }
+        public abstract void ClearValue(int index = 0, bool closeDropdown = true);
 
-        public virtual DateTime? GetIndexValue(int index)
-        {
-            return null;
-        }
+        public abstract DateTime? GetIndexValue(int index);
 
         protected TValue SortValue(TValue value)
         {

--- a/components/date-picker/internal/DatePickerDatetimePanel.razor
+++ b/components/date-picker/internal/DatePickerDatetimePanel.razor
@@ -80,7 +80,7 @@
         bool isValueNull = Value is null;
         Func<int, int?, string> selected;
         string localValue;
-        if (Value is null)
+        if (isValueNull)
         {
             localValue = "";
             selected = (_, _) => "";

--- a/components/date-picker/internal/DatePickerDatetimePanel.razor
+++ b/components/date-picker/internal/DatePickerDatetimePanel.razor
@@ -39,7 +39,7 @@
                             ShowFooter="@ShowToday"
                             IsInView="date => DateHelper.IsSameMonth(date, PickerValue)"
                             IsToday="date => DateHelper.IsSameDay(date, DatePicker.CurrentDate)"
-                            IsSelected="date => DateHelper.IsSameDay(date, Value)"
+                            IsSelected="date => DateHelper.IsSameDay(date, Value) || IsRange && DateHelper.IsSameDay(date, GetIndexValue(Math.Abs(PickerIndex-1)))"
                             GetColTitle='date => date.ToString(Locale.Lang.DateFormat, CultureInfo)'
                             OnValueSelect="OnSelectDate"
                             GetNextColValue="date => DateHelper.AddDaysSafely(date, 1)"

--- a/components/date-picker/internal/DatePickerPanelBase.cs
+++ b/components/date-picker/internal/DatePickerPanelBase.cs
@@ -188,7 +188,7 @@ namespace AntDesign
 
         protected DateTime PickerValue { get => GetIndexPickerValue(PickerIndex); }
 
-        protected DateTime? Value { get => GetIndexValue(PickerIndex); }
+        protected DateTime? Value { get => GetIndexValue(GetPickerIndex()); }
 
         public void PopUpPicker(string type) => ChangePickerType(type, PickerIndex);
 

--- a/components/date-picker/internal/DatePickerStatus.cs
+++ b/components/date-picker/internal/DatePickerStatus.cs
@@ -6,7 +6,6 @@ namespace AntDesign.Internal
     {
         public string InitPicker { get; set; } = null;
         public bool IsValueSelected { get; set; }
-        public bool IsNewValueSelected { get; set; }
-        public DateTime? OldValue { get; set; }
+        public DateTime? SelectedValue { get; set; }
     }
 }

--- a/components/date-picker/internal/DatePickerTemplate.razor.cs
+++ b/components/date-picker/internal/DatePickerTemplate.razor.cs
@@ -1,7 +1,6 @@
-﻿using System;
+using System;
 using System.Text;
 using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Web;
 
 namespace AntDesign.Internal
 {
@@ -294,12 +293,12 @@ namespace AntDesign.Internal
             {
                 if (endDate == null)
                 {
-                    cls.Append($"{PrefixCls}-cell-range-start-single");
+                    cls.Append($" {PrefixCls}-cell-range-start-single");
                 }
-
+                
                 if (startDate != endDate || currentDate > hoverDateTime)
                 {
-                    cls.Append($"{PrefixCls}-cell-range-start");
+                    cls.Append($" {PrefixCls}-cell-range-start");
                 }
 
                 if (currentDate > hoverDateTime)
@@ -337,7 +336,7 @@ namespace AntDesign.Internal
                 {
                     cls.Append($" {PrefixCls}-cell-range-end-single");
                 }
-
+                
                 if (startDate != endDate || currentDate < hoverDateTime)
                 {
                     cls.Append($" {PrefixCls}-cell-range-end");

--- a/site/AntDesign.Docs/Demos/Components/TimePicker/demo/Value.razor
+++ b/site/AntDesign.Docs/Demos/Components/TimePicker/demo/Value.razor
@@ -2,7 +2,7 @@
 
 @code
 {
-    private DateTime _value = DateTime.Now;
+    private DateTime? _value = DateTime.Now;
 
     private void OnChange(DateTimeChangedEventArgs args)
     {

--- a/tests/AntDesign.Tests/DatePicker/DatePickerKeyboardInputTests.razor
+++ b/tests/AntDesign.Tests/DatePicker/DatePickerKeyboardInputTests.razor
@@ -3,14 +3,14 @@
 @inherits AntDesignTestBase
 
 @code {
-	[Fact]
-	public void Enter_applies_input_to_value()
-	{
-		//Arrange
-		JSInterop.SetupVoid(JSInteropConstants.AddPreventKeys, _ => true);
-		JSInterop.SetupVoid(JSInteropConstants.InvokeTabKey, _ => true);
-
-		DateTime value = DateTime.MinValue;
+    [Fact]
+    public void Enter_applies_input_to_value()
+    {
+        //Arrange
+        JSInterop.SetupVoid(JSInteropConstants.AddPreventKeys, _ => true);
+        JSInterop.SetupVoid(JSInteropConstants.InvokeTabKey, _ => true);
+        JSInterop.SetupVoid(JSInteropConstants.Focus, _ => true);
+        DateTime value = DateTime.MinValue;
 		DateTime defaultValue = new DateTime(2020,1,1);
 		DateTime expectedValue = new DateTime(2020,1,2);
 		string expectedValueAsString = expectedValue.ToString("yyyy-MM-dd");
@@ -50,14 +50,15 @@
 	}
 
     [Fact]
-	public void Input_applied_to_value_on_blur_when_valid()
+	public void Input_restored_to_previous_value_on_blur_if_not_confirmed_with_enter_key()
 	{
 		//Arrange
 		JSInterop.SetupVoid(JSInteropConstants.AddPreventKeys, _ => true);
 
 		DateTime value = DateTime.MinValue;
-		DateTime defaultValue = new DateTime(2020,1,1);		
-		var cut = Render<AntDesign.DatePicker<DateTime>>(
+		DateTime defaultValue = new DateTime(2020,1,1);
+        var defaultValueAsString = defaultValue.ToString("yyyy-MM-dd");
+        var cut = Render<AntDesign.DatePicker<DateTime>>(
         @<DatePicker @bind-Value="@value" DefaultValue="@defaultValue" />
         );
         var newValue = defaultValue.AddDays(1);        
@@ -67,10 +68,10 @@
         var input = cut.Find("input");      
         input.Input(newValueAsString);
 		input.Blur();
-		//Assert
-		cut.Instance.Value.Should().Be(newValue);
-		value.Should().Be(newValue);
-		input.GetAttribute("value").Should().Be(newValueAsString);
+        //Assert
+        cut.Instance.Value.Should().Be(defaultValue);
+        value.Should().Be(defaultValue);
+        input.GetAttribute("value").Should().Be(defaultValueAsString);
 	}
 
 	[Fact]


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

#2713 
#2729

### 💡 Background and solution

This pull request brings DatePicker/RangePicker behavior closer to the behavior of the original ant.design.

### 📝 Changelog
Fixes:
- OnChange event behavior #2713 
- Cannot switch year in the RangePicker header #2729 
- Date input with keyboard
- Input panels wrong when start/end is in the same period
- The ending week is not highlighted correctly in Picker=='week'
- The start date is not highlighted during the end date input in the date picker with the time
- Other minor fixes and refactorings

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
