### PR TITLE
fix(module: tabs): ReuseTabs close other tab rendering error

### DIFF
--- a/components/tabs/Tabs.razor.cs
+++ b/components/tabs/Tabs.razor.cs
@@ -555,11 +555,6 @@ namespace AntDesign
 
         private void TryRenderInk()
         {
-            if (_renderedActivePane == _activePane)
-            {
-                return;
-            }
-
             if (IsHorizontal)
             {
                 _inkStyle = $"left: {_activeTabElement.OffsetLeft}px; width: {_activeTabElement.ClientWidth}px";


### PR DESCRIPTION
fix 2725 ReuseTabs close other tab rendering error

The original judgment logic of this module will result in a style rendering exception if the closed tab is not the currently selected tab

https://github.com/ant-design-blazor/ant-design-blazor/issues/2725