### PR TITLE
fix(module: RangePicker): Always run default disabled logic, even with custom function provided

### DIFF
--- a/components/date-picker/RangePicker.razor.cs
+++ b/components/date-picker/RangePicker.razor.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
 using AntDesign.Core.Extensions;
@@ -65,11 +65,28 @@ namespace AntDesign
 
         private bool ShowRanges => Ranges?.Count > 0;
 
+        private readonly Func<DateTime, bool> _defaultDisabledDateCheck;
+
+        private Func<DateTime, bool> _disabledDate;
+
+        [Parameter]
+        public override Func<DateTime, bool> DisabledDate
+        {
+            get
+            {
+                return _disabledDate;
+            }
+            set
+            {
+                _disabledDate = (date) => (value is not null && value(date)) || _defaultDisabledDateCheck(date);
+            }
+        }
+
         public RangePicker()
         {
             IsRange = true;
 
-            DisabledDate = (date) =>
+            _defaultDisabledDateCheck = (date) =>
             {
                 int? index = null;
 
@@ -116,6 +133,7 @@ namespace AntDesign
                     return index == 0 ? formattedDate1 < formattedDate2 : formattedDate1 > formattedDate2;
                 }
             };
+            DisabledDate = null;
         }
 
         private async Task OnInputClick(int index)

--- a/components/date-picker/internal/DatePickerBase.cs
+++ b/components/date-picker/internal/DatePickerBase.cs
@@ -236,7 +236,7 @@ namespace AntDesign
         public EventCallback<DateTimeChangedEventArgs> OnPanelChange { get; set; }
 
         [Parameter]
-        public Func<DateTime, bool> DisabledDate { get; set; } = null;
+        public virtual Func<DateTime, bool> DisabledDate { get; set; } = null;
 
         [Parameter]
         public Func<DateTime, int[]> DisabledHours { get; set; } = null;


### PR DESCRIPTION
We ran into the need to use custom disabled logic, but also wanted to keep the default logic that kept the start/end in the proper order. 

~This PR adds a property to allow that setting which "mode" you want to use and then wraps the DisabledDate function provided in a method to check the type of check to run. It then either runs one or both.~

Through discussion below, this PR updates the disabled logic to always apply the default logic even when custom is provided.

<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Update RangePicker disabled date logic to always apply default logic even when custom is provided. This keeps ranges in the proper order even with custom disabled logic. |
| 🇨🇳 Chinese | 更新 RangePicker 禁用日期逻辑以始终应用默认逻辑，即使在提供自定义时也是如此。即使使用自定义禁用逻辑，这也会使范围保持正确的顺序。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] Changelog is provided or not needed
