### PR TITLE
fix:(module:datepicker): Exception on input with time when Value is null

### DIFF
--- a/components/date-picker/internal/DatePickerDatetimePanel.razor.cs
+++ b/components/date-picker/internal/DatePickerDatetimePanel.razor.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
@@ -96,7 +96,6 @@ namespace AntDesign.Internal
             List<int> disabledHours = new List<int>();
             List<int> disabledMinutes = new List<int>();
             List<int> disabledSeconds = new List<int>();
-            DatePickerDisabledTime userDisabledTime = null;
 
             if (DisabledHours is not null)
             {
@@ -111,7 +110,7 @@ namespace AntDesign.Internal
                 disabledSeconds.AddRange(DisabledSeconds(Value ?? DateTime.Now));
             }
 
-            userDisabledTime = DisabledTime?.Invoke(Value ?? DateTime.Now);
+            var userDisabledTime = DisabledTime?.Invoke(Value ?? DateTime.Now);
 
             if (userDisabledTime != null)
             {
@@ -150,9 +149,9 @@ namespace AntDesign.Internal
             }
         }
 
-        private async Task ScrollToSelectedHourAsync(int? duration = null)
+        private async Task ScrollToSelectedHourAsync(DateTime currentValue, int? duration = null)
         {
-            _selectedHour = Value.Value.Hour;
+            _selectedHour = currentValue.Hour;
 
             var hoursKey = Use12Hours && _selectedHour == 0 ?
                             12 : Use12Hours && _selectedHour > 12 ?
@@ -164,9 +163,9 @@ namespace AntDesign.Internal
             }
         }
 
-        private async Task ScrollToSelectedMinuteAsync(int? duration = null)
+        private async Task ScrollToSelectedMinuteAsync(DateTime currentValue, int? duration = null)
         {
-            _selectedMinute = Value.Value.Minute;
+            _selectedMinute = currentValue.Minute;
 
             if (_minutes.ContainsKey(_selectedMinute.Value))
             {
@@ -174,9 +173,9 @@ namespace AntDesign.Internal
             }
         }
 
-        private async Task ScrollToSelectedSecondAsync(int? duration = null)
+        private async Task ScrollToSelectedSecondAsync(DateTime currentValue, int? duration = null)
         {
-            _selectedSecond = Value.Value.Second;
+            _selectedSecond = currentValue.Second;
 
             if (_seconds.ContainsKey(_selectedSecond.Value))
             {
@@ -195,26 +194,30 @@ namespace AntDesign.Internal
 
             if (currentValue.Hour != _selectedHour)
             {
-                await ScrollToSelectedHourAsync();
+                await ScrollToSelectedHourAsync(currentValue);
             }
             if (currentValue.Minute != _selectedMinute)
             {
-                await ScrollToSelectedMinuteAsync();
+                await ScrollToSelectedMinuteAsync(currentValue);
             }
             if (currentValue.Second != _selectedSecond)
             {
-                await ScrollToSelectedSecondAsync();
+                await ScrollToSelectedSecondAsync(currentValue);
             }
         }
 
         private void DatePicker_OverlayVisibleChanged(object sender, bool visible)
         {
-            if (visible)
+            if (!visible || Value is null)
             {
-                _ = ScrollToSelectedHourAsync(0);
-                _ = ScrollToSelectedMinuteAsync(0);
-                _ = ScrollToSelectedSecondAsync(0);
+                return;
             }
+
+            var currentValue = Value.Value;
+
+            _ = ScrollToSelectedHourAsync(currentValue, 0);
+            _ = ScrollToSelectedMinuteAsync(currentValue, 0);
+            _ = ScrollToSelectedSecondAsync(currentValue, 0);
         }
 
         private async Task InvokeSmoothScrollAsync(ElementReference element, ElementReference parent, int? duration)


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

#2915

### 💡 Background and solution

Fixes InvalidOperationException in the DatePicker/RangePicker (with time input enabled) that happens after clicking the input field when Value is null.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
