### PR TITLE
Fix search bug #2752 #2748

### DIFF
--- a/components/auto-complete/AutoComplete.razor.cs
+++ b/components/auto-complete/AutoComplete.razor.cs
@@ -368,7 +368,7 @@ namespace AntDesign
                 }
             }
 
-            if (_overlayTrigger != null && ShowPanel)
+            if (_overlayTrigger != null)
             {
                 // if options count == 0 then close overlay
                 if (_isOptionsZero && _overlayTrigger.IsOverlayShow())


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
#2752 #2748
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      fix search panel show      |
| 🇨🇳 Chinese |     修复搜索时弹列表不显示      |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

### sum
先说结论，这样能解决问题，但不是很优雅。
根本问题是函数event调用顺序。
![image](https://user-images.githubusercontent.com/50474995/192724279-26c92c08-a1b9-4b0f-878e-2723dfe68f8c.png)
应该是先执行 `OnParametersSet`，让`_isOptionsZero`为`false`，然后执行`InputKeyDown`,判断``为false，展示弹窗
```c#
            else if (!_isOptionsZero)
            {
                Console.WriteLine("InputKeyDown, open");
                this.OpenPanel();
            }
```
，但实际上先执行了`InputKeyDown`,所以再按一次能够弹出来
