### PR TITLE
Change Calculation of Calendarweek for WeekPicker

### DIFF
--- a/components/date-picker/RangePicker.razor.cs
+++ b/components/date-picker/RangePicker.razor.cs
@@ -121,8 +121,11 @@ namespace AntDesign
 
                 if (Picker == DatePickerType.Week)
                 {
-                    var date1Week = DateHelper.GetWeekOfYear(date1, Locale.FirstDayOfWeek);
-                    var date2Week = DateHelper.GetWeekOfYear(date2, Locale.FirstDayOfWeek);
+                    var calendar = CultureInfo.Calendar;
+                    var calendarWeekRule = CultureInfo.DateTimeFormat.CalendarWeekRule;
+                    
+                    var date1Week = calendar.GetWeekOfYear(date1,calendarWeekRule, Locale.FirstDayOfWeek);
+                    var date2Week = calendar.GetWeekOfYear(date2, calendarWeekRule, Locale.FirstDayOfWeek);
                     return index == 0 ? date1Week < date2Week && date1.Year <= date2.Year
                                         : date1.Year >= date2.Year && date1Week > date2Week;
                 }

--- a/components/date-picker/internal/DatePickerBase.cs
+++ b/components/date-picker/internal/DatePickerBase.cs
@@ -829,7 +829,7 @@ namespace AntDesign
             if (string.IsNullOrEmpty(Format))
                 format = _pickerStatus[index].InitPicker switch
                 {
-                    DatePickerType.Week => $"{Locale.Lang.YearFormat}-{DateHelper.GetWeekOfYear(value, Locale.FirstDayOfWeek)}{Locale.Lang.Week}",
+                    DatePickerType.Week => $"{Locale.Lang.YearFormat}-{CultureInfo.Calendar.GetWeekOfYear(value,CultureInfo.DateTimeFormat.CalendarWeekRule, Locale.FirstDayOfWeek)}'{Locale.Lang.Week}'",
                     DatePickerType.Quarter => $"{Locale.Lang.YearFormat}-{DateHelper.GetDayOfQuarter(value)}",
                     _ => InternalFormat,
                 };

--- a/components/date-picker/internal/DatePickerDatePanel.razor
+++ b/components/date-picker/internal/DatePickerDatePanel.razor
@@ -5,6 +5,7 @@
 
 @{
     var calendar = CultureInfo.Calendar;
+    var calendarWeekRule = CultureInfo.DateTimeFormat.CalendarWeekRule;
 
     DateTime monthFirstDayDate = new DateTime(PickerValue.Year, PickerValue.Month, 1, 0, 0, 0);
     int monthFirstDayOfWeek = (int)calendar.GetDayOfWeek(monthFirstDayDate);
@@ -71,8 +72,8 @@
         <RenderFirstCol>
             @if (IsWeek)
             {
-                <td class="@(PrefixCls)-cell @(PrefixCls)-cell-weak">
-                    @DateHelper.GetWeekOfYear(context, Locale.FirstDayOfWeek)
+                <td class="@(PrefixCls)-cell @(PrefixCls)-cell-weak">  
+                    @calendar.GetWeekOfYear(context,calendarWeekRule, Locale.FirstDayOfWeek)
                 </td>
             }
         </RenderFirstCol>


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

The WeekPicker is currently using DateHelper.GetWeekOfYear(DateTime date, DayOfWeek firstDay) for the calculation of the Week number. DateHelper is using the InvariantCulture. 

FirstDayOfWeek of the InvariantCulture is Sunday
For example, for de-DE culture, the default value of FirstDayOfWeek is Monday

Additionaly CalendarWeekRule of InvariantCulture is FirstDay
For de-DE it is FirstFourDayWeek

those differences result in different Weeknumbers for both cultures.
For Example the 3rd April 2023 is Week 15 for Invariant and 14 for de-DE

To resolve this Issue we can use the CultureInfo Property of the DatePicker

```
var calendar = CultureInfo.Calendar;
var calendarWeekRule = CultureInfo.DateTimeFormat.CalendarWeekRule;
var week = calendar.GetWeekOfYear(date1,calendarWeekRule, Locale.FirstDayOfWeek);
```

Another Issue with the german Culture is the Translation for "Week" it contains an 'h' which is also a reserved letter for the time format and will be replaced with the current hour. 
The fix for this is to escape the string with quotation marks


### 📝 Changelog

Change calculation of Week of Year for WeekPicker<TValue>, changes the displayed WeekNumber in the DropDownPanel and in the SelectedValue display 



| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
