### PR TITLE
test(module: drawer): Test, refactor and document Drawer

### DIFF
--- a/components/drawer/Drawer.razor
+++ b/components/drawer/Drawer.razor
@@ -4,7 +4,7 @@
     <div class="@ClassMapper.Class" @ref="@Ref" style="@_drawerStyle @InnerZIndexStyle @Style" id="@Id">
         @if (Mask)
         {
-            <div class="ant-drawer-mask" @onclick="_=>MaskClick()" style="@MaskStyle"></div>
+            <div class="ant-drawer-mask" @onclick="MaskClick" style="@MaskStyle"></div>
         }
         <div class="ant-drawer-content-wrapper @WrapClassName " style="@WrapperStyle" id="@($"ant-drawer-wrap_{Id}")">
             <div class="ant-drawer-content">
@@ -39,7 +39,7 @@
                         {
                             @ContentTemplate
                         }
-                        @if (string.IsNullOrEmpty(ContentString))
+                        @if (!string.IsNullOrEmpty(ContentString))
                         {
                             @((MarkupString)ContentString)
                         }

--- a/components/drawer/Drawer.razor
+++ b/components/drawer/Drawer.razor
@@ -11,7 +11,6 @@
                 <div class="ant-drawer-wrapper-body" style="@(IsLeftOrRight?"height:100%":"")">
                     @if (_title.Value != null || Closable)
                     {
-
                         <div class="@TitleClassMapper.Class">
                             @if (_title.Value != null)
                             {

--- a/components/drawer/Drawer.razor.cs
+++ b/components/drawer/Drawer.razor.cs
@@ -385,15 +385,6 @@ namespace AntDesign
         protected override void OnParametersSet()
         {
             SetClass();
-            if (string.IsNullOrEmpty(Placement) && Placement != _originalPlacement)
-            {
-                _originalPlacement = Placement;
-                _isPlacementFirstChange = false;
-                if (!_isPlacementFirstChange)
-                {
-                    TriggerPlacementChangeCycleOnce();
-                }
-            }
 
             _drawerStyle = "";
 
@@ -449,23 +440,6 @@ namespace AntDesign
         private Timer _timer;
         private int _zIndex = 1000;
         private string _zIndexStyle = "";
-
-        private void TriggerPlacementChangeCycleOnce()
-        {
-            PlacementChanging = true;
-            InvokeStateHasChanged();
-            _timer = new Timer()
-            {
-                AutoReset = false,
-                Interval = 300,
-            };
-            _timer.Elapsed += (_, args) =>
-            {
-                PlacementChanging = false;
-                InvokeStateHasChanged();
-            };
-            _timer.Start();
-        }
 
         /// <summary>
         /// trigger when mask is clicked

--- a/components/drawer/Drawer.razor.cs
+++ b/components/drawer/Drawer.razor.cs
@@ -1,8 +1,13 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Timers;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 using OneOf;
 
 namespace AntDesign
@@ -225,18 +230,18 @@ namespace AntDesign
         [Parameter]
         public bool Visible
         {
-            get => this._isOpen;
+            get => _isOpen;
             set
             {
-                if (this._isOpen && !value)
+                if (_isOpen && !value)
                 {
                     _status = ComponentStatus.Closing;
                 }
-                else if (!this._isOpen && value)
+                else if (!_isOpen && value)
                 {
                     _status = ComponentStatus.Opening;
                 }
-                this._isOpen = value;
+                _isOpen = value;
             }
         }
 
@@ -295,10 +300,10 @@ namespace AntDesign
 
                 return Placement switch
                 {
-                    "left" => $"translateX({this.OffsetX}px);",
-                    "right" => $"translateX(-{this.OffsetX}px);",
-                    "top" => $"translateY({this.OffsetY}px);",
-                    "bottom" => $"translateY(-{this.OffsetY}px);",
+                    "left" => $"translateX({OffsetX}px);",
+                    "right" => $"translateX(-{OffsetX}px);",
+                    "top" => $"translateY({OffsetY}px);",
+                    "bottom" => $"translateY(-{OffsetY}px);",
                     _ => null
                 };
             }
@@ -306,9 +311,7 @@ namespace AntDesign
 
         private const string Duration = "0.3s";
         private const string Ease = "cubic-bezier(0.78, 0.14, 0.15, 0.86)";
-        private string _widthTransition = "";
         private readonly string _transformTransition = $"transform {Duration} {Ease} 0s";
-        private string _heightTransition = "";
 
         /// <summary>
         /// 设置 Drawer 是否隐藏，以及隐藏时候的位置 Offset
@@ -322,7 +325,7 @@ namespace AntDesign
                     return null;
                 }
 
-                return this.Placement switch
+                return Placement switch
                 {
                     "left" => "translateX(-100%)",
                     "right" => "translateX(100%)",
@@ -333,11 +336,11 @@ namespace AntDesign
             }
         }
 
-        private bool IsLeftOrRight => Placement == "left" || this.Placement == "right";
+        private bool IsLeftOrRight => Placement == "left" || Placement == "right";
 
-        private string WidthPx => this.IsLeftOrRight ? StyleHelper.ToCssPixel(this.Width) : null;
+        private string WidthPx => IsLeftOrRight ? StyleHelper.ToCssPixel(Width) : null;
 
-        private string HeightPx => !this.IsLeftOrRight ? StyleHelper.ToCssPixel(this.Height) : null;
+        private string HeightPx => !IsLeftOrRight ? StyleHelper.ToCssPixel(Height) : null;
 
         private ClassMapper TitleClassMapper { get; set; } = new ClassMapper();
 
@@ -356,14 +359,14 @@ namespace AntDesign
         private void SetClass()
         {
             var prefixCls = "ant-drawer";
-            this.ClassMapper.Clear()
+            ClassMapper.Clear()
                 .Add(prefixCls)
                 .If($"{prefixCls}-open", () => _isOpen)
                 .If($"{prefixCls}-{Placement}", () => Placement.IsIn("top", "bottom", "right", "left"))
                 .If($"{prefixCls}-rtl", () => RTL)
                 ;
 
-            this.TitleClassMapper.Clear()
+            TitleClassMapper.Clear()
                 .If("ant-drawer-header", () => _title.Value != null)
                 .If("ant-drawer-header-no-title", () => _title.Value == null)
                 ;
@@ -371,24 +374,24 @@ namespace AntDesign
 
         protected override void OnInitialized()
         {
-            this._originalPlacement = Placement;
+            _originalPlacement = Placement;
 
             // TODO: remove
-            this.SetClass();
+            SetClass();
 
             base.OnInitialized();
         }
 
         protected override void OnParametersSet()
         {
-            this.SetClass();
+            SetClass();
             if (string.IsNullOrEmpty(Placement) && Placement != _originalPlacement)
             {
-                this._originalPlacement = Placement;
+                _originalPlacement = Placement;
                 _isPlacementFirstChange = false;
                 if (!_isPlacementFirstChange)
                 {
-                    this.TriggerPlacementChangeCycleOnce();
+                    TriggerPlacementChangeCycleOnce();
                 }
             }
 
@@ -413,7 +416,7 @@ namespace AntDesign
                         _hasInvokeClosed = false;
                         if (string.IsNullOrWhiteSpace(Style))
                         {
-                            _ = JsInvokeAsync(JSInteropConstants.DisableBodyScroll);
+                            await JsInvokeAsync(JSInteropConstants.DisableBodyScroll);
                         }
                         else if (!_renderInCurrentContainerRegex.IsMatch(Style))
                         {
@@ -423,7 +426,9 @@ namespace AntDesign
                         CalcDrawerStyle();
                         StateHasChanged();
                         await Task.Delay(3000);
-                        _drawerStyle = !string.IsNullOrWhiteSpace(OffsetTransform) ? $"transform: {OffsetTransform};" : "";
+                        _drawerStyle = !string.IsNullOrWhiteSpace(OffsetTransform) 
+                            ? $"transform: {OffsetTransform};" 
+                            : string.Empty;
                         StateHasChanged();
                         break;
                     }
@@ -447,7 +452,7 @@ namespace AntDesign
 
         private void TriggerPlacementChangeCycleOnce()
         {
-            this.PlacementChanging = true;
+            PlacementChanging = true;
             InvokeStateHasChanged();
             _timer = new Timer()
             {
@@ -456,7 +461,7 @@ namespace AntDesign
             };
             _timer.Elapsed += (_, args) =>
             {
-                this.PlacementChanging = false;
+                PlacementChanging = false;
                 InvokeStateHasChanged();
             };
             _timer.Start();
@@ -466,9 +471,9 @@ namespace AntDesign
         /// trigger when mask is clicked
         /// </summary>
         /// <returns></returns>
-        private async Task MaskClick()
+        private async Task MaskClick(MouseEventArgs _)
         {
-            if (this.MaskClosable && this.Mask && this.OnClose.HasDelegate)
+            if (MaskClosable && Mask && OnClose.HasDelegate)
             {
                 await HandleClose();
             }
@@ -502,37 +507,16 @@ namespace AntDesign
             }
         }
 
-        private void CalcAnimation()
-        {
-            switch (this.Placement)
-            {
-                case "left":
-                case "right":
-                    _widthTransition = $"width 0s {Ease} {Duration}";
-                    break;
-
-                case "top":
-                case "bottom":
-                    _heightTransition = $"height 0s {Ease} {Duration}";
-                    break;
-
-                default:
-                    break;
-            }
-        }
-
         private void CalcDrawerStyle()
         {
             string style = null;
             if (_status == ComponentStatus.Opened)
             {
-                CalcAnimation();
-                if (string.IsNullOrWhiteSpace(_heightTransition))
-                {
-                    _heightTransition += ",";
-                }
+                var widthHeightTransition = Placement is "left" or "right"
+                    ? $"width 0s {Ease} {Duration}"
+                    : $"height 0s {Ease} {Duration}";
 
-                style = $"transition:{_transformTransition} {_heightTransition} {_widthTransition};";
+                style = $"transition:{_transformTransition} {widthHeightTransition};";
             }
 
             if (!string.IsNullOrWhiteSpace(OffsetTransform))

--- a/components/drawer/Drawer.razor.cs
+++ b/components/drawer/Drawer.razor.cs
@@ -188,7 +188,7 @@ namespace AntDesign
             set
             {
                 _zIndex = value;
-                if (_zIndex == 1000)
+                if (_zIndex == DefaultZIndez)
                     _zIndexStyle = "";
                 else
                     _zIndexStyle = $"z-index: {_zIndex};";
@@ -312,6 +312,7 @@ namespace AntDesign
         private const string Duration = "0.3s";
         private const string Ease = "cubic-bezier(0.78, 0.14, 0.15, 0.86)";
         private readonly string _transformTransition = $"transform {Duration} {Ease} 0s";
+        private const int DefaultZIndez = 1000;
 
         /// <summary>
         /// 设置 Drawer 是否隐藏，以及隐藏时候的位置 Offset
@@ -438,7 +439,7 @@ namespace AntDesign
         }
 
         private Timer _timer;
-        private int _zIndex = 1000;
+        private int _zIndex = DefaultZIndez;
         private string _zIndexStyle = "";
 
         /// <summary>

--- a/site/AntDesign.Docs/Demos/Components/Drawer/demo/formindrawer.md
+++ b/site/AntDesign.Docs/Demos/Components/Drawer/demo/formindrawer.md
@@ -2,7 +2,7 @@
 order: 2
 title:
   zh-CN: 抽屉表单
-  en-US: Submit form in drawe
+  en-US: Submit Form in Drawer
 ---
 
 ## zh-CN

--- a/site/AntDesign.Docs/Demos/Components/Drawer/doc/index.en-US.md
+++ b/site/AntDesign.Docs/Demos/Components/Drawer/doc/index.en-US.md
@@ -25,24 +25,26 @@ tasks can be achieved more efficiently within thesame context.
 
 | Property      | Description                                                                                    | Type           | Default Value |
 | ------------- | ---------------------------------------------------------------------------------------------- | -------------- | ------------- |
-| Title         | the title for drawer                                                                           | string or slot | -             |
-| BodyStyle     | Style of the drawer content part                                                               | object         | -             |
+| Title         | The title for drawer                                                                           | OneOf<RenderFragment, string> | -             |
 | Closable      | Whether a close (x) button is visible on top right of the Drawer dialog or not.                | boolean        | true          |
-| ChildContent  | Subcomponent                                                                                   | object         | -             |
-| MaskClosable  | Clicking on the mask (area outside the Drawer) to close the Drawer or not.                     | boolean        | true          |
-| MaskStyle     | Style for Drawer's mask element.                                                               | object         | -             |
-| Mask          | Whether to show mask or not.                                                                   | boolean        | true          |
+| ChildContent  | Subcomponent                                                                                   | RenderFragment | -             |
+| Content       | Content for Drawer. When given with ChildContent this is shown above ChildContent.             | OneOf<RenderFragment, string> | -             |
+| MaskClosable  | Clicking on the mask (area outside the Drawer) will close the Drawer or not.                   | boolean        | true          |
+| Mask          | Whether to show mask or not. When true the area around the Drawer will darken when Visible.    | boolean        | true          |
 | Placement     | The placement of the Drawer, option could be `left` , `top`,`right`,`bottom`                   | string         | `right`       |
-| WrapClassName | The class name of the container of the Drawer dialog.                                          | string         | -             |
-| Width         | Width of the Drawer dialog, only when placement is 'left' or 'right'.                          |                | int           |
-| Height        | placement is top or bottom, height of the Drawer dialog.                                       | int            | 256           |
-| ZIndex        | The z-index of the Drawer.                                                                     | int            | -             |
-| OffsetX       | The the X coordinate offset(px), only when placement is `'left'` or `'right'`.                 | int            | 0             |
-| OffsetY       | The the Y coordinate offset(px), only when placement is `'top'` or `'bottom'`.                 | int            | 0             |
+| Width         | Width of the Drawer. Only used when placement is 'left' or 'right'.                            | int            | 256           |
+| Height        | Height of the Drawer. Only used when Placement is 'top' or 'bottom'                            | int            | 256           |
+| ZIndex        | The z-index of the Drawer.                                                                     | int            | 1000          |
+| OffsetX       | The the X coordinate offset(px). Only used when placement is `'left'` or `'right'`.            | int            | 0             |
+| OffsetY       | The the Y coordinate offset(px). Only used when placement is `'top'` or `'bottom'`.            | int            | 0             |
 | Visible       | Whether the Drawer dialog is visible or not.                                                   | boolean        | -             |
-| Keyboard      | Whether support press esc to close                                                             | boolean        | true          |
-| OnClose       | Specify a callback that will be called when a user clicks mask, close button or Cancel button. | EventCallback    | -             |
-| OnOpen        | Specify a callback that will be called after drawer rendered                                   | Func<Task>    | -             |
+| Keyboard      | Whether support press esc to close. **Not currently implemented**                              | boolean        | true          |
+| Handler       | Content that renders as a sibling to the content of the Drawer                                 | RenderFragment | -             |
+| OnClose       | Specify a callback that will be called when a user clicks mask, close button or Cancel button. | EventCallback  | -             |
+| OnOpen        | Specify a callback that will be called after drawer rendered                                   | Func<Task>     | -             |
+| MaskStyle     | Style for Drawer's mask element.                                                               | object         | -             |
+| BodyStyle     | Style of the drawer content part                                                               | object         | -             |
+| WrapClassName | The class name of the container of the Drawer dialog.                                          | string         | -             |
 
 ### DrawerService
 

--- a/site/AntDesign.Docs/Demos/Components/Drawer/doc/index.en-US.md
+++ b/site/AntDesign.Docs/Demos/Components/Drawer/doc/index.en-US.md
@@ -42,8 +42,8 @@ tasks can be achieved more efficiently within thesame context.
 | Handler       | Content that renders as a sibling to the content of the Drawer                                 | RenderFragment | -             |
 | OnClose       | Specify a callback that will be called when a user clicks mask, close button or Cancel button. | EventCallback  | -             |
 | OnOpen        | Specify a callback that will be called after drawer rendered                                   | Func<Task>     | -             |
-| MaskStyle     | Style for Drawer's mask element.                                                               | object         | -             |
-| BodyStyle     | Style of the drawer content part                                                               | object         | -             |
+| MaskStyle     | Style for Drawer's mask element.                                                               | string         | -             |
+| BodyStyle     | Style of the drawer content part                                                               | string         | -             |
 | WrapClassName | The class name of the container of the Drawer dialog.                                          | string         | -             |
 
 ### DrawerService

--- a/site/AntDesign.Docs/Demos/Components/Drawer/doc/index.zh-CN.md
+++ b/site/AntDesign.Docs/Demos/Components/Drawer/doc/index.zh-CN.md
@@ -21,24 +21,26 @@ cover: https://gw.alipayobjects.com/zos/alicdn/7z8NJQhFb/Drawer.svg
 
 | 参数          | 说明                                                    | 类型           | 默认值  |
 | ------------- | ------------------------------------------------------- | -------------- | ------- |
-| Title         | 标题                                                    | string or slot | -       |
-| BodyStyle     | 可用于设置 Drawer 内容部分的样式                          | object         | -       |
-| Closable      | 是否显示右上角的关闭按钮                                | boolean        | true    |
-| ChildContent  | 抽屉元素之间的子组件                                    | object         | -       |
-| MaskClosable  | 点击蒙层是否允许关闭                                    | boolean        | true    |
-| MaskStyle     | 遮罩样式                                                | object         | -       |
-| Mask          | 是否展示遮罩                                            | boolean       | true    |
-| Placement     | 抽屉的方向,可选值为 `left` , `top`,`right`,`bottom`     | string         | right |
-| WrapClassName | 对话框外层容器的类名                                    | string         | -       |
-| Width         | 宽度                                                  | string\|int    | 256     |
-| Height        | 高度, 在 placement 为 top 或 bottom 时使用              |                | int     |
-| ZIndex        | 设置 Drawer 的 z-index                                 | int            | -       |
-| OffsetX       | X 轴方向的偏移量，只在方向为 `'left'`或`'right'` 时生效 | int            | 0       |
-| OffsetY       | Y 轴方向的偏移量，只在方向为 `'top'`或`'bottom'` 时生效 | int            | 0       |
-| Visible       | Drawer 是否可见                                         | boolean        | -       |
-| Keyboard      | 是否支持键盘 esc 关闭                                   | boolean        | true    |
-| OnClose       | 点击遮罩层或右上角叉或取消按钮的回调                    | EventCallback  | -       |
-| OnOpen        | 抽屉渲染之后回调事件                                    | Func<Task>   | -       |
+| Title | 抽屉的标题 | OneOf<RenderFragment, 字符串> | - |
+| Closable | 在抽屉对话框的右上角是否可见关闭 (x) 按钮。| 布尔值 | 真实 |
+| ChildContent | 子组件 | 渲染片段 | - |
+| Content | 抽屉的内容。当与 ChildContent 一起给出时，这显示在 ChildContent 上方。| OneOf<RenderFragment, 字符串> | - |
+| MaskClosable | 单击遮罩（抽屉外区域）将关闭或关闭抽屉。| 布尔值 | 真实 |
+| Mask | 是否显示面具。当为真时，抽屉周围的区域在可见时会变暗。| 布尔值 | 真实 |
+| Placement | 抽屉的位置，选项可以是`left`，`top`，`right`，`bottom` | 字符串 | `正确` |
+| Width | 抽屉的宽度。仅在放置为“左”或“右”时使用。| 整数 | 256 |
+| Height | 抽屉高度。仅在 Placement 为“top”或“bottom”时使用 | 整数 | 256 |
+| ZIndex | 抽屉的 z-index。| 整数 | 1000 |
+| OffsetX | X 坐标偏移量(px)。仅在放置为“左”或“右”时使用。| 整数 | 0 |
+| OffsetY | Y 坐标偏移量(px)。仅在放置为“顶部”或“底部”时使用。| 整数 | 0 |
+| Visible | 抽屉对话框是否可见。| 布尔值 | - |
+| Keyboard | 是否支持按esc关闭。**目前未实施** | 布尔值 | 真实 |
+| Handler | 呈现为抽屉内容的兄弟的内容 | 渲染片段 | - |
+| OnClose | 指定当用户单击掩码、关闭按钮或取消按钮时将调用的回调。| 事件回调 | - |
+| OnOpen | 指定将在抽屉呈现后调用的回调 | 函数<任务> | - |
+| MaskStyle | 抽屉遮罩元素的样式。| 字符串 | - |
+| BodyStyle | 抽屉内容部分的样式| 字符串 | - |
+| WrapClassName | Drawer 对话框的容器的类名。| 字符串 | - |
 
 ### DrawerService
 

--- a/tests/AntDesign.TestKit/AntDesignTestBase.cs
+++ b/tests/AntDesign.TestKit/AntDesignTestBase.cs
@@ -22,6 +22,7 @@ namespace AntDesign.Tests
             //Needed for Tests using Overlay
             Services.AddScoped<AntDesign.JsInterop.DomEventService>(sp => new TestDomEventService(Context.JSInterop.JSRuntime, MockedDomEventListener));
             JSInterop.SetupVoid(JSInteropConstants.OverlayComponentHelper.DeleteOverlayFromContainer, _ => true);
+            JSInterop.Mode = JSRuntimeMode.Strict;
 
             CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.GetCultureInfo("en-US");
         }

--- a/tests/AntDesign.Tests/Drawer/DrawerTests.cs
+++ b/tests/AntDesign.Tests/Drawer/DrawerTests.cs
@@ -1,0 +1,405 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using System.Threading.Tasks;
+using Bunit;
+using FluentAssertions;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using Xunit;
+
+namespace AntDesign.Tests.Drawer
+{
+    public class DrawerTests : AntDesignTestBase
+    {
+        public DrawerTests() : base()
+        {
+            JSInterop.Mode = JSRuntimeMode.Loose;
+        }
+
+        [Theory]
+        [InlineData("left", "width:256px;transform:translateX(-100%);", "height:100%")]
+        [InlineData("right", "width:256px;transform:translateX(100%);", "height:100%")]
+        [InlineData("top", "height:256px;transform:translateY(-100%);", "")]
+        [InlineData("bottom", "height:256px;transform:translateY(100%);", "")]
+        public void ItShouldRenderWrapperProperly(string placement, string contentWrapperStyle, string bodyWrapperStyle)
+        {
+            var systemUnderTest = RenderComponent<AntDesign.Drawer>(parameters => parameters.Add(x => x.Placement, placement));
+
+            systemUnderTest.MarkupMatches($@"<div class=""ant-drawer ant-drawer-{placement}"" style=""z-index:-9999;"" id:ignore>
+                <div class=""ant-drawer-mask""></div>
+                <div class=""ant-drawer-content-wrapper"" style=""{contentWrapperStyle}"" id:ignore>
+                    <div class=""ant-drawer-content"">
+                        <div class=""ant-drawer-wrapper-body"" style=""{bodyWrapperStyle}"">
+                            <div class=""ant-drawer-header-no-title"">
+                                <button aria-label=""Close"" class=""ant-drawer-close"">
+                                    <span role=""img"" class=""anticon anticon-close"" id:ignore>
+                                        <svg focusable=""false"" width=""1em"" height=""1em"" fill=""currentColor""
+                                            style=""pointer-events: none;"" xmlns=""http://www.w3.org/2000/svg"" class=""icon""
+                                            viewBox=""0 0 1024 1024"">
+                                            <path
+                                                d=""M563.8 512l262.5-312.9c4.4-5.2.7-13.1-6.1-13.1h-79.8c-4.7 0-9.2 2.1-12.3 5.7L511.6 449.8 295.1 191.7c-3-3.6-7.5-5.7-12.3-5.7H203c-6.8 0-10.5 7.9-6.1 13.1L459.4 512 196.9 824.9A7.95 7.95 0 0 0 203 838h79.8c4.7 0 9.2-2.1 12.3-5.7l216.5-258.1 216.5 258.1c3 3.6 7.5 5.7 12.3 5.7h79.8c6.8 0 10.5-7.9 6.1-13.1L563.8 512z"">
+                                            </path>
+                                        </svg>
+                                    </span>
+                                </button>
+                            </div>
+                            <div class=""ant-drawer-body"">
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>");
+        }
+
+        [Theory]
+        [InlineData("top", "left", "width:256px;transform:translateX(-100%);", "height:100%")]
+        [InlineData("top", "right", "width:256px;transform:translateX(100%);", "height:100%")]
+        [InlineData("left", "top", "height:256px;transform:translateY(-100%);", "")]
+        [InlineData("left", "bottom", "height:256px;transform:translateY(100%);", "")]
+        public void ItShouldChangePlacementAfterRender(string initialPlacement, string placement, string contentWrapperStyle, string bodyWrapperStyle)
+        {
+            var systemUnderTest = RenderComponent<AntDesign.Drawer>(parameters => parameters.Add(x => x.Placement, initialPlacement));
+
+            systemUnderTest.SetParametersAndRender(parameters => parameters.Add(x => x.Placement, placement));
+
+            systemUnderTest.MarkupMatches($@"<div class=""ant-drawer ant-drawer-{placement}"" style=""z-index:-9999;"" id:ignore>
+                <div class=""ant-drawer-mask""></div>
+                <div class=""ant-drawer-content-wrapper"" style=""{contentWrapperStyle}"" id:ignore>
+                    <div class=""ant-drawer-content"">
+                        <div class=""ant-drawer-wrapper-body"" style=""{bodyWrapperStyle}"">
+                            <div class=""ant-drawer-header-no-title"">
+                                <button aria-label=""Close"" class=""ant-drawer-close"">
+                                    <span role=""img"" class=""anticon anticon-close"" id:ignore>
+                                        <svg focusable=""false"" width=""1em"" height=""1em"" fill=""currentColor""
+                                            style=""pointer-events: none;"" xmlns=""http://www.w3.org/2000/svg"" class=""icon""
+                                            viewBox=""0 0 1024 1024"">
+                                            <path
+                                                d=""M563.8 512l262.5-312.9c4.4-5.2.7-13.1-6.1-13.1h-79.8c-4.7 0-9.2 2.1-12.3 5.7L511.6 449.8 295.1 191.7c-3-3.6-7.5-5.7-12.3-5.7H203c-6.8 0-10.5 7.9-6.1 13.1L459.4 512 196.9 824.9A7.95 7.95 0 0 0 203 838h79.8c4.7 0 9.2-2.1 12.3-5.7l216.5-258.1 216.5 258.1c3 3.6 7.5 5.7 12.3 5.7h79.8c6.8 0 10.5-7.9 6.1-13.1L563.8 512z"">
+                                            </path>
+                                        </svg>
+                                    </span>
+                                </button>
+                            </div>
+                            <div class=""ant-drawer-body"">
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>");
+        }
+
+        [Fact]
+        public void ItShouldRenderTitle()
+        {
+            var systemUnderTest = RenderComponent<AntDesign.Drawer>(parameters => parameters.Add(x => x.Title, "Test Title"));
+
+            systemUnderTest.Find(".ant-drawer-title").MarkupMatches(@"<div class=""ant-drawer-title"">Test Title</div>");
+        }
+
+        [Fact]
+        public void ItShouldRenderTitleRenderFragment()
+        {
+            RenderFragment fragment = builder =>
+            {
+                builder.OpenElement(0, "span");
+                builder.AddContent(1, "Testing");
+                builder.CloseElement();
+            };
+
+            var systemUnderTest = RenderComponent<AntDesign.Drawer>(parameters => parameters.Add(x => x.Title, fragment));
+
+            systemUnderTest.Find(".ant-drawer-title").MarkupMatches(@"<div class=""ant-drawer-title""><span>Testing</span></div>");
+        }
+
+        [Fact]
+        public void ItShouldNotRenderMaskWhenTurnedOff()
+        {
+            var systemUnderTest = RenderComponent<AntDesign.Drawer>(parameters => parameters.Add(x => x.Mask, false));
+
+            systemUnderTest.FindAll(".ant-drawer-mask").Should().BeEmpty();
+        }
+
+        [Fact]
+        public void ItShouldNotRenderCloseButtonWhenTurnedOff()
+        {
+            var systemUnderTest = RenderComponent<AntDesign.Drawer>(parameters => parameters.Add(x => x.Closable, false));
+
+            systemUnderTest.FindAll(".ant-drawer-close").Should().BeEmpty();
+        }
+
+        [Fact]
+        public void ItShouldRenderContentString()
+        {
+            var systemUnderTest = RenderComponent<AntDesign.Drawer>(parameters => parameters.Add(x => x.Content, "Test Llama"));
+
+            systemUnderTest.Find(".ant-drawer-body").MarkupMatches(@"<div class=""ant-drawer-body"">Test Llama</div>");
+        }
+
+        [Fact]
+        public void ItShouldRenderContentRenderFragment()
+        {
+            RenderFragment fragment = builder =>
+            {
+                builder.OpenElement(0, "span");
+                builder.AddContent(1, "Testing");
+                builder.CloseElement();
+            };
+
+            var systemUnderTest = RenderComponent<AntDesign.Drawer>(parameters => parameters.Add(x => x.Content, fragment));
+
+            systemUnderTest.Find(".ant-drawer-body").MarkupMatches(@"<div class=""ant-drawer-body"">
+                <span>Testing</span>
+            </div>");
+        }
+
+        [Fact]
+        public void ItShouldRenderChildContent()
+        {
+            RenderFragment fragment = builder =>
+            {
+                builder.OpenElement(0, "span");
+                builder.AddContent(1, "Testing");
+                builder.CloseElement();
+            };
+
+            var systemUnderTest = RenderComponent<AntDesign.Drawer>(parameters => parameters.Add(x => x.ChildContent, fragment));
+
+            systemUnderTest.Find(".ant-drawer-body").MarkupMatches(@"<div class=""ant-drawer-body"">
+                <span>Testing</span>
+            </div>");
+        }
+
+        [Fact]
+        public void ItShouldRenderChildContentAndContentParameterString()
+        {
+            RenderFragment fragment = builder =>
+            {
+                builder.OpenElement(0, "span");
+                builder.AddContent(1, "Testing");
+                builder.CloseElement();
+            };
+
+            var systemUnderTest = RenderComponent<AntDesign.Drawer>(parameters => parameters
+                .Add(x => x.ChildContent, fragment)
+                .Add(x => x.Content, "First Content"));
+
+            systemUnderTest.Find(".ant-drawer-body").MarkupMatches(@"<div class=""ant-drawer-body"">
+                First Content
+                <span>Testing</span>
+            </div>");
+        }
+
+        [Fact]
+        public void ItShouldRenderChildContentAndContentParameterRenderFragment()
+        {
+            RenderFragment childContent = builder =>
+            {
+                builder.OpenElement(0, "span");
+                builder.AddContent(1, "Testing");
+                builder.CloseElement();
+            };
+
+            RenderFragment fragment = builder =>
+            {
+                builder.OpenElement(0, "span");
+                builder.AddContent(1, "First Content Woo!");
+                builder.CloseElement();
+            };
+
+            var systemUnderTest = RenderComponent<AntDesign.Drawer>(parameters => parameters
+                .Add(x => x.ChildContent, childContent)
+                .Add(x => x.Content, fragment));
+
+            systemUnderTest.Find(".ant-drawer-body").MarkupMatches(@"<div class=""ant-drawer-body"">
+                <span>First Content Woo!</span>
+                <span>Testing</span>
+            </div>");
+        }
+
+        [Fact]
+        public void ItShouldRenderGivenZIndexWhenVisible()
+        {
+            var systemUnderTest = RenderComponent<AntDesign.Drawer>(parameters => parameters
+                .Add(x => x.ZIndex, 4000)
+                .Add(x => x.Visible, true));
+
+            systemUnderTest.Find(".ant-drawer").Attributes.Single(x => x.Name == "style").Value.Trim().Should().Contain("z-index: 4000;");
+        }
+
+        [Fact]
+        public void ItShouldRenderZIndexBelowEverythingWhenNotVisible()
+        {
+            var systemUnderTest = RenderComponent<AntDesign.Drawer>(parameters => parameters
+                .Add(x => x.ZIndex, 4000)
+                .Add(x => x.Visible, false));
+
+            systemUnderTest.MarkupMatches(@"
+                <div class=""ant-drawer ant-drawer-right"" style=""z-index:-9999;"" id:ignore diff:ignoreChildren></div>");
+        }
+
+        [Theory]
+        [InlineData("right", "transition:transform 0.3s cubic-bezier(0.78, 0.14, 0.15, 0.86) 0s width 0s cubic-bezier(0.78, 0.14, 0.15, 0.86) 0.3s;")]
+        [InlineData("left", "transition:transform 0.3s cubic-bezier(0.78, 0.14, 0.15, 0.86) 0s width 0s cubic-bezier(0.78, 0.14, 0.15, 0.86) 0.3s;")]
+        [InlineData("top", "transition:transform 0.3s cubic-bezier(0.78, 0.14, 0.15, 0.86) 0s height 0s cubic-bezier(0.78, 0.14, 0.15, 0.86) 0.3s;")]
+        [InlineData("bottom", "transition:transform 0.3s cubic-bezier(0.78, 0.14, 0.15, 0.86) 0s height 0s cubic-bezier(0.78, 0.14, 0.15, 0.86) 0.3s;")]
+        public void ItShouldRenderProperAnimationStyleWhenVisible(string placement, string expectedStyle)
+        {
+            var systemUnderTest = RenderComponent<AntDesign.Drawer>(parameters => parameters
+                .Add(x => x.Placement, placement)
+                .Add(x => x.Visible, true));
+
+            var resultingStyle = systemUnderTest.Find(".ant-drawer").Attributes.Single(x => x.Name == "style").Value.Trim();
+            resultingStyle.Should().Contain(expectedStyle);
+        }
+
+        [Theory]
+        [InlineData("right", 20, "transform: translateX(-20px)")]
+        [InlineData("left", 25, "transform: translateX(25px)")]
+        public void ItShouldRenderProperOffsetXStyleWhenVisible(string placement, int offset, string expectedStyle)
+        {
+            var systemUnderTest = RenderComponent<AntDesign.Drawer>(parameters => parameters
+                .Add(x => x.Placement, placement)
+                .Add(x => x.Visible, true)
+                .Add(x => x.OffsetX, offset));
+
+            var resultingStyle = systemUnderTest.Find(".ant-drawer").Attributes.Single(x => x.Name == "style").Value.Trim();
+            resultingStyle.Should().Contain(expectedStyle);
+        }
+
+        [Theory]
+        [InlineData("top", 20, "transform: translateY(20px)")]
+        [InlineData("bottom", 25, "transform: translateY(-25px)")]
+        public void ItShouldRenderProperOffsetYStyleWhenVisible(string placement, int offset, string expectedStyle)
+        {
+            var systemUnderTest = RenderComponent<AntDesign.Drawer>(parameters => parameters
+                .Add(x => x.Placement, placement)
+                .Add(x => x.Visible, true)
+                .Add(x => x.OffsetY, offset));
+
+            var resultingStyle = systemUnderTest.Find(".ant-drawer").Attributes.Single(x => x.Name == "style").Value.Trim();
+            resultingStyle.Should().Contain(expectedStyle);
+        }
+
+        [Fact]
+        public void ItShouldCallCloseWhenClickingMaskByDefault()
+        {
+            var closed = false;
+            var onClose = () =>
+            {
+                closed = true;
+            };
+            var systemUnderTest = RenderComponent<AntDesign.Drawer>(parameters => parameters
+                .Add(x => x.OnClose, onClose)
+                .Add(x => x.MaskClosable, true));
+
+            systemUnderTest.InvokeAsync(() => systemUnderTest.Find(".ant-drawer-mask").TriggerEvent("onclick", new MouseEventArgs()));
+
+            systemUnderTest.WaitForAssertion(() => closed.Should().BeTrue());
+        }
+
+        [Fact]
+        public void ItShouldNotCallCloseWhenClickingMaskWhenCloseableDisabled()
+        {
+            var closed = false;
+            var onClose = () =>
+            {
+                closed = true;
+            };
+            var systemUnderTest = RenderComponent<AntDesign.Drawer>(parameters => parameters
+                .Add(x => x.OnClose, onClose)
+                .Add(x => x.MaskClosable, false));
+
+            systemUnderTest.InvokeAsync(() => systemUnderTest.Find(".ant-drawer-mask").TriggerEvent("onclick", new MouseEventArgs()));
+
+            systemUnderTest.WaitForAssertion(() => closed.Should().BeFalse());
+        }
+
+        [Fact]
+        public void ItShouldNotCallCloseWhenClickingCloseButtonByDefault()
+        {
+            var closed = false;
+            var onClose = () =>
+            {
+                closed = true;
+            };
+            var systemUnderTest = RenderComponent<AntDesign.Drawer>(parameters => parameters
+                .Add(x => x.OnClose, onClose));
+
+            systemUnderTest.InvokeAsync(() => systemUnderTest.Find(".ant-drawer-close").TriggerEvent("onclick", new MouseEventArgs()));
+
+            systemUnderTest.WaitForAssertion(() => closed.Should().BeTrue());
+        }
+
+        [Fact]
+        public void ItShouldNotCallOnCloseWhenVisibleChangedToFalseAfterRender()
+        {
+            var closed = false;
+            var onClose = () =>
+            {
+                closed = true;
+            };
+            var systemUnderTest = RenderComponent<AntDesign.Drawer>(parameters => parameters
+                .Add(x => x.Placement, "right")
+                .Add(x => x.Visible, true));
+
+            systemUnderTest.SetParametersAndRender(parameters => parameters.Add(x => x.Visible, false));
+
+            closed.Should().BeFalse();
+        }
+
+        [Fact]
+        public void ItShouldCallOnOpenWhenVisibleChangedToTrueAfterRender()
+        {
+            var opened = false;
+            var onOpen = () =>
+            {
+                opened = true;
+
+                return Task.CompletedTask;
+            };
+
+            var systemUnderTest = RenderComponent<AntDesign.Drawer>(parameters => parameters
+                .Add(x => x.Placement, "right")
+                .Add(x => x.Visible, false)
+                .Add(x => x.OnOpen, onOpen));
+
+            systemUnderTest.SetParametersAndRender(parameters => parameters.Add(x => x.Visible, true));
+
+            opened.Should().BeTrue();
+        }
+
+        [Fact]
+        public void ItShouldCloseWhenVisibleChangedToFalseAfterRender()
+        {
+            var systemUnderTest = RenderComponent<AntDesign.Drawer>(parameters => parameters
+                .Add(x => x.Placement, "right")
+                .Add(x => x.Visible, true));
+
+            systemUnderTest.SetParametersAndRender(parameters => parameters.Add(x => x.Visible, false));
+        }
+
+        [Fact]
+        public void ItShouldRenderHandlerNextToContentWhenProvided()
+        {
+            RenderFragment fragment = builder =>
+            {
+                builder.OpenElement(0, "span");
+                builder.AddContent(1, "Handler Stuff");
+                builder.CloseElement();
+            };
+
+            var systemUnderTest = RenderComponent<AntDesign.Drawer>(parameters => parameters.Add(x => x.Handler, fragment));
+
+            systemUnderTest.MarkupMatches(@"<div diff:ignoreAttributes>
+                <div class=""ant-drawer-mask""></div>
+                <div class=""ant-drawer-content-wrapper"" diff:ignoreAttributes>
+                    <div class=""ant-drawer-content"" diff:ignoreChildren></div>
+                    <span>Handler Stuff</span>
+                </div>
+            </div>");
+        }
+    }
+}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->
Bug fix:
- Content string would never render (wrong condition checked)

Refactors:
- Remove `this.`
- Remove code that didn't do anything helpful from my testing - will comment on inline
- Moved code to make it more obvious only one condition can exist at a time - will comment on inline

Documentation site update to match available parameters

### 🤔 This is a ...

- [ ] New feature
- [X] Bug fix
- [X] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [X] Refactoring
- [ ] Code style optimization
- [X] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
#2644 
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix bug where Content wouldn't render in Drawer if it was a string and not RenderFragment       |
| 🇨🇳 Chinese |  修复如果内容是字符串而不是 RenderFragment，则内容不会在 Drawer 中呈现的错误         |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
