### PR TITLE
fix(module:select): Selected options will display even with HideSelected set to true when searching or clearing search

### DIFF
--- a/components/select/Select.razor.cs
+++ b/components/select/Select.razor.cs
@@ -1209,7 +1209,7 @@ namespace AntDesign
             }
             else
             {
-                SelectOptionItems.Where(x => x.IsHidden).ForEach(i => i.IsHidden = false);
+                UnhideSelectOptions();
                 if (SelectMode == SelectMode.Tags && CustomTagSelectOptionItem is not null)
                 {
                     SelectOptionItems.Remove(CustomTagSelectOptionItem);
@@ -1291,13 +1291,15 @@ namespace AntDesign
                         {
                             item.IsActive = false;
                         }
-                        if (item.IsHidden)
-                            item.IsHidden = false;
+
+                        item.IsHidden = item.IsSelected && HideSelected;
                     }
                     else
                     {
                         if (!item.IsHidden)
+                        {
                             item.IsHidden = true;
+                        }
                         item.IsActive = false;
                     }
                 }
@@ -1338,14 +1340,18 @@ namespace AntDesign
                             }
                         }
                         else if (item.IsActive)
+                        {
                             item.IsActive = false;
-                        if (item.IsHidden)
-                            item.IsHidden = false;
+                        }
+
+                        item.IsHidden = item.IsSelected && HideSelected;
                     }
                     else
                     {
                         if (!item.IsHidden)
+                        {
                             item.IsHidden = true;
+                        }
                         item.IsActive = false;
                     }
                 }

--- a/components/select/SelectBase.cs
+++ b/components/select/SelectBase.cs
@@ -1012,6 +1012,19 @@ namespace AntDesign
             }
         }
 
+        /// <summary>
+        /// Unhide all select options, except any that are selected in the case that <see cref="HideSelected"/> is true
+        /// </summary>
+        protected void UnhideSelectOptions()
+        {
+            var hiddenOptions = SelectOptionItems.Where(x => x.IsHidden);
+
+            foreach (var option in hiddenOptions)
+            {
+                option.IsHidden = HideSelected && option.IsSelected;
+            }
+        }
+
         protected abstract void SetClassMap();
     }
 }

--- a/tests/AntDesign.Tests/Select/Select.SelectOptions.Tests.razor
+++ b/tests/AntDesign.Tests/Select/Select.SelectOptions.Tests.razor
@@ -1,4 +1,5 @@
-﻿@inherits AntDesignTestBase
+﻿@using AntDesign.Core.JsInterop.Modules.Components;
+@inherits AntDesignTestBase
 @code {
     record Person(int Id, string Name);
     class PersonClass 
@@ -42,10 +43,10 @@
         Person value = _persons[1];
         var cut = Render<AntDesign.Select<Person, Person>>(
         @<AntDesign.Select Mode="default"
-			TItemValue="Person"
-			TItem="Person"
+            TItemValue="Person"
+            TItem="Person"
             @bind-Value="@value">
-			<SelectOptions>						
+            <SelectOptions>						
                 @foreach (var item in _persons)
                 {
                     <SelectOption @key="item"
@@ -54,8 +55,8 @@
                                   Value=@item
                                   Label=@item.Name />
                 }
-			</SelectOptions>
-		</AntDesign.Select>
+            </SelectOptions>
+        </AntDesign.Select>
     );
         //Act
         value = new Person(5, "NewPerson");
@@ -77,10 +78,10 @@
         IEnumerable<Person> values = new List<Person>() { _persons[1] };
         var cut = Render<AntDesign.Select<Person, Person>>(
         @<AntDesign.Select Mode="multiple"
-			TItemValue="Person"
-			TItem="Person"
+            TItemValue="Person"
+            TItem="Person"
             @bind-Values="@values">
-			<SelectOptions>						
+            <SelectOptions>						
                 @foreach (var item in _persons)
                 {
                     <SelectOption @key="item"
@@ -89,9 +90,9 @@
                                   Value=@item
                                   Label=@item.Name />
                 }
-			</SelectOptions>
-		</AntDesign.Select>
-        );
+            </SelectOptions>
+            </AntDesign.Select>
+    );
         //Act
         var newPerson = new Person(5, "NewPerson");
         _persons.Add(newPerson);   
@@ -105,6 +106,111 @@
         cut.FindAll("div.ant-select-item-option-content").Should().HaveCount(_persons.Count);
         selectedItems.Should().HaveCount(values.Count());
         selectedItems.Select(x => x.TextContent).Should().ContainInOrder(new string[] { "Lucy", "NewPerson"});
+    }
+
+    [Theory]
+    [InlineData("default")]
+    [InlineData("multiple")]
+    public void Will_not_show_selected_items_on_search_when_hide_selected_is_true(string mode)
+    {
+        JSInterop.SetupVoid("AntDesign.interop.eventHelper.addPreventKeys", _ => true);
+        JSInterop.SetupVoid("AntDesign.interop.domManipulationHelper.focus", _ => true);
+        JSInterop
+            .Setup<OverlayPosition>("AntDesign.interop.overlayHelper.addOverlayToContainer", _ => true)
+            .SetResult(new OverlayPosition
+                {
+                    Bottom = 10,
+                    Left = 10,
+                    Right = 10,
+                    Top = 10,
+                    Placement = Placement.TopLeft,
+                    ZIndex = 100
+                });
+
+        IEnumerable<Person> values = new List<Person>();
+        var itemsChanged = false;
+
+        var cut = Render<AntDesign.Select<Person, Person>>(
+            @<AntDesign.Select Mode=@mode
+                EnableSearch=true
+                HideSelected=true
+                SearchDebounceMilliseconds=0
+                OnSelectedItemChanged="() => { itemsChanged = true; }"
+                OnSelectedItemsChanged="() => { itemsChanged = true; }"
+                TItemValue="Person"
+                TItem="Person"
+                @bind-Values="@values">
+                <SelectOptions>
+                    @foreach (var item in _persons)
+                    {
+                        <SelectOption @key="item"
+                              TItemValue="Person"
+                              TItem="Person"
+                              Value=@item
+                              Label=@item.Name />
+                    }
+                </SelectOptions>
+            </AntDesign.Select>
+    );
+
+        cut.Find("input[type=search]").Input("John");
+        cut.Find(".ant-select-item-option").Click();
+        cut.WaitForState(() => itemsChanged);
+        cut.Find("input[type=search]").Input("John");
+
+        // All items should be hidden because there is only 1 John and it is selected, but HideSelected is true
+        cut.FindAll(".ant-select-item-option").Where(x => !x.Attributes["style"]?.Value?.Trim()?.Contains("display:none") ?? true).Count().Should().Be(0);
+    }
+
+    [Fact]
+    public void Multiple_will_not_show_selected_items_when_clearing_search_when_hide_selected_is_true()
+    {
+        JSInterop.SetupVoid("AntDesign.interop.eventHelper.addPreventKeys", _ => true);
+        JSInterop.SetupVoid("AntDesign.interop.domManipulationHelper.focus", _ => true);
+        JSInterop
+        .Setup<OverlayPosition>("AntDesign.interop.overlayHelper.addOverlayToContainer", _ => true)
+        .SetResult(new OverlayPosition
+                {
+                    Bottom = 10,
+                    Left = 10,
+                    Right = 10,
+                    Top = 10,
+                    Placement = Placement.TopLeft,
+                    ZIndex = 100
+                });
+
+        IEnumerable<Person> values = new List<Person>();
+        var itemsChanged = false;
+
+        var cut = Render<AntDesign.Select<Person, Person>>(
+            @<AntDesign.Select Mode="multiple"
+                               EnableSearch=true
+                               HideSelected=true
+                               SearchDebounceMilliseconds=0
+                               OnSelectedItemsChanged="() => { itemsChanged = true; }"
+                               TItemValue="Person"
+                               TItem="Person"
+                                   @bind-Values="@values">
+                <SelectOptions>
+                    @foreach (var item in _persons)
+                    {
+                        <SelectOption @key="item"
+                              TItemValue="Person"
+                              TItem="Person"
+                              Value=@item
+                              Label=@item.Name />
+                    }
+                </SelectOptions>
+            </AntDesign.Select>
+            );
+
+        cut.Find("input[type=search]").Input("John");
+        cut.Find(".ant-select-item-option").Click();
+        cut.WaitForState(() => itemsChanged);
+        cut.Find("input[type=search]").Input(string.Empty);
+
+        // All items except John should be visible because John is selected and HideSelected is true
+        cut.FindAll(".ant-select-item-option").Where(x => !x.Attributes["style"]?.Value?.Trim()?.Contains("display:none") ?? true).Count().Should().Be(3);
     }
 }
 }


### PR DESCRIPTION
This can be seen in the "hide selected" demo on the documentation. If you select an option in the list, then type in a search that would include that selected option it displays - it should not. If you then remove the search it will still display. This PR fixes those issues.

<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix(module:select): Fix bug where selected options will display even with HideSelected set to true when searching or clearing search |
| 🇨🇳 Chinese | fix(module:select)：修复在搜索或清除搜索时即使将 HideSelected 设置为 true 也会显示所选选项的错误 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
