### PR TITLE
fix(module: select): NotifyFieldChanged on null Values

### DIFF
--- a/components/select/SelectBase.cs
+++ b/components/select/SelectBase.cs
@@ -252,29 +252,41 @@ namespace AntDesign
             get => _selectedValues;
             set
             {
-                if (value != null && _selectedValues != null)
+                if (value != null)
                 {
-                    var hasChanged = !value.SequenceEqual(_selectedValues);
-
-                    if (!hasChanged)
+                    if (_selectedValues != null)
                     {
+                        var hasChanged = !value.SequenceEqual(_selectedValues);
+
+                        if (!hasChanged)
+                        {
+                            return;
+                        }
+
+                        _selectedValues = value;
+                        _ = OnValuesChangeAsync(value);
+                    }
+                    else
+                    {
+                        _selectedValues = value;
+
+                        _ = OnValuesChangeAsync(value);
+                    }
+                }
+                else
+                {
+                    // value is null
+                    if (_selectedValues != null)
+                    {
+                        _selectedValues = null;
+
+                        _ = OnValuesChangeAsync(null);
+                    }
+                    else
+                    {
+                        // Don't notify that the field changed (as both values are null)
                         return;
                     }
-
-                    _selectedValues = value;
-                    _ = OnValuesChangeAsync(value);
-                }
-                else if (value != null && _selectedValues == null)
-                {
-                    _selectedValues = value;
-
-                    _ = OnValuesChangeAsync(value);
-                }
-                else if (value == null && _selectedValues != null)
-                {
-                    _selectedValues = default;
-
-                    _ = OnValuesChangeAsync(default);
                 }
 
                 if (_isNotifyFieldChanged && Form?.ValidateOnChange == true)


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

When making a custom input component that required support for both a single `Value` as well as multiple `Values`, I encountered the problem that setting `SelectBase`'s `Values` to null (in the case I was using only a single `Value` would call `NotifyFieldChanged`. Since the field didn't actually change, but the component was rerendered on a validation state change, this resulted in an infinite loop.
I added a case for when both `value` and `_selectedValues` are `null`, in which case `NotifyFieldChanged` is not called.
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog
`EditContext.NotifyFieldChanged` is no longer called when `Values` is kept `null`.
<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix incorrect call of `EditContext.NotifyFieldChanged` when `SelectBase.Values` is set (unchanged) to null  |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
