### PR TITLE
Protected selected items' selection sequences;

### DIFF
--- a/components/select/SelectBase.cs
+++ b/components/select/SelectBase.cs
@@ -810,6 +810,7 @@ namespace AntDesign
 
             if (ValuesChanged.HasDelegate)
             {
+                _selectedValues = newSelectedValues;
                 await ValuesChanged.InvokeAsync(newSelectedValues);
             }
             else

--- a/components/select/SelectBase.cs
+++ b/components/select/SelectBase.cs
@@ -808,9 +808,9 @@ namespace AntDesign
                 }
             }
 
+            _selectedValues = newSelectedValues;
             if (ValuesChanged.HasDelegate)
             {
-                _selectedValues = newSelectedValues;
                 await ValuesChanged.InvokeAsync(newSelectedValues);
             }
             else

--- a/tests/AntDesign.Tests/Select/Select.SelectOptions.Tests.razor
+++ b/tests/AntDesign.Tests/Select/Select.SelectOptions.Tests.razor
@@ -157,6 +157,7 @@
         cut.Find(".ant-select-item-option").Click();
         cut.WaitForState(() => itemsChanged);
         cut.Find("input[type=search]").Input("John");
+        cut.WaitForState(() => itemsChanged);
 
         // All items should be hidden because there is only 1 John and it is selected, but HideSelected is true
         cut.FindAll(".ant-select-item-option").Where(x => !x.Attributes["style"]?.Value?.Trim()?.Contains("display:none") ?? true).Count().Should().Be(0);
@@ -208,6 +209,7 @@
         cut.Find(".ant-select-item-option").Click();
         cut.WaitForState(() => itemsChanged);
         cut.Find("input[type=search]").Input(string.Empty);
+        cut.WaitForState(() => itemsChanged);
 
         // All items except John should be visible because John is selected and HideSelected is true
         cut.FindAll(".ant-select-item-option").Where(x => !x.Attributes["style"]?.Value?.Trim()?.Contains("display:none") ?? true).Count().Should().Be(3);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
Issue: Select component can not present the sequence of each selected item.
For example: Select 2, 1 items in Select component, Select'd Values is 1, 2 (reversed sequence) instead of 2,1 (correct sequences)
Solution: Initlaize a private variable to fix the condition.

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
