### PR TITLE
fix(module: radio): the disabled parameter for RadioGroup with `RadioOption<TValue>` options doesn't work

### DIFF
--- a/components/radio/RadioGroup.razor
+++ b/components/radio/RadioGroup.razor
@@ -18,7 +18,7 @@
 				{
 					@foreach (var radio in Options.AsT1)
 					{
-						<Radio TValue="TValue" Value="radio.Value" Disabled="radio.Disabled">@radio.Label</Radio>
+						<Radio Value="radio.Value">@radio.Label</Radio>
 					}
 				}
 			}

--- a/site/AntDesign.Docs/Demos/Components/Radio/demo/EnumGroup.razor
+++ b/site/AntDesign.Docs/Demos/Components/Radio/demo/EnumGroup.razor
@@ -1,19 +1,24 @@
 ﻿@using System.ComponentModel.DataAnnotations
 
-<EnumRadioGroup TEnum="Fruits" @bind-Value="_radioValue"></EnumRadioGroup>
+<EnumRadioGroup TEnum="Fruits" @bind-Value="_radioValue" Disabled="_disabled"></EnumRadioGroup>
 <br />
 Value: @_radioValue
 
+<div style="margin-top: 20px">
+    <Button Type="primary" OnClick="_=>_disabled=!_disabled">Toggle Disabled</Button>
+</div>
+
 @code {
-	Fruits _radioValue = Fruits.Apple;
+    Fruits _radioValue = Fruits.Apple;
+    bool _disabled;
 
-	enum Fruits
-	{
-		[Display(Name = "🍎 Apple")]
-		Apple,
+    enum Fruits
+    {
+        [Display(Name = "🍎 Apple")]
+        Apple,
 
-		Pear,
+        Pear,
 
-		Orange
-	}
+        Orange
+    }
 }

--- a/tests/AntDesign.Tests/Radio/RadioGroupTests.razor
+++ b/tests/AntDesign.Tests/Radio/RadioGroupTests.razor
@@ -109,13 +109,38 @@
             @<RadioGroup @bind-Value=@value Disabled=@initGroupDisabled>
                     <Radio Value="1">A</Radio>
                     <Radio Value="2">B</Radio>
-    </RadioGroup>
+        </RadioGroup>
     );
         var members = radioGroup.FindComponents<Radio<int>>();
         //Act
 #pragma warning disable BL0005
         radioGroup.Instance.Disabled = !initGroupDisabled;
 #pragma warning restore BL0005
+        
+        radioGroup.Render();
+        //Assert
+        Assert.All(members, e => Assert.Equal(!initGroupDisabled, e.Instance.Disabled));
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Sync_Disabled_basic_radioGroup_with_options(bool initGroupDisabled)
+    {
+        var options = new RadioOption<int>[] { new() { Value = 1, Label = "A" }, new() { Value = 1, Label = "A" } };
+        //Arrange
+        int value = 1;
+        IRenderedComponent<RadioGroup<int>> radioGroup = Render<RadioGroup<int>>(
+            @<RadioGroup Options="options" @bind-Value=@value Disabled=@initGroupDisabled />
+        );
+        var members = radioGroup.FindComponents<Radio<int>>();
+        //Act
+#pragma warning disable BL0005
+        radioGroup.Instance.Disabled = !initGroupDisabled;
+#pragma warning restore BL0005
+
+        radioGroup.Render();
+
         //Assert
         Assert.All(members, e => Assert.Equal(!initGroupDisabled, e.Instance.Disabled));
     }
@@ -132,14 +157,18 @@
                     <Radio Value="1" Disabled=true>A</Radio>
                     <Radio Value="2">B</Radio>
         </RadioGroup>
-        );
+    );
         var members = radioGroup.FindComponents<Radio<int>>();
         //Act
 #pragma warning disable BL0005
         radioGroup.Instance.Disabled = !initGroupDisabled;
 #pragma warning restore BL0005
+
+        radioGroup.Render();
+
         //Assert
         members[0].Instance.Disabled.Should().BeTrue();
         members[1].Instance.Disabled.Should().Be(!initGroupDisabled);
     }
+
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

fixed #2743 

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  fixed Radio that the disabled parameter for RadioGroup with `RadioOption<TValue>` options doesn't work         |
| 🇨🇳 Chinese |  修复 Radio 的 disabled 属性在 使用了 RadioOption<TValue> 作为options 的 RadioGroup   中不起作用的问题    |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
