### PR TITLE
Revert "add `SimplifySearchResults ` to hide the nodes without any matched parent or child from the search results"

### DIFF
--- a/components/tree/Tree.razor.cs
+++ b/components/tree/Tree.razor.cs
@@ -429,12 +429,6 @@ namespace AntDesign
         [Parameter]
         public string MatchedClass { get; set; }
 
-        /// <summary>
-        /// Determine whether to simplify the search results
-        /// </summary>
-        [Parameter]
-        public bool SimplifySearchResults { get; set; }
-
         private void SearchNodes()
         {
             var allList = _allNodes.ToList();

--- a/components/tree/TreeNode.razor.cs
+++ b/components/tree/TreeNode.razor.cs
@@ -60,26 +60,6 @@ namespace AntDesign
         internal bool IsLastNode => NodeIndex == (ParentNode?.ChildNodes.Count ?? TreeComponent?.ChildNodes.Count) - 1;
 
         /// <summary>
-        /// Determine whether it should be hidden from the search reaults.
-        /// </summary>
-        internal bool SearchHidden
-        {
-            get
-            {
-                if (!TreeComponent.SimplifySearchResults)
-                    return false;
-
-                if (string.IsNullOrWhiteSpace(TreeComponent.SearchValue))
-                    return false;
-
-                if (Matched || HasChildNodeMatched() || HasParentNodeMatched())
-                    return false;
-
-                return true;
-            }
-        }
-
-        /// <summary>
         /// add node to parent node
         /// </summary>
         /// <param name="treeNode"></param>
@@ -309,7 +289,6 @@ namespace AntDesign
                 .If("ant-tree-treenode-checkbox-indeterminate", () => Indeterminate)
                 .If("ant-tree-treenode-selected", () => Selected)
                 .If("ant-tree-treenode-loading", () => Loading)
-                .If("ant-tree-treenode-search-hidden", () => SearchHidden)
                 .If("drop-target", () => DragTarget)
                 .If("drag-over-gap-bottom", () => DragTarget && DragTargetBottom)
                 .If("drag-over", () => DragTarget && !DragTargetBottom)
@@ -476,7 +455,6 @@ namespace AntDesign
                 TreeComponent.AddOrRemoveCheckNode(this);
             StateHasChanged();
         }
-
         /// <summary>
         /// Set the checkbox state when ini
         /// </summary>
@@ -511,7 +489,6 @@ namespace AntDesign
                 foreach (var child in subnode.ChildNodes)
                     child?.SetChildChecked(child, check);
         }
-
         /// <summary>
         /// Sets the checkbox status of child nodes whern bind default
         /// </summary>
@@ -525,7 +502,7 @@ namespace AntDesign
             if (subnode.HasChildNodes)
                 foreach (var child in subnode.ChildNodes)
                     child?.SetChildCheckedDefault(child, check);
-        }
+        }        
 
         /// <summary>
         /// Update check status
@@ -590,7 +567,6 @@ namespace AntDesign
             if (ParentNode == null)
                 StateHasChanged();
         }
-
         /// <summary>
         /// Update check status when bind default
         /// </summary>
@@ -716,31 +692,9 @@ namespace AntDesign
         public bool Matched { get; set; }
 
         /// <summary>
-        /// Whether there is a matched child node
+        /// 子节点存在满足搜索条件，所以夫节点也需要显示
         /// </summary>
-        public bool HasChildNodeMatched()
-        {
-            if (!HasChildNodes)
-            {
-                return false;
-            }
-
-            return ChildNodes.Any(child => child.Matched || child.HasChildNodeMatched());
-        }
-
-        /// <summary>
-        /// Whether there is a matched parent node
-        /// </summary>
-        public bool HasParentNodeMatched()
-        {
-            if (ParentNode == null)
-                return false;
-
-            if (ParentNode.Matched)
-                return true;
-
-            return ParentNode.HasParentNodeMatched();
-        }
+        internal bool HasChildMatched { get; set; }
 
         #endregion Title
 

--- a/components/tree/style/patch.less
+++ b/components/tree/style/patch.less
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://github.com/ant-design-blazor/ng-zorro-antd/blob/master/LICENSE
  */
@@ -10,8 +10,4 @@
 .@{tree-prefix-cls}-child-tree {
   // The overflow of the collapse animation in edge and IE is invalid
   overflow: hidden;
-}
-
-.@{tree-node-prefix-cls}-search-hidden {
-  display: none !important;
 }

--- a/site/AntDesign.Docs/Demos/Components/Tree/demo/Search_.razor
+++ b/site/AntDesign.Docs/Demos/Components/Tree/demo/Search_.razor
@@ -1,11 +1,7 @@
-﻿<div>
-    <div style="margin-bottom: 16px">
-		simplifySearchResults: <Switch @bind-Checked="_simplifySearchResults" />
-	</div>
-    <Search @bind-Value="@searchKey" Placeholder="Search.." BindOnInput />
+<div>
+    <Search @bind-Value="@searchKey" Placeholder="Search.." />
     <Tree ShowIcon
           SearchValue="@searchKey"
-          SimplifySearchResults="@_simplifySearchResults"
           MatchedClass="site-tree-search-value"
           DataSource="datas"
           TitleExpression="x => x.DataItem.Title"
@@ -19,7 +15,6 @@
 </style>
 
 @code {
-    bool _simplifySearchResults = false;
     string searchKey;
 
     List<Data> datas = new List<Data>()

--- a/site/AntDesign.Docs/Demos/Components/Tree/demo/search.md
+++ b/site/AntDesign.Docs/Demos/Components/Tree/demo/search.md
@@ -1,4 +1,4 @@
-﻿---
+---
 order: 4
 title:
   zh-CN: 可搜索
@@ -7,11 +7,11 @@ title:
 
 ## zh-CN
 
-可搜索的树。可以使用 `SearchExpression` 来自定义匹配规则。使用 `SimplifySearchResults` 来简化搜索结果，隐藏父节点或子节点均不匹配的节点。
+可搜索的树。可以使用 `SearchExpression` 来自定义匹配规则。
 
 ## en-US
 
-Searchable Tree. You also can use `SearchExpression` to customize the matching rules, use `SimplifySearchResults` to hide the nodes without any matched parent or child from the search results.
+Searchable Tree. You also can use `SearchExpression` to customize the matching rules.
 
 
 <style>

--- a/site/AntDesign.Docs/Demos/Components/Tree/doc/index.en-US.md
+++ b/site/AntDesign.Docs/Demos/Components/Tree/doc/index.en-US.md
@@ -1,4 +1,4 @@
-ï»¿---
+---
 category: Components
 type: Data Display
 title: Tree
@@ -24,7 +24,7 @@ Almost anything can be represented in a tree structure. Examples include directo
 | Draggable | Whether the node allows drag and drop | boolean | false |  |
 | BlockNode | Whether treeNode fill remaining horizontal space | boolean | false |  |
 | ShowLeafIcon | Displays the cotyledon icon | boolean | false |  |
-| SwitcherIcon | Customize toggle icon the value is Icon types | string | null | |
+| SwitcherIcon | Customize toggle icon£¬the value is Icon types | string | null | |
 | Selectable | Whether can be selected | boolean | true |  |
 | DefaultSelectedKeys | Specifies the keys of the default selected treeNodes | string[] | null |  |
 | Multiple  |  Allows selecting multiple treeNodes | boolean | false  |   |
@@ -36,7 +36,6 @@ Almost anything can be represented in a tree structure. Examples include directo
 | SearchExpression  | Customized matching expression  |  Func\<TreeNode\<TItem\>, bool\> | null  |   |
 | MatchedStyle  | Search for matching text styles | string  | null  |   |
 | MatchedClass | The  class name of matching text | string | null |  |
-| SimplifySearchResults  | Whether to hide the nodes without any matched parent or child |  boolean | false  |   |
 | DataSource | bing datasource | List  |  null  |   |
 | TitleExpression  |  Specifies a method that returns the text of the node. | Func  |   |   |
 | KeyExpression |  Specifies a method that returns the key of the node. |  Func |   |   |
@@ -50,7 +49,7 @@ Almost anything can be represented in a tree structure. Examples include directo
 | ExpandedKeys  |  (Controlled) expands the specified tree node | string[]  |  null  |   |
 | AutoExpandParent | Whether to automatically expand a parent treeNode | bool | false |  |
 
-### Bind
+### Bind °ó¶¨Öµ
 
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
@@ -65,7 +64,7 @@ Almost anything can be represented in a tree structure. Examples include directo
 
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
-| OnNodeLoadDelayAsync  |   Lazy load callbacks. You must use async and the return type is Task, otherwise you may experience load lag and display problems | EventCallback  |   |   |
+| OnNodeLoadDelayAsync  |   Lazy load callbacks ¡£You must use async and the return type is Task, otherwise you may experience load lag and display problems | EventCallback  |   |   |
 | OnClick |  Click the tree node callback | EventCallback  |   |   |
 | OnDblClick | Double-click the node callback  |  EventCallback |   |   |
 | OnContextMenu  |  Right-click tree node callback | EventCallback  |  |   |
@@ -75,7 +74,7 @@ Almost anything can be represented in a tree structure. Examples include directo
 | OnDragEnter |  Called when drag and drop into a releasable target  | EventCallback  |   |   |
 | OnDragLeave | Called when drag and drop away from a releasable target  | EventCallback  |   |   |
 | OnDrop | Triggered when drag-and-drop drops succeed  | EventCallback  |   |   |
-| OnDragEnd | Drag-and-drop end callback, this callback method must be set  | EventCallback  |   |   |
+| OnDragEnd | Drag-and-drop end callback ¡£this callback method must be set  | EventCallback  |   |   |
 
 ### Tree Functions
 
@@ -108,5 +107,5 @@ Almost anything can be represented in a tree structure. Examples include directo
 | Icon | icon  |  string |  false |   |
 | IconTemplate | icon template | RenderFragment | null |  |
 | DataItem | dataitem |  Type |  |   | 
-| SwitcherIcon | Customize node toggle icon, the value is Icon types  | string | null | |
+| SwitcherIcon | Customize node toggle icon £¬the value is Icon types  | string | null | |
 | SwitcherIconTemplate | SwitcherIcon template | RenderFragment | null | |

--- a/site/AntDesign.Docs/Demos/Components/Tree/doc/index.zh-CN.md
+++ b/site/AntDesign.Docs/Demos/Components/Tree/doc/index.zh-CN.md
@@ -1,4 +1,4 @@
-﻿---
+---
 category: Components
 type: 数据展示
 title: Tree
@@ -37,7 +37,6 @@ cover: https://gw.alipayobjects.com/zos/alicdn/Xh-oWqg9k/Tree.svg
 | SearchExpression  | 自定义搜索匹配方法  |  Func\<TreeNode\<TItem\>, bool\> | null  |   |
 | MatchedStyle  | 搜索匹配关键字高亮样式 | string  | null  |   |
 | MatchedClass  | 搜索匹配关键字高亮样式 | string  | null  |   |
-| SimplifySearchResults  | 简化搜索结果，隐藏父节点或子节点均无匹配的节点 |  boolean | false  |   |
 | DataSource | 数据源 | List  |  null  |   |
 | TitleExpression  |  指定一个方法，该表达式返回节点的文本。 | Func  |   |   |
 | KeyExpression |  指定一个返回节点Key的方法。 |  Func |   |   |


### PR DESCRIPTION
Reverts ant-design-blazor/ant-design-blazor#3221

#3242 is better implement.