### PR TITLE
fix:(module: datepicker): tab key does not confirm the value

### DIFF
--- a/components/date-picker/DatePicker.Razor.cs
+++ b/components/date-picker/DatePicker.Razor.cs
@@ -80,8 +80,6 @@ namespace AntDesign
             }
         }
 
-        private DateTime? _cacheDuringInput;
-
         protected void OnInput(ChangeEventArgs args, int index = 0)
         {
             if (index != 0)
@@ -95,7 +93,6 @@ namespace AntDesign
             if (!_duringManualInput)
             {
                 _duringManualInput = true;
-                _cacheDuringInput = GetIndexValue(0);
             }
 
             if (FormatAnalyzer.TryPickerStringConvert(args.Value.ToString(), out TValue changeValue, IsNullable))
@@ -112,18 +109,9 @@ namespace AntDesign
         {
             if (_openingOverlay)
                 return;
-
-            if (_duringManualInput)
-            {
-                if (Value is null && _pickerStatus[0].SelectedValue is not null ||
-                    !Convert.ToDateTime(Value, CultureInfo).Equals(_pickerStatus[0].SelectedValue))
-                {
-                    _pickerStatus[0].SelectedValue = null;
-                    ChangePickerValue(_cacheDuringInput ?? _pickerValuesAfterInit);
-                }
-                _duringManualInput = false;
-            }
             AutoFocus = false;
+            if (!_dropDown.IsOverlayShow())
+                _pickerStatus[0].SelectedValue = null;
             await Task.Yield();
         }
 

--- a/components/date-picker/DatePicker.Razor.cs
+++ b/components/date-picker/DatePicker.Razor.cs
@@ -136,23 +136,23 @@ namespace AntDesign
             if (e == null) throw new ArgumentNullException(nameof(e));
             var key = e.Key.ToUpperInvariant();
 
-            if (key == "ENTER" || key == "TAB" || key == "ESCAPE")
+            var isEnter = key == "ENTER";
+            var isTab = key == "TAB";
+            var isEscape = key == "ESCAPE";
+            var isOverlayShown = _dropDown.IsOverlayShow();
+
+            if (isEnter || isTab || isEscape)
             {
                 _duringManualInput = false;
 
-                if (key == "ESCAPE" && _dropDown.IsOverlayShow())
+                if (isEscape && isOverlayShown)
                 {
                     Close();
                     await Js.FocusAsync(_inputStart.Ref);
                 }
-                else if (key == "ENTER")
+                else if (isEnter || isTab)
                 {
-                    if (string.IsNullOrEmpty(_inputStart.Value))
-                    {
-                        if (!_dropDown.IsOverlayShow())
-                            await _dropDown.Show();
-                    }
-                    else if (HasTimeInput && _pickerStatus[0].SelectedValue is not null)
+                    if (HasTimeInput && _pickerStatus[0].SelectedValue is not null)
                     {
                         await OnOkClick();
                     }
@@ -160,33 +160,25 @@ namespace AntDesign
                     {
                         await OnSelect(_pickerStatus[0].SelectedValue.Value, 0);
                     }
-                    else
+                    else if (isOverlayShown)
                     {
-                        if (!_dropDown.IsOverlayShow())
-                            await _dropDown.Show();
-                        else
-                            Close();
+                        Close();
                     }
-
+                    else if (!isTab)
+                    {
+                        await _dropDown.Show();
+                    }
                 }
-                else if (key == "TAB")
-                {
-                    Close();
-                    AutoFocus = false;
-                }
-            }
-            else if (key == "ARROWDOWN")
-            {
-                if (!_dropDown.IsOverlayShow())
-                    await _dropDown.Show();
             }
             else if (key == "ARROWUP")
             {
-                if (_dropDown.IsOverlayShow())
+                if (isOverlayShown)
                     Close();
             }
-            else if (!_dropDown.IsOverlayShow())
+            else if (!isOverlayShown)
+            {
                 await _dropDown.Show();
+            }
         }
 
         /// <summary>

--- a/components/date-picker/RangePicker.razor.cs
+++ b/components/date-picker/RangePicker.razor.cs
@@ -1,11 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using AntDesign.Core.Extensions;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
-using Microsoft.JSInterop;
 
 namespace AntDesign
 {
@@ -66,9 +64,6 @@ namespace AntDesign
         private bool ShowFooter => !IsShowTime && (RenderExtraFooter != null || ShowRanges);
 
         private bool ShowRanges => Ranges?.Count > 0;
-
-        private DateTime? _cacheDuringInput;
-        private DateTime _pickerValueCache;
 
         public RangePicker()
         {
@@ -205,12 +200,9 @@ namespace AntDesign
             if (!_duringManualInput)
             {
                 _duringManualInput = true;
-                _cacheDuringInput = GetIndexValue(index);
-                _pickerValueCache = PickerValues[index];
             }
 
-            if (FormatAnalyzer.TryPickerStringConvert(args.Value.ToString(), out DateTime parsedValue, false)
-                )
+            if (FormatAnalyzer.TryPickerStringConvert(args.Value.ToString(), out DateTime parsedValue, false))
             {
                 _pickerStatus[index].SelectedValue = parsedValue;
                 ChangePickerValue(parsedValue, index);
@@ -335,20 +327,7 @@ namespace AntDesign
             {
                 return;
             }
-
-            if (_duringManualInput)
-            {
-                var array = Value as Array;
-
-                if (array.GetValue(index) is null && _pickerStatus[index].SelectedValue is not null ||
-                    !Convert.ToDateTime(array.GetValue(index), CultureInfo).Equals(_pickerStatus[index].SelectedValue))
-                {
-                    _pickerStatus[index].SelectedValue = null;
-                    ChangePickerValue(_cacheDuringInput ?? _pickerValuesAfterInit[index]);
-                }
-                _duringManualInput = false;
-            }
-
+            _duringManualInput = false;
             AutoFocus = false;
         }
 

--- a/components/date-picker/internal/DatePickerBase.cs
+++ b/components/date-picker/internal/DatePickerBase.cs
@@ -932,15 +932,15 @@ namespace AntDesign
 
             if (IsRange)
             {
-                if (visible)
-                    _pickerStatus[index].SelectedValue = GetIndexValue(index);
-
-                var otherIndex = Math.Abs(index - 1);
-                _pickerStatus[otherIndex].SelectedValue = null;
+                _pickerStatus[Math.Abs(index - 1)].SelectedValue = null;
 
                 if (!visible)
                 {
                     ResetPlaceholder();
+                }
+                else
+                {
+                    _pickerStatus[index].SelectedValue = GetIndexValue(index);
                 }
             }
 

--- a/components/date-picker/internal/DatePickerBase.cs
+++ b/components/date-picker/internal/DatePickerBase.cs
@@ -466,12 +466,12 @@ namespace AntDesign
 
                 if (IsRange)
                 {
-                    var otherIndex = Math.Abs(index - 1);
-
                     if (!HasTimeInput)
                     {
-                        if (GetIndexValue(otherIndex) is not null)
+                        if (IsValidRange(date, index))
                         {
+                            var otherIndex = Math.Abs(index - 1);
+
                             if (_pickerStatus[otherIndex].SelectedValue is not null)
                             {
                                 ChangeValue(_pickerStatus[otherIndex].SelectedValue.Value, otherIndex, closeDropdown);
@@ -521,7 +521,8 @@ namespace AntDesign
                 var otherIndex = Math.Abs(index - 1);
                 var otherValue = GetIndexValue(otherIndex);
 
-                if (_pickerStatus[index].SelectedValue is not null && otherValue is not null)
+                if (_pickerStatus[index].SelectedValue is not null && otherValue is not null
+                    && IsValidRange(_pickerStatus[index].SelectedValue.Value, index))
                 {
                     if (_pickerStatus[otherIndex].SelectedValue is not null)
                     {
@@ -577,7 +578,6 @@ namespace AntDesign
             }
             else
             {
-                await Focus(index); //keep focus on current input
                 return false;
             }
 
@@ -932,6 +932,9 @@ namespace AntDesign
 
             if (IsRange)
             {
+                if (visible)
+                    _pickerStatus[index].SelectedValue = GetIndexValue(index);
+
                 var otherIndex = Math.Abs(index - 1);
                 _pickerStatus[otherIndex].SelectedValue = null;
 
@@ -975,6 +978,22 @@ namespace AntDesign
             }
         }
 
+        protected bool IsValidRange(DateTime newValue, int newValueIndex)
+        {
+            var otherValue = GetIndexValue(Math.Abs(newValueIndex - 1));
+
+            if (otherValue is null)
+            {
+                return false;
+            }
+
+            return newValueIndex switch
+            {
+                0 when newValue > otherValue => false,
+                1 when newValue < otherValue => false,
+                _ => true
+            };
+        }
         internal void OnNowClick()
         {
             ChangeValue(DateTime.Now, GetOnFocusPickerIndex());

--- a/tests/AntDesign.Tests/DatePicker/DatePickerKeyboardInputTests.razor
+++ b/tests/AntDesign.Tests/DatePicker/DatePickerKeyboardInputTests.razor
@@ -3,8 +3,13 @@
 @inherits AntDesignTestBase
 
 @code {
-    [Fact]
-    public void Enter_applies_input_to_value()
+
+    [Theory]
+    [InlineData("Enter", true)]
+    [InlineData("Tab", true)]
+    [InlineData("Enter", false)]
+    [InlineData("Tab", false)]
+    public void Key_applies_input_to_value(string key, bool showTime)
     {
         //Arrange
         JSInterop.SetupVoid(JSInteropConstants.AddPreventKeys, _ => true);
@@ -13,14 +18,20 @@
         DateTime value = DateTime.MinValue;
 		DateTime defaultValue = new DateTime(2020,1,1);
 		DateTime expectedValue = new DateTime(2020,1,2);
-		string expectedValueAsString = expectedValue.ToString("yyyy-MM-dd");
+
+        if (showTime)
+        {
+            expectedValue = expectedValue.AddHours(10).AddMinutes(30).AddSeconds(5);
+        }
+
+        string expectedValueAsString = expectedValue.ToString(showTime ? "yyyy-MM-dd HH:mm:ss" : "yyyy-MM-dd");
 		var cut = Render<AntDesign.DatePicker<DateTime>>(
-			@<DatePicker @bind-Value="@value" DefaultValue="@defaultValue" />
+			@<DatePicker @bind-Value="@value" DefaultValue="@defaultValue" ShowTime="showTime" />
 		);
 		//Act
 		var input = cut.Find("input");
 		input.Input(expectedValueAsString);
-		input.KeyDown("ENTER");
+		input.KeyDown(key);
 		//Assert
 		cut.Instance.Value.Should().Be(expectedValue);
 		value.Should().Be(expectedValue);
@@ -145,5 +156,4 @@
 		selectedCell.GetAttribute("title").Should().Be(expectedValueAsString);
 		selectedCell.Children[0].TextContent.Trim().Should().Be(expectedValue.Day.ToString());
 	}
-
 }

--- a/tests/AntDesign.Tests/DatePicker/RangePickerTests.razor
+++ b/tests/AntDesign.Tests/DatePicker/RangePickerTests.razor
@@ -200,4 +200,53 @@
         cut.Instance.Value[1].Should().Be(expectedEnd);
         input[1].GetAttribute("value").Should().Be(endValueAsString);
     }
+
+    [Theory]
+    [InlineData("Enter", true)]
+    [InlineData("Tab", true)]
+    [InlineData("Enter", false)]
+    [InlineData("Tab", false)]
+    public async Task Key_applies_input_to_value(string key, bool showTime)
+    {
+        //Arrange
+        JSInterop.SetupVoid(JSInteropConstants.AddPreventKeys, _ => true);
+        JSInterop.SetupVoid(JSInteropConstants.InvokeTabKey, _ => true);
+
+        var range = new DateTime[]
+        {
+            new DateTime(2022, 1, 1, 0, 0, 0),
+            new DateTime(2022, 1, 1, 1, 0, 0)
+        };
+
+        var expectedStart = new DateTime(2022, 6, 8, 0, 0, 0);
+        var expectedEnd = new DateTime(2022, 6, 9, 0, 0, 0);
+
+        if (showTime)
+        {
+            expectedStart = expectedStart.AddHours(20).AddMinutes(30).AddSeconds(5);
+            expectedEnd = expectedEnd.AddHours(1).AddMinutes(50).AddSeconds(5);
+        }
+
+        var format = showTime ? "yyyy-MM-dd HH:mm:ss" : "yyyy-MM-dd";
+        string startValueAsString = expectedStart.ToString(format);
+        string endValueAsString = expectedEnd.ToString(format);
+
+        //Act
+        var cut = Render<AntDesign.RangePicker<DateTime[]>>
+                  (@<RangePicker @bind-Value="range" ShowTime="showTime" />  );
+
+        //Act
+        var input = cut.FindAll("input");
+        await input[0].InputAsync(new ChangeEventArgs() { Value = startValueAsString });
+        await input[0].KeyDownAsync(new KeyboardEventArgs() { Key = key });
+        await input[1].InputAsync(new ChangeEventArgs() { Value = endValueAsString });
+        await input[1].KeyDownAsync(new KeyboardEventArgs() { Key = key });
+
+        //Assert
+        input = cut.FindAll("input");
+        range[0].Should().Be(expectedStart);
+        input[0].GetAttribute("value").Should().Be(startValueAsString);
+        range[1].Should().Be(expectedEnd);
+        input[1].GetAttribute("value").Should().Be(endValueAsString);
+	}
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

#2841

### 💡 Background and solution

This fixes two issues from #2841. 

Also, it brings RangePicker's behavior closer to the original antdesign. It gives the ability to select the range values more conveniently. Now it's possible to select the start date later than the end date without clearing the value.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
