### PR TITLE
fix(module: tabs): avoid active pane after tabs is dispsed

### DIFF
--- a/components/tabs/Tabs.razor.cs
+++ b/components/tabs/Tabs.razor.cs
@@ -687,6 +687,8 @@ namespace AntDesign
             DomEventListener.DisposeExclusive();
 
             _panes.Clear();
+            _tabs.Clear();
+            _invisibleTabs.Clear();
 
             base.Dispose(disposing);
         }

--- a/components/tabs/Tabs.razor.cs
+++ b/components/tabs/Tabs.razor.cs
@@ -349,6 +349,10 @@ namespace AntDesign
 
         internal void RemovePane(TabPane tab)
         {
+            // fix https://github.com/ant-design-blazor/ant-design-blazor/issues/2180
+            if (IsDisposed)
+                return;
+
             if (tab.IsTab)
             {
                 var index = _tabs.IndexOf(tab);
@@ -681,6 +685,9 @@ namespace AntDesign
         protected override void Dispose(bool disposing)
         {
             DomEventListener.DisposeExclusive();
+
+            _panes.Clear();
+
             base.Dispose(disposing);
         }
     }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

fixed #2180

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix avoid active pane after tabs is dispsed        |
| 🇨🇳 Chinese |  修复 Tabs 关闭异常，阻止在 disposed 后还触发渲染器         |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
