### PR TITLE
fix(module: notification): RTL incorrect style

### DIFF
--- a/components/core/Base/AntDomComponentBase.cs
+++ b/components/core/Base/AntDomComponentBase.cs
@@ -37,8 +37,6 @@ namespace AntDesign
 
         protected AntDomComponentBase()
         {
-            ClassMapper
-                .Get(() => this.Class);
         }
 
         protected override void OnInitialized()

--- a/components/modal/style/entry.less
+++ b/components/modal/style/entry.less
@@ -1,3 +1,4 @@
 @import './index.less';
 // style dependencies
 @import '../../button/style/entry.less';
+@import './patch.less';

--- a/components/notification/Notification.razor
+++ b/components/notification/Notification.razor
@@ -7,12 +7,14 @@
     var configs = configKv.Value;
     var className = GetClassName(placement);
     var style = GetStyle(placement);
-    <div @key="placement" class="@className" style="@style" @ref="Ref">
-        <span>
-            @foreach (var itemConfig in configs)
-            {
-                <NotificationItem @key="itemConfig" Config="itemConfig" OnClose="RemoveItem" />
-            }
-        </span>
+    <div>
+        <div @key="placement" class="@className" style="@style" @ref="Ref">
+            <div>
+                @foreach (var itemConfig in configs)
+                {
+                    <NotificationItem @key="itemConfig" Config="itemConfig" OnClose="RemoveItem"/>
+                }
+            </div>
+        </div>
     </div>
 }

--- a/components/notification/Notification.razor.cs
+++ b/components/notification/Notification.razor.cs
@@ -63,17 +63,21 @@ namespace AntDesign
 
         private string GetClassName(NotificationPlacement placement)
         {
-            string placementStr = placement.ToString();
+            var placementStr = placement.ToString();
             placementStr = placementStr[0] == 'T'
                 ? "t" + placementStr.Substring(1)
                 : "b" + placementStr.Substring(1);
-            string className = $"{ClassPrefix} {ClassPrefix}-" + placementStr;
+            var className = $"{ClassPrefix} {ClassPrefix}-" + placementStr;
 
-            if (_isRtl)
+            var rtl = RTL;
+            if (_isRtl.HasValue)
+            {
+                rtl = _isRtl.Value;
+            }
+            if (rtl)
             {
                 className += $" {ClassPrefix}-rtl";
             }
-
             return className;
         }
 
@@ -96,7 +100,7 @@ namespace AntDesign
 
         private double _top = 24;
         private double _bottom = 24;
-        private bool _isRtl;
+        private bool? _isRtl;
         private NotificationPlacement _defaultPlacement = NotificationPlacement.TopRight;
         private double _defaultDuration = 4.5;
 
@@ -104,6 +108,7 @@ namespace AntDesign
         {
             builder.OpenComponent<Icon>(0);
             builder.AddAttribute(1, "Type", "close");
+            builder.AddAttribute(2, "Class", $"{ClassPrefix}-notice-close-icon");
             builder.CloseComponent();
         };
 
@@ -127,10 +132,7 @@ namespace AntDesign
             {
                 _top = defaultConfig.Top.Value;
             }
-            if (defaultConfig.Rtl != null)
-            {
-                _isRtl = defaultConfig.Rtl.Value;
-            }
+            _isRtl = defaultConfig.Rtl;
             if (defaultConfig.Placement != null)
             {
                 _defaultPlacement = defaultConfig.Placement.Value;

--- a/components/notification/Notification.razor.cs
+++ b/components/notification/Notification.razor.cs
@@ -69,12 +69,7 @@ namespace AntDesign
                 : "b" + placementStr.Substring(1);
             var className = $"{ClassPrefix} {ClassPrefix}-" + placementStr;
 
-            var rtl = RTL;
-            if (_isRtl.HasValue)
-            {
-                rtl = _isRtl.Value;
-            }
-            if (rtl)
+            if (IsRtl())
             {
                 className += $" {ClassPrefix}-rtl";
             }
@@ -85,6 +80,10 @@ namespace AntDesign
         {
             switch (placement)
             {
+                case NotificationPlacement.Top:
+                    return $"inset: {_top}px auto auto 50%; transform: translateX(-50%);";
+                case NotificationPlacement.Bottom:
+                    return $"inset: auto auto {_bottom}px 50%; transform: translateX(-50%);";
                 case NotificationPlacement.TopRight:
                     return $"right: 0px; top:{_top}px; bottom: auto;";
                 case NotificationPlacement.TopLeft:
@@ -96,12 +95,32 @@ namespace AntDesign
             }
         }
 
+        private bool IsRtl()
+        {
+            var rtl = RTL;
+            if (_isRtl.HasValue)
+            {
+                rtl = _isRtl.Value;
+            }
+            return rtl;
+        }
+
+        private NotificationPlacement GetDefaultPlacement()
+        {
+            if (_defaultPlacement.HasValue)
+            {
+                return _defaultPlacement.Value;
+            }
+
+            return IsRtl() ? NotificationPlacement.TopLeft : NotificationPlacement.TopRight;
+        }
+
         #region GlobalConfig
 
         private double _top = 24;
         private double _bottom = 24;
         private bool? _isRtl;
-        private NotificationPlacement _defaultPlacement = NotificationPlacement.TopRight;
+        private NotificationPlacement? _defaultPlacement;
         private double _defaultDuration = 4.5;
 
         private RenderFragment _defaultCloseIcon = (builder) =>
@@ -133,10 +152,7 @@ namespace AntDesign
                 _top = defaultConfig.Top.Value;
             }
             _isRtl = defaultConfig.Rtl;
-            if (defaultConfig.Placement != null)
-            {
-                _defaultPlacement = defaultConfig.Placement.Value;
-            }
+            _defaultPlacement = defaultConfig.Placement;
             if (defaultConfig.Duration != null)
             {
                 _defaultDuration = defaultConfig.Duration.Value;
@@ -149,7 +165,7 @@ namespace AntDesign
 
         private NotificationConfig ExtendConfig(NotificationConfig config)
         {
-            config.Placement ??= _defaultPlacement;
+            config.Placement ??= GetDefaultPlacement();
             config.Duration ??= _defaultDuration;
             config.CloseIcon ??= _defaultCloseIcon;
 

--- a/components/notification/NotificationItem.razor
+++ b/components/notification/NotificationItem.razor
@@ -2,10 +2,10 @@
 @inherits NotificationBase
 
 <div id="@Config.Key"
-     class="@(ClassPrefix)-notice @(ClassPrefix)-notice-closable @GetClassName()"
-     style="@Config.Style"
-     @onclick="OnClick"
-     @ref="Ref">
+ class="@(ClassPrefix)-notice @(ClassPrefix)-notice-closable @GetClassName()"
+ style="@Config.Style"
+ @onclick="OnClick"
+ @ref="Ref">
 
     <div class="@(ClassPrefix)-notice-content">
         <div class="@GetIconClassName()">
@@ -20,37 +20,37 @@
                 switch (Config.NotificationType)
                 {
                     case NotificationType.Success:
-                        {
-                            <span role="img" aria-label="check-circle" class="anticon anticon-check-circle @(ClassPrefix)-notice-icon @(ClassPrefix)-notice-icon-success">
-                                <Icon Type="check-circle" Theme="outline"></Icon>
-                            </span>
+                    {
+                        <span role="img" aria-label="check-circle" class="anticon anticon-check-circle @(ClassPrefix)-notice-icon @(ClassPrefix)-notice-icon-success">
+                            <Icon Type="check-circle" Theme="outline"></Icon>
+                        </span>
 
-                            break;
-                        }
+                        break;
+                    }
                     case NotificationType.Warning:
-                        {
-                            <span role="img" aria-label="exclamation-circle" class="anticon anticon-exclamation-circle @(ClassPrefix)-notice-icon @(ClassPrefix)-notice-icon-warning">
-                                <Icon Type="exclamation-circle" Theme="outline"></Icon>
-                            </span>
+                    {
+                        <span role="img" aria-label="exclamation-circle" class="anticon anticon-exclamation-circle @(ClassPrefix)-notice-icon @(ClassPrefix)-notice-icon-warning">
+                            <Icon Type="exclamation-circle" Theme="outline"></Icon>
+                        </span>
 
-                            break;
-                        }
+                        break;
+                    }
                     case NotificationType.Error:
-                        {
-                            <span role="img" aria-label="close-circle" class="anticon anticon-close-circle @(ClassPrefix)-notice-icon @(ClassPrefix)-notice-icon-error">
-                                <Icon Type="close-circle" Theme="outline"></Icon>
-                            </span>
+                    {
+                        <span role="img" aria-label="close-circle" class="anticon anticon-close-circle @(ClassPrefix)-notice-icon @(ClassPrefix)-notice-icon-error">
+                            <Icon Type="close-circle" Theme="outline"></Icon>
+                        </span>
 
-                            break;
-                        }
+                        break;
+                    }
                     case NotificationType.Info:
-                        {
-                            <span role="img" aria-label="info-circle" class="anticon anticon-info-circle @(ClassPrefix)-notice-icon @(ClassPrefix)-notice-icon-info">
-                                <Icon Type="info-circle" Theme="outline"></Icon>
-                            </span>
+                    {
+                        <span role="img" aria-label="info-circle" class="anticon anticon-info-circle @(ClassPrefix)-notice-icon @(ClassPrefix)-notice-icon-info">
+                            <Icon Type="info-circle" Theme="outline"></Icon>
+                        </span>
 
-                            break;
-                        }
+                        break;
+                    }
                 }
             }
 
@@ -90,10 +90,8 @@
     </div>
 
     <a tabindex="0" class="@(ClassPrefix)-notice-close" @onclick="Close" @onclick:preventDefault @onclick:stopPropagation>
-        <span class="@(ClassPrefix)-close-x">
-            <span role="img" aria-label="close" class="anticon anticon-close @(ClassPrefix)-close-icon">
-                @Config.CloseIcon
-            </span>
+        <span class="@(ClassPrefix)-notice-close-x">
+            @Config.CloseIcon
         </span>
     </a>
 </div>

--- a/components/notification/style/entry.less
+++ b/components/notification/style/entry.less
@@ -1,1 +1,2 @@
 @import './index.less';
+@import './patch.less';

--- a/components/notification/style/patch.less
+++ b/components/notification/style/patch.less
@@ -1,0 +1,11 @@
+﻿@keyframes NotificationBottomFadeIn {
+    0% {
+        margin-bottom: -100%;
+        opacity: 0;
+    }
+
+    100% {
+        margin-bottom: auto !important;
+        opacity: 1;
+    }
+}

--- a/components/notification/type/NotificationPlacement.cs
+++ b/components/notification/type/NotificationPlacement.cs
@@ -9,6 +9,8 @@ namespace AntDesign
         TopLeft = 0,
         TopRight = 1,
         BottomLeft = 2,
-        BottomRight = 3
+        BottomRight = 3,
+        Top = 4,
+        Bottom = 5,
     }
 }

--- a/site/AntDesign.Docs/App.razor
+++ b/site/AntDesign.Docs/App.razor
@@ -12,9 +12,9 @@
             </LayoutView>
         </NotFound>
     </ConventionRouter>
+    
+    <AntContainer />
 </ConfigProvider>
-
-<AntContainer />
 
 @code{
 

--- a/site/AntDesign.Docs/Demos/Components/Notification/demo/Duration.razor
+++ b/site/AntDesign.Docs/Demos/Components/Notification/demo/Duration.razor
@@ -9,9 +9,9 @@
     {
         await _notice.Open(new NotificationConfig()
         {
-            Message = "title",
+                Message = "Notification Title",
             Duration = 0,
-            Description = "This notification box will not close automatically"
+                Description = "I will never close automatically. This is a purposely very very long description that has many many characters and words."
         });
     }
 }

--- a/site/AntDesign.Docs/Demos/Components/Notification/demo/Placement.razor
+++ b/site/AntDesign.Docs/Demos/Components/Notification/demo/Placement.razor
@@ -1,40 +1,71 @@
 ﻿@inject INotificationService _notice
 
-<div>
-    <Button Type="@ButtonType.Primary" OnClick="@OnTopLeftClick">
-        <Icon Type="Radius-Upleft" Theme="Outline"></Icon>
-        TopLeft
-    </Button>
+<Space>
+    <SpaceItem>
+        <Button Type="@ButtonType.Primary" OnClick="@OnTopClick">
+            <Icon Type="border-top" Theme="Outline"/>
+            Top
+        </Button>
+    </SpaceItem>
+    
+    <SpaceItem>
+        <Button Type="@ButtonType.Primary" OnClick="@OnBottomClick">
+            <Icon Type="border-bottom" Theme="Outline"/>
+            Bottom
+        </Button>
+    </SpaceItem>
+</Space>
+<Divider />
 
-    <Button Type="@ButtonType.Primary" OnClick="@OnTopRightClick">
-        <Icon Type="Radius-Upright" Theme="Outline"></Icon>
-        TopRight
-    </Button>
-</div>
+<Space>
+    <SpaceItem>
+        <Button Type="@ButtonType.Primary" OnClick="@OnTopLeftClick">
+            <Icon Type="radius-upleft" Theme="outline" />
+            TopLeft
+        </Button>
+    </SpaceItem>
 
-<br/>
+    <SpaceItem>
+        <Button Type="@ButtonType.Primary" OnClick="@OnTopRightClick">
+            <Icon Type="radius-upright" Theme="outline" />
+            TopRight
+        </Button>
+    </SpaceItem>
+</Space>
+<Divider />
 
-<div>
-    <Button Type="@ButtonType.Primary" OnClick="@OnBottomLeftClick">
-        <Icon Type="Radius-Bottomleft" Theme="Outline"></Icon>
-        BottomLeft
-    </Button>
 
-    <Button Type="@ButtonType.Primary" OnClick="@OnBottomRightClick">
-        <Icon Type="Radius-Bottomright" Theme="Outline"></Icon>
-        BottomRight
-    </Button>
-</div>
+<Space>
+    <SpaceItem>
+        <Button Type="@ButtonType.Primary" OnClick="@OnBottomLeftClick">
+            <Icon Type="radius-bottomleft" Theme="outline" />
+            BottomLeft
+        </Button>
+    </SpaceItem>
+
+    <SpaceItem>
+        <Button Type="@ButtonType.Primary" OnClick="@OnBottomRightClick">
+            <Icon Type="radius-bottomright" Theme="outline" />
+            BottomRight
+        </Button>
+    </SpaceItem>
+</Space>
+
 
 @code {
     private async Task OpenWithPlacement(NotificationPlacement placement)
     {
-        await _notice.Open(new NotificationConfig()
-        {
-            Message = $"Notification {placement}",
-            Description = "This is the content of the notification. This is the content of the notification. This is the content of the notification.",
-            Placement = placement
-        });
+        var config = new NotificationConfig()
+            {
+                Message = $"Notification {placement} {DateTime.Now :O}",
+                Description = "This is the content of the notification. This is the content of the notification. This is the content of the notification.",
+                Placement = placement
+            };
+#if DEBUG
+        config.Duration = 0;
+#endif
+
+        await _notice.Open(config);
     }
 
     private async Task OnTopLeftClick()
@@ -55,5 +86,15 @@
     private async Task OnBottomRightClick()
     {
         await OpenWithPlacement(NotificationPlacement.BottomRight);
+    }
+
+    private async Task OnBottomClick()
+    {
+        await OpenWithPlacement(NotificationPlacement.Bottom);
+    }
+
+    private async Task OnTopClick()
+    {
+        await OpenWithPlacement(NotificationPlacement.Top);
     }
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [x] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

#3040

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  1. fix(module: notification): RTL incorrect style; <br/> 2. feat(module: notification):  add top and bottom placement support;  <br/> 3. fix(module: modal): patch.less is lost when sync the css; <br/> 4. fix(module: AntDomComponentBase): ClassMapper.ToString() generates Class parameters twice |
| 🇨🇳 Chinese |     1. 修复 notification 在 RTL 下显示异常问题; <br/> 2. notification 新增 top 和 bottom 位置支持;  <br/> 3. 修复 modal 同步样式时导致  patch.less  丢失; <br/> 4. 修复 AntDomComponentBase 中 ClassMapper.ToString() 时重复输出 Class 参数的问题   |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
