### PR TITLE
feat:(module: datepicker): Add selected week range visualization

### DIFF
--- a/components/date-picker/internal/DatePickerDatePanel.razor
+++ b/components/date-picker/internal/DatePickerDatePanel.razor
@@ -111,7 +111,10 @@
 
     private string GetRowClass(DateTime viewDate)
     {
-        string selectedRowClass = IsWeek && DateHelper.IsSameWeek(viewDate, Value, Locale.FirstDayOfWeek) ? $"{PrefixCls}-week-panel-row-selected" : "";
+        var isSelectedWeek = IsWeek && (DateHelper.IsSameWeek(viewDate, Value, Locale.FirstDayOfWeek)
+                                      || IsRange && DateHelper.IsSameWeek(viewDate, GetIndexValue(Math.Abs(GetPickerIndex() - 1)), Locale.FirstDayOfWeek));
+
+        string selectedRowClass = isSelectedWeek ? $"{PrefixCls}-week-panel-row-selected" : "";
         string rowClass = IsWeek ? $"{PrefixCls}-week-panel-row" : "";
 
         return $"{rowClass} {selectedRowClass}";

--- a/components/date-picker/internal/DatePickerPanelBase.cs
+++ b/components/date-picker/internal/DatePickerPanelBase.cs
@@ -200,6 +200,6 @@ namespace AntDesign
                 .If($"{PrefixCls}-panel-rtl", () => RTL);
         }
 
-        private int GetPickerIndex() => IsRange && !IsShowTime ? DatePicker.GetOnFocusPickerIndex() : PickerIndex;
+        protected int GetPickerIndex() => IsRange && !IsShowTime ? DatePicker.GetOnFocusPickerIndex() : PickerIndex;
     }
 }

--- a/components/date-picker/internal/DatePickerTemplate.razor.cs
+++ b/components/date-picker/internal/DatePickerTemplate.razor.cs
@@ -119,7 +119,7 @@ namespace AntDesign.Internal
         private bool IsDateInRange(DateTime currentColDate)
         {
             if (!IsRange ||
-                !Picker.IsIn(DatePickerType.Date, DatePickerType.Year, DatePickerType.Month, DatePickerType.Quarter))
+                !Picker.IsIn(DatePickerType.Date, DatePickerType.Year, DatePickerType.Month, DatePickerType.Quarter, DatePickerType.Week))
             {
                 return false;
             }
@@ -130,6 +130,11 @@ namespace AntDesign.Internal
             if (startValue == null || endValue == null)
             {
                 return false;
+            }
+
+            if (Picker.IsIn(DatePickerType.Week))
+            {
+                startValue = startValue.Value.AddDays(6 - (int)startValue.Value.DayOfWeek);
             }
 
             DateTime currentDate = FormatDateByPicker(currentColDate);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

#945 

### 💡 Background and solution

This adds selected week range visualization to the `RangePicker` with `Picker="@DatePickerType.Week"`.

<img width="418" alt="image" src="https://user-images.githubusercontent.com/3949302/202917791-7e374a70-5c6e-4f39-8526-0edbe301e5e6.png">

As a downside, selecting the week that exists on both panels looks a bit cramped.

<img width="420" alt="image" src="https://user-images.githubusercontent.com/3949302/202917897-803223f9-06f1-4962-ad7c-406a0e6e990d.png">

vs the current version which looks like below

<img width="421" alt="image" src="https://user-images.githubusercontent.com/3949302/202918587-20afee90-10fe-4cce-b470-4ff550adf33d.png">

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
