### PR TITLE
fix(module: ResizeObserver): work incorrectly cause by wrong key type

### DIFF
--- a/components/core/JsInterop/DomEventListener.cs
+++ b/components/core/JsInterop/DomEventListener.cs
@@ -38,12 +38,6 @@ namespace AntDesign.JsInterop
             return new DomEventKey(selector, eventName, _id);
         }
 
-        private (string dom, string eventName) ParseKey(string key)
-        {
-            var keyParts = key.Split('-');
-            return (keyParts[1], keyParts[2]);
-        }
-
         public void AddExclusive<T>(object dom, string eventName, Action<T> callback, bool preventDefault = false)
         {
             var key = FormatKey(dom, eventName);
@@ -156,7 +150,7 @@ namespace AntDesign.JsInterop
                 if (!_domEventSubscriptionsStore.ContainsKey(key))
                 {
                     _domEventSubscriptionsStore[key] = new List<DomEventSubscription>();
-                    await _jsRuntime.InvokeVoidAsync(JSInteropConstants.ObserverConstants.Resize.Create, key, DotNetObjectReference.Create(new Invoker<string>((p) =>
+                    await _jsRuntime.InvokeVoidAsync(JSInteropConstants.ObserverConstants.Resize.Create, key.ToString(), DotNetObjectReference.Create(new Invoker<string>((p) =>
                     {
                         for (var i = 0; i < _domEventSubscriptionsStore[key].Count; i++)
                         {
@@ -165,7 +159,7 @@ namespace AntDesign.JsInterop
                             subscription.Delegate.DynamicInvoke(tP);
                         }
                     })));
-                    await _jsRuntime.InvokeVoidAsync(JSInteropConstants.ObserverConstants.Resize.Observe, key, dom);
+                    await _jsRuntime.InvokeVoidAsync(JSInteropConstants.ObserverConstants.Resize.Observe, key.ToString(), dom);
                 }
                 _domEventSubscriptionsStore[key].Add(new DomEventSubscription(callback, typeof(List<ResizeObserverEntry>), _id));
             }
@@ -191,7 +185,7 @@ namespace AntDesign.JsInterop
             var key = FormatKey(dom.Id, nameof(JSInteropConstants.ObserverConstants.Resize));
             if (await IsResizeObserverSupported())
             {
-                await _jsRuntime.InvokeVoidAsync(JSInteropConstants.ObserverConstants.Resize.Dispose, key);
+                await _jsRuntime.InvokeVoidAsync(JSInteropConstants.ObserverConstants.Resize.Dispose, key.ToString());
             }
             _domEventSubscriptionsStore.TryRemove(key, out _);
         }
@@ -201,7 +195,7 @@ namespace AntDesign.JsInterop
             var key = FormatKey(dom.Id, nameof(JSInteropConstants.ObserverConstants.Resize));
             if (await IsResizeObserverSupported())
             {
-                await _jsRuntime.InvokeVoidAsync(JSInteropConstants.ObserverConstants.Resize.Disconnect, key);
+                await _jsRuntime.InvokeVoidAsync(JSInteropConstants.ObserverConstants.Resize.Disconnect, key.ToString());
             }
             if (_domEventSubscriptionsStore.ContainsKey(key))
             {

--- a/components/core/JsInterop/DomEventSubscription.cs
+++ b/components/core/JsInterop/DomEventSubscription.cs
@@ -46,6 +46,11 @@ namespace AntDesign.JsInterop
         }
     }
 
-    public record DomEventKey(string Selector, string EventName, string ListenerId);
-
+    public record DomEventKey(string Selector, string EventName, string ListenerId)
+    {
+        public override string ToString()
+        {
+            return $"{Selector}-{EventName}-{ListenerId}";
+        }
+    }
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fixed ResizeObserver work incorrectly cause by wrong key type        |
| 🇨🇳 Chinese |   修复 ResizeObserver 由于key类型的改动导致无效的问题        |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
