### PR TITLE
fix(module: Overlay): overlay show after mouse leave trigger

### DIFF
--- a/components/core/Component/Overlay/OverlayTrigger.razor.cs
+++ b/components/core/Component/Overlay/OverlayTrigger.razor.cs
@@ -566,6 +566,10 @@ namespace AntDesign.Internal
 
         internal virtual async Task Show(int? overlayLeft = null, int? overlayTop = null)
         {
+            if (!_mouseInTrigger && IsContainTrigger(TriggerType.Hover))
+            {
+                return;
+            }
             await _overlay.Show(overlayLeft, overlayTop);
         }
 

--- a/tests/AntDesign.Tests/Menu/Menu.Horizontal.Tests.razor
+++ b/tests/AntDesign.Tests/Menu/Menu.Horizontal.Tests.razor
@@ -4,36 +4,36 @@
     public Menu_Horizontal_Tests()
     {
         JSInterop.Setup<AntDesign.JsInterop.DomRect>(JSInteropConstants.GetBoundingClientRect, _ => true)
-            .SetResult(new AntDesign.JsInterop.DomRect());
+        .SetResult(new AntDesign.JsInterop.DomRect());
         JSInterop.Setup<OverlayPosition>(JSInteropConstants.OverlayComponentHelper.AddOverlayToContainer, _ => true)
-            .SetResult(new OverlayPosition() { Top = 0, Left = 0, ZIndex = 5000, Placement = Placement.BottomLeft });
+        .SetResult(new OverlayPosition() { Top = 0, Left = 0, ZIndex = 5000, Placement = Placement.BottomLeft });
         JSInterop.Setup<HtmlElement>(JSInteropConstants.DomInfoHelper.GetFirstChildDomInfo, _ => true)
-            .SetResult(new HtmlElement { ClientWidth = 123 });
+        .SetResult(new HtmlElement { ClientWidth = 123 });
     }
 
     private RenderFragment GetBasicHorizontalRender()
     {
         return @<Menu Mode=MenuMode.Horizontal>
-                <MenuItem>Navigation One</MenuItem>
-                <SubMenu Title="Navigation Two">
-                    <MenuItemGroup Title="Item 1">
-                        <MenuItem Key="nest:2:1">Option 1</MenuItem>
-                        <MenuItem>Option 2</MenuItem>
-                    </MenuItemGroup>
-                    <MenuDivider />
-                    <MenuItemGroup Title="Item 2">
-                        <MenuItem>Option 3</MenuItem>
-                        <SubMenu Title="Option 4">
-                            <MenuItem Key="nest:2:2:4">Option 1</MenuItem>
-                            <SubMenu Title="Option 5">
-                                <MenuItem Key="nest:2:2:4:5:1">Option 1</MenuItem>
-                                <MenuItem Key="nest:2:2:4:5:2">Option 2</MenuItem>
-                            </SubMenu>
-                        </SubMenu>
-                    </MenuItemGroup>
+        <MenuItem>Navigation One</MenuItem>
+        <SubMenu Title="Navigation Two">
+            <MenuItemGroup Title="Item 1">
+                <MenuItem Key="nest:2:1">Option 1</MenuItem>
+                <MenuItem>Option 2</MenuItem>
+            </MenuItemGroup>
+            <MenuDivider />
+            <MenuItemGroup Title="Item 2">
+                <MenuItem>Option 3</MenuItem>
+                <SubMenu Title="Option 4">
+                    <MenuItem Key="nest:2:2:4">Option 1</MenuItem>
+                    <SubMenu Title="Option 5">
+                        <MenuItem Key="nest:2:2:4:5:1">Option 1</MenuItem>
+                        <MenuItem Key="nest:2:2:4:5:2">Option 2</MenuItem>
+                    </SubMenu>
                 </SubMenu>
-                <MenuItem>Navigation Three</MenuItem>
-            </Menu>;
+            </MenuItemGroup>
+        </SubMenu>
+        <MenuItem>Navigation Three</MenuItem>
+        </Menu>;
     }
 
 
@@ -46,12 +46,12 @@
         //Act
         //Assert
         cut.MarkupMatches(@"
-            <ul class=""ant-menu ant-menu-root ant-menu-light ant-menu-horizontal"" id:ignore direction=""ltr"" role=""menu"">        
+            <ul class=""ant-menu ant-menu-root ant-menu-light ant-menu-horizontal"" id:ignore direction=""ltr"" role=""menu"">
 		        <li class=""ant-menu-item"" role=""menuitem"" style="""">
 			        <span class=""ant-menu-title-content"">
-                        Navigation One	
+                        Navigation One
 			        </span>
-		        </li>       
+		        </li>
                 <li class=""ant-menu-submenu ant-menu-submenu-vertical"" role=""menuitem"" style=""position:relative;"">
                     <div class=""ant-menu-submenu-title"" role=""button"">
                         <span class=""ant-menu-title-content"">
@@ -61,10 +61,25 @@
                 </li>
         		<li class=""ant-menu-item"" role=""menuitem"" style="""">
         			<span class=""ant-menu-title-content"">
-                        Navigation Three	
+                        Navigation Three
 			        </span>
 		        </li>
-            </ul>");             
+            </ul>");
+    }
+
+    [Fact]
+    public async Task Basic_horizontal_submenu_should_be_hidden_when_mouseleave()
+    {
+        //Arrange
+        var cut = Render<AntDesign.Menu>(GetBasicHorizontalRender());
+        //Act
+        var topExpandable = cut.FindComponent<AntDesign.Internal.SubMenuTrigger>();
+        await cut.Find(".ant-menu-submenu").TriggerEventAsync("onmouseenter", EventArgs.Empty);
+        await cut.Find(".ant-menu-submenu").TriggerEventAsync("onmouseleave", EventArgs.Empty);
+        await cut.InvokeAsync(() => topExpandable.Instance.Show());
+        // Assert
+        var topOverlay = topExpandable.FindComponent<AntDesign.Internal.Overlay>();
+        topOverlay.Find(".ant-menu-submenu").ClassList.Contains("ant-menu-submenu-hidden");
     }
 
     [Fact]
@@ -74,26 +89,27 @@
 
         var cut = Render<AntDesign.Menu>(GetBasicHorizontalRender());
         //Act
-        var topExpandable = cut.FindComponent<AntDesign.Internal.SubMenuTrigger>();        
+        var topExpandable = cut.FindComponent<AntDesign.Internal.SubMenuTrigger>();
+        cut.Find(".ant-menu-submenu").TriggerEvent("onmouseenter", EventArgs.Empty);
         await cut.InvokeAsync(() => topExpandable.Instance.Show());
         var topOverlay = topExpandable.FindComponent<AntDesign.Internal.Overlay>();
         //Assert
         topOverlay.MarkupMatches(@"
             <div class=""ant-menu-submenu ant-menu-submenu-popup ant-menu ant-menu-light ant-menu-submenu-placement-bottomLeft ant-slide-up-enter ant-slide-up-enter-active ant-slide-up"" style:ignore>
-                <ul direction=""ltr"" class=""ant-menu ant-menu-sub ant-menu-light ant-menu-vertical"" style=""min-width: 123px"" role=""menu"">                        
+                <ul direction=""ltr"" class=""ant-menu ant-menu-sub ant-menu-light ant-menu-vertical"" style=""min-width: 123px"" role=""menu"">
                     <li class=""ant-menu-item-group"">
                         <div class=""ant-menu-item-group-title"">
-                            Item 1    
+                            Item 1
                         </div>
-                        <ul class=""ant-menu-item-group-list"">        
+                        <ul class=""ant-menu-item-group-list"">
 		                    <li class=""ant-menu-item"" role=""menuitem"" style="""">
 			                    <span class=""ant-menu-title-content"">
-                                    Option 1	
+                                    Option 1
 			                    </span>
-		                    </li>            
+		                    </li>
 		                    <li class=""ant-menu-item"" role=""menuitem"" style="""">
 			                    <span class=""ant-menu-title-content"">
-                                    Option 2	
+                                    Option 2
 			                    </span>
 		                    </li>
                         </ul>
@@ -103,10 +119,10 @@
                         <div class=""ant-menu-item-group-title"">
                             Item 2
                         </div>
-                        <ul class=""ant-menu-item-group-list"">        
+                        <ul class=""ant-menu-item-group-list"">
 		                    <li class=""ant-menu-item"" role=""menuitem"" style="""">
 			                    <span class=""ant-menu-title-content"">
-                                    Option 3	
+                                    Option 3
 			                    </span>
 		                    </li>
                             <li class=""ant-menu-submenu ant-menu-submenu-vertical"" role=""menuitem"" style=""position:relative;"">
@@ -115,13 +131,13 @@
                                         Option 4
                                     </span>
                                     <i class=""ant-menu-submenu-arrow""></i>
-                                </div>                
+                                </div>
                             </li>
                         </ul>
                     </li>
                 </ul>
             </div>
-        ");             
+        ");
     }
 
     [Fact]
@@ -131,18 +147,20 @@
 
         var cut = Render<AntDesign.Menu>(GetBasicHorizontalRender());
         //Act
-        var topExpandable = cut.FindComponent<AntDesign.Internal.SubMenuTrigger>();        
-        await cut.InvokeAsync(() => topExpandable.Instance.Show());        
+        var topExpandable = cut.FindComponent<AntDesign.Internal.SubMenuTrigger>();
+        topExpandable.Find(".ant-menu-submenu").TriggerEvent("onmouseenter", EventArgs.Empty);
+        await cut.InvokeAsync(() => topExpandable.Instance.Show());
         var midExpandable = topExpandable.FindComponent<AntDesign.Internal.SubMenuTrigger>();
+        midExpandable.Find(".ant-menu-submenu").TriggerEvent("onmouseenter", EventArgs.Empty);
         await topExpandable.InvokeAsync(() => midExpandable.Instance.Show());
         var midOverlay = midExpandable.FindComponent<AntDesign.Internal.Overlay>();
-        //Assert        
+        //Assert
         midOverlay.MarkupMatches(@"
             <div style:ignore class=""ant-menu-submenu   ant-menu-submenu-popup ant-menu ant-menu-light ant-menu-submenu-placement-rightTop ant-slide-up-enter ant-slide-up-enter-active ant-slide-up"">
                 <ul direction=""ltr"" class=""ant-menu ant-menu-sub ant-menu-light ant-menu-vertical"" style=""min-width: 123px"" role=""menu"">
                     <li class=""ant-menu-item"" role=""menuitem"" style="""">
                 		<span class=""ant-menu-title-content"">
-                            Option 1	
+                            Option 1
                 		</span>
 		            </li>
                     <li class=""ant-menu-submenu ant-menu-submenu-vertical"" role=""menuitem"" style=""position:relative;"">
@@ -151,10 +169,10 @@
                                 Option 5
                             </span>
                             <i class=""ant-menu-submenu-arrow""></i>
-                        </div>                
+                        </div>
                     </li>
                 </ul>
-            </div>");           
+            </div>");
     }
 
     [Fact]
@@ -164,20 +182,23 @@
 
         var cut = Render<AntDesign.Menu>(GetBasicHorizontalRender());
         //Act
-        var topExpandable = cut.FindComponent<AntDesign.Internal.SubMenuTrigger>();        
-        await cut.InvokeAsync(() => topExpandable.Instance.Show());        
+        var topExpandable = cut.FindComponent<AntDesign.Internal.SubMenuTrigger>();
+        cut.Find(".ant-menu-submenu").TriggerEvent("onmouseenter", EventArgs.Empty);
+        await cut.InvokeAsync(() => topExpandable.Instance.Show());
         var midExpandable = topExpandable.FindComponent<AntDesign.Internal.SubMenuTrigger>();
+        midExpandable.Find(".ant-menu-submenu").TriggerEvent("onmouseenter", EventArgs.Empty);
         await topExpandable.InvokeAsync(() => midExpandable.Instance.Show());
         var bottomExpandable = midExpandable.FindComponent<AntDesign.Internal.SubMenuTrigger>();
+        bottomExpandable.Find(".ant-menu-submenu").TriggerEvent("onmouseenter", EventArgs.Empty);
         await midExpandable.InvokeAsync(() => bottomExpandable.Instance.Show());
-        var bottomOverlay = bottomExpandable.FindComponent<AntDesign.Internal.Overlay>();              
-        //Assert        
+        var bottomOverlay = bottomExpandable.FindComponent<AntDesign.Internal.Overlay>();
+        //Assert
         bottomOverlay.MarkupMatches(@"
             <div style:ignore class=""ant-menu-submenu   ant-menu-submenu-popup ant-menu ant-menu-light ant-menu-submenu-placement-rightTop ant-slide-up-enter ant-slide-up-enter-active ant-slide-up"">
                 <ul direction=""ltr"" class=""ant-menu ant-menu-sub ant-menu-light ant-menu-vertical"" style=""min-width: 123px"" role=""menu"">
                     <li class=""ant-menu-item"" role=""menuitem"" style="""">
                 		<span class=""ant-menu-title-content"">
-                            Option 1	
+                            Option 1
                 		</span>
 		            </li>
                     <li class=""ant-menu-item"" role=""menuitem"" style="""">


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

fixed #2107
fixed #2739

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fixed Overlay would show after mouse leave the trigger      |
| 🇨🇳 Chinese |   修复 Overlay 会在鼠标离开触发元素之后还打开        |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
