### PR TITLE
fix(module: tree): fix IList `DataSource` cannot be modify in place

### DIFF
--- a/components/tree/TreeNode.razor.cs
+++ b/components/tree/TreeNode.razor.cs
@@ -713,7 +713,14 @@ namespace AntDesign
             get
             {
                 if (TreeComponent.ChildrenExpression != null)
-                    return TreeComponent.ChildrenExpression(this)?.ToList() ?? new List<TItem>();
+                {
+                    var childItems = TreeComponent.ChildrenExpression(this);
+                    if (childItems is IList<TItem> list)
+                    {
+                        return list;
+                    }
+                    return childItems?.ToList() ?? new List<TItem>();
+                }
                 else
                     return new List<TItem>();
             }
@@ -728,7 +735,7 @@ namespace AntDesign
             if (this.ParentNode != null)
                 return this.ParentNode.ChildDataItems;
             else
-                return this.TreeComponent.DataSource.ToList();
+                return this.TreeComponent.DataSource as IList<TItem> ?? this.TreeComponent.DataSource.ToList();
         }
 
         #endregion data binding

--- a/tests/AntDesign.Tests/Tree/TreeTests.razor
+++ b/tests/AntDesign.Tests/Tree/TreeTests.razor
@@ -1,0 +1,104 @@
+﻿@inherits AntDesignTestBase
+
+@code {
+
+    record Item(string Name)
+    {
+        public List<Item> Children { get; set; } = new();
+    };
+
+    [Fact]
+    public async Task Parent_MoveDown_item_mutate_datasource()
+    {
+        var data = new List<Item>
+        {
+            new Item("Item 1"),
+            new Item("Item 2"),
+        };
+
+        var cut = Render<Tree<Item>>(@<Tree TItem="Item" DataSource="data"/>);
+        var firstItem = cut.FindComponent<TreeNode<Item>>();
+
+        var firstItemIndex = data.IndexOf(firstItem.Instance.DataItem) + 1;
+        firstItem.Instance.MoveDown();
+
+        var resultList = firstItem.Instance.GetParentChildDataItems();
+        resultList.Should().HaveElementAt(firstItemIndex, firstItem.Instance.DataItem, "DataSource should be mutated");
+    }
+
+    [Fact]
+    public async Task Parent_Remove_item_mutate_datasource()
+    {
+        var data = new List<Item>
+        {
+            new Item("Item 1"),
+            new Item("Item 2"),
+        };
+
+        var cut = Render<Tree<Item>>(@<Tree TItem="Item" DataSource="data"/>);
+        var firstItem = cut.FindComponent<TreeNode<Item>>();
+        firstItem.Instance.Remove();
+
+        data.Should().NotContain(firstItem.Instance.DataItem, "Item should be removed in DataSource");
+    }
+
+    [Fact]
+    public async Task Children_MoveDown_item_mutate_datasource()
+    {
+        var data = new List<Item>
+        {
+            new Item("Item 1")
+            {
+                Children = new List<Item>
+                {
+                    new Item("Child 1-1"),
+                    new Item("Child 1-2"),
+                }
+            },
+        };
+
+        var cut = Render<Tree<Item>>(
+            @<Tree TItem="Item"
+                   DataSource="data"
+                   ChildrenExpression="node => node.DataItem.Children">
+            </Tree>);
+
+        var treeNodes = cut.FindComponents<TreeNode<Item>>();
+        var childComponent = treeNodes.First(component => component.Instance.DataItem.Name.Equals("Child 1-1"));
+
+        var childItemIndex = data[0].Children.IndexOf(childComponent.Instance.DataItem) + 1;
+        childComponent.Instance.MoveDown();
+
+        var resultList = childComponent.Instance.GetParentChildDataItems();
+        resultList.Should().HaveElementAt(childItemIndex, childComponent.Instance.DataItem, "DataSource should be mutated");
+    }
+
+    [Fact]
+    public async Task Children_Remove_item_mutate_datasource()
+    {
+        var data = new List<Item>
+        {
+            new Item("Item 1")
+            {
+                Children = new List<Item>
+                {
+                    new Item("Child 1-1"),
+                    new Item("Child 1-2"),
+                }
+            },
+        };
+
+        var cut = Render<Tree<Item>>(
+            @<Tree TItem="Item"
+                   DataSource="data"
+                   ChildrenExpression="node => node.DataItem.Children">
+            </Tree>);
+
+        var treeNodes = cut.FindComponents<TreeNode<Item>>();
+        var childComponent = treeNodes.First(component => component.Instance.DataItem.Name.Equals("Child 1-2"));
+        childComponent.Instance.Remove();
+
+        data[0].Children.Should().NotContain(childComponent.Instance.DataItem, "Item should be removed in DataSource");
+    }
+
+}


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
Possible https://github.com/ant-design-blazor/ant-design-blazor/issues/2896
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

In https://github.com/ant-design-blazor/ant-design-blazor/pull/2507, `Tree#DataSource` and `Tree#ChildrenExpression` are changed to `IEnumerable` making modifying DataSource in place not possible. This issue is currently present in [Tree demo draggable](https://antblazor.com/en-US/components/tree#components-tree-demo-draggable) page at the time of writing.

This PR aims to fix this by skipping `ToList()` call when the `DataSource` is IList in both TreeNode `ChildDataItems` and `GetParentChildDataItems`.

Additionally, some test cases are added to verify it.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
