### PR TITLE
Fix: Add `type="button"` to Drawer close button.

### DIFF
--- a/components/drawer/Drawer.razor
+++ b/components/drawer/Drawer.razor
@@ -27,7 +27,7 @@
                             }
                             @if (Closable)
                             {
-                                <button @onclick="_=>CloseClick()" aria-label="Close" class="ant-drawer-close">
+                                <button @onclick="_=>CloseClick()" type="button" aria-label="Close" class="ant-drawer-close">
                                     <Icon Type="close" />
                                 </button>
                             }

--- a/tests/AntDesign.Tests/Drawer/DrawerTests.cs
+++ b/tests/AntDesign.Tests/Drawer/DrawerTests.cs
@@ -33,7 +33,7 @@ namespace AntDesign.Tests.Drawer
                     <div class=""ant-drawer-content"">
                         <div class=""ant-drawer-wrapper-body"" style=""{bodyWrapperStyle}"">
                             <div class=""ant-drawer-header-no-title"">
-                                <button aria-label=""Close"" class=""ant-drawer-close"">
+                                <button type=""button"" aria-label=""Close"" class=""ant-drawer-close"">
                                     <span role=""img"" class=""anticon anticon-close"" id:ignore>
                                         <svg focusable=""false"" width=""1em"" height=""1em"" fill=""currentColor""
                                             style=""pointer-events: none;"" xmlns=""http://www.w3.org/2000/svg"" class=""icon""
@@ -69,7 +69,7 @@ namespace AntDesign.Tests.Drawer
                     <div class=""ant-drawer-content"">
                         <div class=""ant-drawer-wrapper-body"" style=""{bodyWrapperStyle}"">
                             <div class=""ant-drawer-header-no-title"">
-                                <button aria-label=""Close"" class=""ant-drawer-close"">
+                                <button type=""button"" aria-label=""Close"" class=""ant-drawer-close"">
                                     <span role=""img"" class=""anticon anticon-close"" id:ignore>
                                         <svg focusable=""false"" width=""1em"" height=""1em"" fill=""currentColor""
                                             style=""pointer-events: none;"" xmlns=""http://www.w3.org/2000/svg"" class=""icon""


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [X] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

-

### 💡 Background and solution

Without this close button triggers form submit if drawer is defined within form (<button> without type specified defaults to form submit behavior).

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Added `type="button"` to close button in Drawer  component  |
| 🇨🇳 Chinese |           |

Should not break anything or require changes from user side.

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] Changelog is provided or not needed
