### PR TITLE
feat(module:tree-select): Use attribute splatting for internal tree

### DIFF
--- a/components/tree-select/TreeSelect.razor
+++ b/components/tree-select/TreeSelect.razor
@@ -51,6 +51,7 @@
                         MatchedStyle="@MatchedStyle"
                         MatchedClass="@MatchedClass"
                         SearchValue="@_searchValue"
+                        @attributes="TreeAttributes"
                   >
                     <Nodes>
                       @if (IsTemplatedNodes)

--- a/components/tree-select/TreeSelect.razor.cs
+++ b/components/tree-select/TreeSelect.razor.cs
@@ -79,6 +79,8 @@ namespace AntDesign
         [Parameter] public bool ShowTreeLine { get; set; }
 
         [Parameter] public bool ShowLeafIcon { get; set; }
+        
+        [Parameter] public IDictionary<string, object> TreeAttributes { get; set; }
 
         /// <summary>
         /// Specifies a method that returns the text of the node.


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->
I wanted to use the `OnNodeLoadDelayAsync` for `TreeSelect`. Essentially the same problem as #2939, that the parameter could not be given. This time I decided to fix it by using attribute splatting, so that all `Tree` attributes can be accessed in `TreeSelect`.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  All additional parameters of `Tree` that can't be given to `TreeSelect` directly can now be given in a dictionary to the `TreeAttributes` parameter |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
