### PR TITLE
 fix(module: tree): Fix search crash issue after Tree custom SearchExpression

### DIFF
--- a/components/tree/TreeNodeTitle.razor
+++ b/components/tree/TreeNodeTitle.razor
@@ -37,25 +37,38 @@
         else
         {
             <span class="ant-tree-title" style="pointer-events: none;">
+
+
                 @if (SelfNode.TitleTemplate != null)
                 {
                     @SelfNode.TitleTemplate
-                }
-                else if (SelfNode.Matched && !string.IsNullOrWhiteSpace(TreeComponent.SearchValue))
-                {
-                    int index = SelfNode.Title.IndexOf(TreeComponent.SearchValue, StringComparison.InvariantCultureIgnoreCase);
-                    var start = SelfNode.Title.Substring(0, index);
-                    var match = SelfNode.Title.Substring(index, TreeComponent.SearchValue.Length);
-                    var end = SelfNode.Title.Substring(index + TreeComponent.SearchValue.Length);
-                    var value = $"{start}<span class=\"{TreeComponent.MatchedClass}\" style=\"{TreeComponent.MatchedStyle}\">{match}</span>{end}";
-                    <span>
-                       @((MarkupString)value)
-                    </span>
+                    return;
                 }
                 else
                 {
-                    @SelfNode.Title
+                    bool shouldMarkup = SelfNode.Matched && !string.IsNullOrWhiteSpace(TreeComponent.SearchValue);
+                    int index = -1;
+                    if (shouldMarkup)
+                    {
+                        index = SelfNode.Title.IndexOf(TreeComponent.SearchValue, StringComparison.InvariantCultureIgnoreCase);
+                    }
+
+                    if (shouldMarkup && (index > -1))
+                    {
+                        var start = SelfNode.Title.Substring(0, index);
+                        var match = SelfNode.Title.Substring(index, TreeComponent.SearchValue.Length);
+                        var end = SelfNode.Title.Substring(index + TreeComponent.SearchValue.Length);
+                        var value = $"{start}<span class=\"{TreeComponent.MatchedClass}\" style=\"{TreeComponent.MatchedStyle}\">{match}</span>{end}";
+                        <span>
+                            @((MarkupString)value)
+                        </span>
+                    }
+                    else
+                    {
+                        @SelfNode.Title
+                    }
                 }
+ 
             </span>
         }
         @if (SelfNode.DragTarget)

--- a/components/tree/TreeNodeTitle.razor
+++ b/components/tree/TreeNodeTitle.razor
@@ -37,12 +37,9 @@
         else
         {
             <span class="ant-tree-title" style="pointer-events: none;">
-
-
                 @if (SelfNode.TitleTemplate != null)
                 {
                     @SelfNode.TitleTemplate
-                    return;
                 }
                 else
                 {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
- Tree自定义SearchExpression后Title中不包括过滤内容导致的bug
- 判断要匹配字符串在Title内的index，只有 index>-1才做匹配高亮
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
