### PR TITLE
fix(module: select): add tags when datasource is empty

### DIFF
--- a/components/select/Select.razor.cs
+++ b/components/select/Select.razor.cs
@@ -476,24 +476,6 @@ namespace AntDesign
                 return;
             }
 
-            // clear DataSource
-            if (DataSource?.Any() == false && SelectOptionItems.Any())
-            {
-                SelectOptionItems.Clear();
-                SelectedOptionItems.Clear();
-
-                Value = default;
-
-                _datasource = DataSource;
-                _dataSourceShallowCopy = new List<TItem>();
-                _dataSourceCopy = new List<TItem>();
-                TypeDefaultExistsAsSelectOption = false;
-
-                OnDataSourceChanged?.Invoke();
-
-                return;
-            }
-
             // DataSource maybe changed
             if (DataSource != null)
             {
@@ -647,12 +629,11 @@ namespace AntDesign
             if (SelectOptionItems.Any())
             {
                 // Delete items from SelectOptions if it is no longer in the datastore
-                for (var i = SelectOptionItems.Count - 1; i >= 0; i--)
+                foreach (var selectOption in SelectOptionItems)
                 {
-                    var selectOption = SelectOptionItems.ElementAt(i);
                     if (!selectOption.IsAddedTag)
                     {
-                        var exists = _datasource.Where(x => x.Equals(selectOption.Item)).FirstOrDefault();
+                        var exists = _datasource.FirstOrDefault(x => x.Equals(selectOption.Item));
 
                         if (exists is null)
                         {
@@ -749,6 +730,21 @@ namespace AntDesign
                             //SelectedOptionItems.Add(updateSelectOption);
                         }
                         processedSelectedCount--;
+                    }
+                }
+            }
+
+            // add the tag options back in if they were removed since they are separate from the datasource
+            foreach (var tag in AddedTags)
+            {
+                if (!SelectOptionItems.Contains(tag))
+                {
+                    SelectOptionItems.Add(tag);
+
+                    if (tag.IsSelected)
+                    {
+                        processedSelectedCount--;
+                        SelectedOptionItems.Add(tag);
                     }
                 }
             }

--- a/components/select/SelectBase.cs
+++ b/components/select/SelectBase.cs
@@ -748,10 +748,7 @@ namespace AntDesign
                     {
                         SelectOptionItems.Remove(selectOption);
                         SelectedOptionItems.Remove(selectOption);
-                        if (selectOption.IsAddedTag && SelectOptions != null)
-                        {
-                            AddedTags.Remove(selectOption);
-                        }
+                        AddedTags.Remove(selectOption);
                     }
 
                     if (IsResponsive)

--- a/tests/AntDesign.Tests/Select/Select.Tags.Tests.razor
+++ b/tests/AntDesign.Tests/Select/Select.Tags.Tests.razor
@@ -71,26 +71,55 @@
 						<SelectOption TItemValue="string" TItem="string" Value="@value" Label="@value" />									
 					}
 				</SelectOptions>
-			</AntDesign.Select>
-		);
-		//Act
+            </AntDesign.Select>
+    );
+        //Act
 
-		//TOOD: When using @bind-Values, bUnit does not render the selected items. This 
-		//		Requires investigation - more likely scenario is that Select components
-		//		should be refactored.
-		cut.SetParametersAndRender(parameters => parameters.Add(p => p.Values, values));   		
-		//Assert
-		var items = cut.Find("div.ant-select-selection-overflow").Children;
-		var tags = items.Where(i => i.ClassList.Count() == 1);
-		var rest = items.Filter(".ant-select-selection-overflow-item-rest");
-		var input = items.Filter(".ant-select-selection-overflow-item-suffix");
+        //TOOD: When using @bind-Values, bUnit does not render the selected items. This 
+        //		Requires investigation - more likely scenario is that Select components
+        //		should be refactored.
+        cut.SetParametersAndRender(parameters => parameters.Add(p => p.Values, values));   		
+        //Assert
+        var items = cut.Find("div.ant-select-selection-overflow").Children;
+        var tags = items.Where(i => i.ClassList.Count() == 1);
+        var rest = items.Filter(".ant-select-selection-overflow-item-rest");
+        var input = items.Filter(".ant-select-selection-overflow-item-suffix");
 
-		items.Should().HaveCount(4);
-		tags.Should().HaveCount(2);
-		rest.Should().HaveCount(1);
-		rest.ElementAt(0).GetAttribute("style").Should().Contain("order: 5");
-		input.Should().HaveCount(1);
-		input.ElementAt(0).GetAttribute("style").Should().Contain("order: 6");
+        items.Should().HaveCount(4);
+        tags.Should().HaveCount(2);
+        rest.Should().HaveCount(1);
+        rest.ElementAt(0).GetAttribute("style").Should().Contain("order: 5");
+        input.Should().HaveCount(1);
+        input.ElementAt(0).GetAttribute("style").Should().Contain("order: 6");
+    }
+
+    [Fact]
+    public async Task ItShouldAddTags_WhenDatasourceIsEmpty()
+    {
+        //Arrange
+        JSInterop.Setup<OverlayPosition>(JSInteropConstants.OverlayComponentHelper.AddOverlayToContainer, _ => true)
+            .SetResult(new OverlayPosition() { Top = 0, Left = 0, ZIndex = 5000, Placement = Placement.BottomLeft });
+
+        var datasource = new List<string>();
+
+        var systemUnderTest = Render<Select<string, string>>(
+            @<AntDesign.Select Mode="tags" TItemValue="string" TItem="string" DataSource="datasource" EnableSearch />
+        );
+
+        var input = systemUnderTest.Find("input.ant-select-selection-search-input");
+
+        await systemUnderTest.InvokeAsync(() => input.Input("Tag1"));
+        await systemUnderTest.InvokeAsync(() => systemUnderTest.WaitForState(() => systemUnderTest.Instance.ActiveOption is not null));
+        input.KeyUp("ENTER");
+
+        input.Input("Tag2");
+        await systemUnderTest.InvokeAsync(() => systemUnderTest.WaitForState(() => systemUnderTest.Instance.ActiveOption.Value.Equals("Tag2")));
+        input.KeyUp("ENTER");
+
+        systemUnderTest.FindAll("span.ant-select-selection-item-content")
+            .Select(x => x.TextContent.Trim())
+            .Should()
+            .BeEquivalentTo(new[] { "Tag1", "Tag2" });
     }
 }
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

fixes #2965 

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

When there was a select component set to `Tags` mode and the datasource was empty, any entered tag options were being hidden from user even though they went through the two way binding. 

There was an issue where whenever the datasource was empty it would use `Clear()` on the option list instead of letting the change trickle down to where it updates the option list based on the datasource.  To ensure the user entered tags do not go away I add them after the option list is created.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Select mode Tags will retain tag options when datasource is empty   |
| 🇨🇳 Chinese |  選擇模式標籤將在數據源為空時保留標籤選項  |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
