### PR TITLE
fix(module: Textarea): Fix Textarea not rendering maxlength on textarea

### DIFF
--- a/components/input/Input.cs
+++ b/components/input/Input.cs
@@ -293,7 +293,18 @@ namespace AntDesign
             _inputString = Value?.ToString();
 
             SetClasses();
+            SetAttributes();
             _isInitialized = true;
+        }
+
+        protected void SetAttributes()
+        {
+            Attributes ??= new Dictionary<string, object>();
+
+            if (MaxLength >= 0 && !Attributes.ContainsKey("maxlength"))
+            {
+                Attributes?.Add("maxlength", MaxLength);
+            }
         }
 
         protected virtual void SetClasses()
@@ -316,13 +327,6 @@ namespace AntDesign
                 .GetIf(() => $"{PrefixCls}-status-{FormItem?.ValidateStatus.ToString().ToLowerInvariant()}", () => FormItem is { ValidateStatus: not FormValidateStatus.Default })
                 .If($"{InputElementSuffixClass}", () => !string.IsNullOrEmpty(InputElementSuffixClass))
                 ;
-
-            Attributes ??= new Dictionary<string, object>();
-
-            if (MaxLength >= 0 && !Attributes.ContainsKey("maxlength"))
-            {
-                Attributes?.Add("maxlength", MaxLength);
-            }
 
             if (AllowClear)
             {
@@ -383,7 +387,9 @@ namespace AntDesign
             {
                 BindOnInput = true;
             }
+
             SetClasses();
+            SetAttributes();
         }
 
         protected virtual Task OnChangeAsync(ChangeEventArgs args)

--- a/tests/AntDesign.Tests/Input/InputTests.razor
+++ b/tests/AntDesign.Tests/Input/InputTests.razor
@@ -6,11 +6,12 @@
 	public void Input_Bordered_sets_class()
 	{
 		//Arrange
-		var cut = Render<AntDesign.Input<string>>(@<AntDesign.Input TValue="string" Bordered="false"/>
-	);
+		var cut = Render<AntDesign.Input<string>>(@<AntDesign.Input TValue="string" Bordered="false"/>);
+
 		//Act
 		ITokenList classList = cut.Find("input").ClassList;		
-		//Assert           
+		
+        //Assert
 		classList.Contains("ant-input-borderless").Should().BeTrue();
 	}
 
@@ -191,6 +192,30 @@
         await Task.Delay(250);
 
         cut.Instance.Value.Should().Be("newValue");
+    }
+
+    [Fact]
+    public void Input_MaxLength_Adds_Attribute_To_Input()
+    {
+        string? value = null;
+        var cut = Render<AntDesign.Input<string>>(@<AntDesign.Input @bind-Value=@value MaxLength="50" />);
+
+        var textAreaElement = cut.Find("input");
+
+        textAreaElement.Attributes.Single(x => x.Name.ToLowerInvariant() == "maxlength").Value.Should().Be("50");
+    }
+
+    [Fact]
+    public void Input_MaxLength_Adds_Attribute_To_Input_After_Initial_Render()
+    {
+        string? value = null;
+        var cut = Render<AntDesign.Input<string>>(@<AntDesign.Input @bind-Value=@value />);
+
+        cut.Find("input").Attributes.SingleOrDefault(x => x.Name.ToLowerInvariant() == "maxlength").Should().BeNull();
+
+        cut.SetParametersAndRender(parameters => parameters.Add(x => x.MaxLength, 50));
+
+        cut.WaitForAssertion(() => cut.Find("input").Attributes.Single(x => x.Name.ToLowerInvariant() == "maxlength").Value.Should().Be("50"));
     }
 
 

--- a/tests/AntDesign.Tests/Input/TextAreaTests.razor
+++ b/tests/AntDesign.Tests/Input/TextAreaTests.razor
@@ -1,37 +1,37 @@
-﻿@inherits AntDesignTestBase	
+﻿@inherits AntDesignTestBase
 @code {
     AntDesign.TextArea.TextAreaInfo _textAreaInfo = new AntDesign.TextArea.TextAreaInfo
-    {
-        LineHeight = 10,
-        PaddingTop = 1,
-        PaddingBottom = 1,
-        BorderBottom = 1,
-        BorderTop = 1
-    };
+            {
+                LineHeight = 10,
+                PaddingTop = 1,
+                PaddingBottom = 1,
+                BorderBottom = 1,
+                BorderTop = 1
+            };
 
 
     private void JSCommonMock()
     {
-        JSInterop.SetupVoid(JSInteropConstants.InputComponentHelper.DisposeResizeTextArea, _ => true);   
+        JSInterop.SetupVoid(JSInteropConstants.InputComponentHelper.DisposeResizeTextArea, _ => true);
     }
 
-	[Fact]
-	public void TextArea_ShowCount_shows_initial_value()
-	{
+    [Fact]
+    public void TextArea_ShowCount_shows_initial_value()
+    {
         //Arrange
         JSCommonMock();
         JSInterop.Setup<AntDesign.TextArea.TextAreaInfo>(JSInteropConstants.InputComponentHelper.GetTextAreaInfo, _ => true)
-            .SetResult(_textAreaInfo);
-		string value = "0123456789";
-		var cut = Render(
+        .SetResult(_textAreaInfo);
+        string value = "0123456789";
+        var cut = Render(
     @<AntDesign.TextArea ShowCount MaxLength=100 Value=@value />);
-		//Act
-		var divWrapper = cut.Find("div");
-		var attribute = divWrapper.GetAttribute("data-count");
-        
-		//Assert           
+        //Act
+        var divWrapper = cut.Find("div");
+        var attribute = divWrapper.GetAttribute("data-count");
+
+        //Assert
         attribute.Should().Be($"{value.Length} / 100");
-	}
+    }
 
     [Fact]
     public void TextArea_ShowCount_without_maxlength()
@@ -39,7 +39,7 @@
         //Arrange
         JSCommonMock();
         JSInterop.Setup<AntDesign.TextArea.TextAreaInfo>(JSInteropConstants.InputComponentHelper.GetTextAreaInfo, _ => true)
-        .SetResult(_textAreaInfo);
+    .SetResult(_textAreaInfo);
         string value = "0123456789";
         var cut = Render(
     @<AntDesign.TextArea ShowCount Value=@value />);
@@ -51,23 +51,23 @@
         attribute.Should().Be($"{value.Length}");
     }
 
-	[Fact]
-	public void TextArea_ShowCount_increase()
-	{
-		//Arrange	
+    [Fact]
+    public void TextArea_ShowCount_increase()
+    {
+        //Arrange
         JSCommonMock();
         JSInterop.Setup<AntDesign.TextArea.TextAreaInfo>(JSInteropConstants.InputComponentHelper.GetTextAreaInfo, _ => true)
             .SetResult(_textAreaInfo);
-		string value = "";
-		string newValue = "newValue";
-		var cut = Render<AntDesign.TextArea>(@<AntDesign.TextArea ShowCount MaxLength=100 Value=@value DebounceMilliseconds="0"/>);
+        string value = "";
+        string newValue = "newValue";
+        var cut = Render<AntDesign.TextArea>(@<AntDesign.TextArea ShowCount MaxLength=100 Value=@value DebounceMilliseconds="0" />);
         //Act
         cut.Find("textarea").Input(newValue);
         cut.Find("textarea").KeyUp(String.Empty);
         cut.Render();
         var divWrapper = cut.Find("div");
         var attribute = divWrapper.GetAttribute("data-count");
-        //Assert				
+        //Assert
         attribute.Should().Be($"{newValue.Length} / 100");
     }
 
@@ -78,14 +78,46 @@
         JSCommonMock();
         JSInterop.Setup<AntDesign.TextArea.TextAreaInfo>(JSInteropConstants.InputComponentHelper.GetTextAreaInfo, _ => true)
             .SetResult(_textAreaInfo);
-        var cut = Render<AntDesign.TextArea>(@<AntDesign.TextArea ReadOnly Value="@("0123456789")"/>);
-		//Act
-		var textAreaElement = cut.Find("textarea");
-		//Assert           
-		textAreaElement.HasAttribute("readonly");
-	}
+        var cut = Render<AntDesign.TextArea>(@<AntDesign.TextArea ReadOnly Value="@("0123456789")" />);
+        //Act
+        var textAreaElement = cut.Find("textarea");
+        //Assert
+        textAreaElement.HasAttribute("readonly");
+    }
 
-	@*[Fact]
+    [Fact]
+    public void TextArea_MaxLength_Adds_Attribute_To_Textarea()
+    {
+        JSCommonMock();
+        JSInterop
+            .Setup<TextArea.TextAreaInfo>(JSInteropConstants.InputComponentHelper.GetTextAreaInfo, _ => true)
+            .SetResult(_textAreaInfo);
+
+        var cut = Render<TextArea>(@<TextArea MaxLength="50" />);
+
+        var textAreaElement = cut.Find("textarea");
+
+        textAreaElement.Attributes.Single(x => x.Name.ToLowerInvariant() == "maxlength").Value.Should().Be("50");
+    }
+
+    [Fact]
+    public void TextArea_MaxLength_Adds_Attribute_To_Textarea_After_Initial_Render()
+    {
+        JSCommonMock();
+        JSInterop
+            .Setup<TextArea.TextAreaInfo>(JSInteropConstants.InputComponentHelper.GetTextAreaInfo, _ => true)
+            .SetResult(_textAreaInfo);
+
+        var cut = Render<TextArea>(@<TextArea />);
+
+        cut.Find("textarea").Attributes.SingleOrDefault(x => x.Name.ToLowerInvariant() == "maxlength").Should().BeNull();
+
+        cut.SetParametersAndRender(parameters => parameters.Add(x => x.MaxLength, 50));
+
+        cut.WaitForAssertion(() => cut.Find("textarea").Attributes.Single(x => x.Name.ToLowerInvariant() == "maxlength").Value.Should().Be("50"));
+    }
+
+    @*[Fact]
 	public void TextArea_Rows_creates_with_expected_height()
 	{
         //Arrange
@@ -106,7 +138,7 @@
         styleAttribute.Should().Contain($"height: {expectedHeight}px");
 	}*@
 
-	@*[Fact]
+    @*[Fact]
 	public void TextArea_MinRows_creates_with_expected_height()
 	{
         //Arrange
@@ -127,31 +159,31 @@
         styleAttribute.Should().Contain($"height: {expectedHeight}px");
 	}*@
 
-	[Fact]
-	public void TextArea_AutoSize_is_true_when_MinRows_set()
-	{
+    [Fact]
+    public void TextArea_AutoSize_is_true_when_MinRows_set()
+    {
         //Arrange
         JSCommonMock();
         JSInterop.Setup<AntDesign.TextArea.TextAreaInfo>(JSInteropConstants.InputComponentHelper.RegisterResizeTextArea, _ => true)
             .SetResult(_textAreaInfo);
-        var cut = Render<AntDesign.TextArea>(@<AntDesign.TextArea MinRows="1" AutoSize="false"/>);
+        var cut = Render<AntDesign.TextArea>(@<AntDesign.TextArea MinRows="1" AutoSize="false" />);
         //Act && Assert
         cut.Instance.AutoSize.Should().BeTrue();
-	}
+    }
 
-	[Fact]
-	public void TextArea_AutoSize_is_true_when_MaxRows_set()
-	{
+    [Fact]
+    public void TextArea_AutoSize_is_true_when_MaxRows_set()
+    {
         //Arrange
         JSCommonMock();
         JSInterop.Setup<AntDesign.TextArea.TextAreaInfo>(JSInteropConstants.InputComponentHelper.RegisterResizeTextArea, _ => true)
             .SetResult(_textAreaInfo);
-        var cut = Render<AntDesign.TextArea>(@<AntDesign.TextArea MaxRows="4" AutoSize="false"/>);
+        var cut = Render<AntDesign.TextArea>(@<AntDesign.TextArea MaxRows="4" AutoSize="false" />);
         //Act && Assert
         cut.Instance.AutoSize.Should().BeTrue();
-	}
+    }
 
-	@*[Fact]
+    @*[Fact]
 	public void TextArea_MaxRows_will_take_precedence_over_Rows()
 	{
         //Arrange


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [X] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [X] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
#3104 
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
Textarea is no longer rendering max length onto the markup - this fixes that and adds tests to prevent a regression.
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix(module: Textarea): Fix Textarea not rendering maxlength on textarea |
| 🇨🇳 Chinese | fix(module: Textarea)：修复 Textarea 不在 textarea 上渲染 maxlength |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] Changelog is provided or not needed
