### PR TITLE
fix(module: checkbox):  CheckboxGroup will report an error when the internal Checkbox is null

### DIFF
--- a/components/checkbox/CheckboxGroup.razor.cs
+++ b/components/checkbox/CheckboxGroup.razor.cs
@@ -173,7 +173,7 @@ namespace AntDesign
         {
             if (firstRender)
             {
-                if (ChildContent is not null && _checkboxItems.Count > 0)
+                if (ChildContent is not null && _checkboxItems?.Count > 0)
                 {
                     _constructedOptions = CreateConstructedOptions();
                 }


### PR DESCRIPTION
fix(module: checkbox):  CheckboxGroup will report an error when the internal Checkbox is null
[fix3161](https://github.com/ant-design-blazor/ant-design-blazor/issues/3161)