### PR TITLE
fix(module: tabs): rewrite the logic of ReuseTabs about tab key

### DIFF
--- a/components/tabs/Reuse/ReuseTabs.razor.cs
+++ b/components/tabs/Reuse/ReuseTabs.razor.cs
@@ -39,8 +39,8 @@ namespace AntDesign
 
         private string CurrentUrl
         {
-            get => GetNewKeyByUrl(Navmgr.ToBaseRelativePath(Navmgr.Uri));
-            set => Navmgr.NavigateTo(value);
+            get => Navmgr.ToBaseRelativePath(Navmgr.Uri) == "" ? "/" : Navmgr.ToBaseRelativePath(Navmgr.Uri);
+            set => Navmgr.NavigateTo(value == "/" ? "" : value);
         }
 
         private ReuseTabsPageItem[] Pages => _pageMap.Values.Where(x => !x.Ignore).OrderBy(x => x.CreatedAt).ToArray();
@@ -52,8 +52,6 @@ namespace AntDesign
 
         protected override void OnInitialized()
         {
-            ReuseTabsService.GetNewKeyByUrl += GetNewKeyByUrl;
-
             ReuseTabsService.OnClosePage += RemovePage;
             ReuseTabsService.OnCloseOther += RemoveOther;
             ReuseTabsService.OnCloseAll += RemoveAll;
@@ -63,8 +61,6 @@ namespace AntDesign
 
         protected override void Dispose(bool disposing)
         {
-            ReuseTabsService.GetNewKeyByUrl -= GetNewKeyByUrl;
-
             ReuseTabsService.OnClosePage -= RemovePage;
             ReuseTabsService.OnCloseOther -= RemoveOther;
             ReuseTabsService.OnCloseAll -= RemoveAll;
@@ -184,8 +180,6 @@ namespace AntDesign
 
         public void AddReuseTabsPageItem(string url, Type pageType)
         {
-            url = this.GetNewKeyByUrl(url);
-
             if (_pageMap.ContainsKey(url)) return;
 
             var reuseTabsPageItem = new ReuseTabsPageItem();
@@ -235,10 +229,7 @@ namespace AntDesign
             StateHasChanged();
         }
 
-        private string GetNewKeyByUrl(string url)
-        {
-            return GetNewKeyByUrlBase(url);
-        }
+
 
         public void RemovePageBase(string key)
         {
@@ -256,13 +247,5 @@ namespace AntDesign
             }
         }
 
-        public string GetNewKeyByUrlBase(string url)
-        {
-            if (url == "")
-            {
-                url = "/";
-            }
-            return url;
-        }
     }
 }

--- a/components/tabs/Reuse/ReuseTabsService.cs
+++ b/components/tabs/Reuse/ReuseTabsService.cs
@@ -3,9 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
-using System.Text;
-using Microsoft.AspNetCore.Components;
 
 namespace AntDesign
 {
@@ -21,16 +18,16 @@ namespace AntDesign
 
         internal event Action OnUpdate;
 
-        internal event Func<string, string> GetNewKeyByUrl;
+
 
         public void ClosePage(string key)
         {
-            OnClosePage?.Invoke(GetNewKeyByUrl?.Invoke(key));
+            OnClosePage?.Invoke(key);
         }
 
         public void CloseOther(string key)
         {
-            OnCloseOther?.Invoke(GetNewKeyByUrl.Invoke(key));
+            OnCloseOther?.Invoke(key);
         }
 
         public void CloseAll()


### PR DESCRIPTION
[fix3152](https://github.com/ant-design-blazor/ant-design-blazor/issues/3152)

Rewrite the logic of ReuseTabs about the tab key. In fact, the logic of GetNewKeyByUrl does not need to be a separate method. The value of the tab key is mainly derived from CurrentUrl, so use the ternary operator directly for the default page when the get set of CurrentUrl When it is an empty string, it is temporarily replaced with /, and adjusted to a real empty string when actually jumping

重写了 ReuseTabs 关于 tab key 的逻辑，之前其中 GetNewKeyByUrl 的逻辑其实没必要单独独立一个方法，tab key 的取值主要是源自 CurrentUrl，所以直接在 CurrentUrl 的 get set 时利用三元运算符针对 默认页时为 空字符串的情况进行了临时替换为 / ，并在实际跳转时调整为真实的 空字符串