### PR TITLE
fix(module: cascader): make boudary adjust mode default to InView

### DIFF
--- a/components/cascader/Cascader.razor.cs
+++ b/components/cascader/Cascader.razor.cs
@@ -16,7 +16,7 @@ namespace AntDesign
         /// <summary>
         /// Overlay adjustment strategy (when for example browser resize is happening)
         /// </summary>
-        [Parameter] public TriggerBoundaryAdjustMode BoundaryAdjustMode { get; set; } = TriggerBoundaryAdjustMode.None;
+        [Parameter] public TriggerBoundaryAdjustMode BoundaryAdjustMode { get; set; } = TriggerBoundaryAdjustMode.InView;
 
         [Parameter] public bool ChangeOnSelect { get; set; }
 

--- a/site/AntDesign.Docs/Pages/Test.razor
+++ b/site/AntDesign.Docs/Pages/Test.razor
@@ -1,0 +1,28 @@
+﻿<Select Mode="tags"
+        DataSource="@_items"
+		@bind-Values="@_selectedValues"
+		TItemValue="string"
+		TItem="string"
+		EnableSearch>
+</Select>
+
+<Button OnClick="@OnButtonClick">Click me to update datasource</Button>
+@code
+{
+    List<string> _items = new List<string>();
+    IEnumerable<string> _selectedValues;
+
+    protected void OnButtonClick()
+    {
+        const int min = 10;
+        const int max = 36;
+
+        for (var i = min; max > i; i++)
+        {
+            var value = Convert.ToString(i, 16).PadLeft(2, '0') + i.ToString();
+            _items.Add(value);
+
+            
+        }
+    }
+}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

fixed #2435

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fixed Cascader boudary adjust mode default to InView       |
| 🇨🇳 Chinese |    修复   Cascader 边界调整模式默认改为 InView     |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
