### PR TITLE
fix:(module: locale): wrong day order

### DIFF
--- a/components/locales/ru-RU.json
+++ b/components/locales/ru-RU.json
@@ -64,7 +64,7 @@
       "quarterSelect": "Выберите четверть",
       "week": "Неделя",
       "monthFormat": "MMM",
-      "shortWeekDays": [ "Пн", "Вт", "Ср", "Чт", "Пт", "Сб", "Вс" ]
+      "shortWeekDays": [ "Вс", "Пн", "Вт", "Ср", "Чт", "Пт", "Сб" ]
     },
     "timePickerLocale": {
       "placeholder": "Выберите время",


### PR DESCRIPTION

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [x] Localization

### 🔗 Related issue link


### 💡 Background and solution

incorrect day order displayed on calendars and datepickers for russian locale, relates to changes made in commit: 894439adec248573a9e19a20453a730307824e5c

### 📝 Changelog


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  fix day order in calendar header for russian locale        |
| 🇨🇳 Chinese |           |

