### PR TITLE
feat(module: input): add EventCallback OnClear

### DIFF
--- a/components/input/Input.cs
+++ b/components/input/Input.cs
@@ -51,6 +51,12 @@ namespace AntDesign
         public bool AllowClear { get; set; }
 
         /// <summary>
+        /// Callback when the content is cleared by clicking the "ClearIcon"
+        /// </summary>
+        [Parameter]
+        public EventCallback OnClear { get; set; }
+
+        /// <summary>
         /// Controls the autocomplete attribute of the input HTML element.
         /// Default = true
         /// </summary>
@@ -252,11 +258,15 @@ namespace AntDesign
             IsFocused = true;
             _inputString = null;
             await this.FocusAsync(Ref);
+
             if (OnChange.HasDelegate)
                 await OnChange.InvokeAsync(Value);
-            else
-                //Without the delay, focus is not enforced.
-                await Task.Delay(1);
+
+            if (OnClear.HasDelegate)
+                await OnClear.InvokeAsync(Value);
+
+            //Without the delay, focus is not enforced.
+            await Task.Delay(1);
         }
 
         private string _inputString;

--- a/components/input/Input.cs
+++ b/components/input/Input.cs
@@ -259,14 +259,11 @@ namespace AntDesign
             _inputString = null;
             await this.FocusAsync(Ref);
 
-            if (OnChange.HasDelegate)
-                await OnChange.InvokeAsync(Value);
-
             if (OnClear.HasDelegate)
                 await OnClear.InvokeAsync(Value);
-
-            //Without the delay, focus is not enforced.
-            await Task.Delay(1);
+            else
+                //Without the delay, focus is not enforced.
+                await Task.Yield();
         }
 
         private string _inputString;


### PR DESCRIPTION
add EventCallback OnClear to component Input<T> as a parameter it is called when the input contents are cleared by clicking the clear icon

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

In some cases, we need to be notified when the user clears input contents by clicking the clear icon, for example if a keywork-searching was in effect, we need to reset the search results. But current there's no callback defined for this event.

### 💡 Background and solution

The solution is quite simple, just add an event callback into component Input, and invoke it when user clears the contents.

`
        [Parameter]
        public EventCallback OnClear { get; set; }
`
### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
