### PR TITLE
fix(module: datepicker): RangePicker. OnOpenChange called twice on close

### DIFF
--- a/components/date-picker/RangePicker.razor.cs
+++ b/components/date-picker/RangePicker.razor.cs
@@ -123,8 +123,8 @@ namespace AntDesign
                 {
                     var calendar = CultureInfo.Calendar;
                     var calendarWeekRule = CultureInfo.DateTimeFormat.CalendarWeekRule;
-                    
-                    var date1Week = calendar.GetWeekOfYear(date1,calendarWeekRule, Locale.FirstDayOfWeek);
+
+                    var date1Week = calendar.GetWeekOfYear(date1, calendarWeekRule, Locale.FirstDayOfWeek);
                     var date2Week = calendar.GetWeekOfYear(date2, calendarWeekRule, Locale.FirstDayOfWeek);
                     return index == 0 ? date1Week < date2Week && date1.Year <= date2.Year
                                         : date1.Year >= date2.Year && date1Week > date2Week;
@@ -471,28 +471,13 @@ namespace AntDesign
                 array.SetValue(value, index);
             }
 
+            var otherIndex = Math.Abs(index - 1);
+
             //if Value was just now instantiated then set the other index to existing DefaultValue
             if (isValueInstantiated && DefaultValue != null)
             {
                 var arrayDefault = DefaultValue as Array;
-                int oppositeIndex = index == 1 ? 0 : 1;
-                array.SetValue(arrayDefault.GetValue(oppositeIndex), oppositeIndex);
-            }
-
-            _pickerStatus[index].IsValueSelected = true;
-
-            if (closeDropdown && !HasTimeInput)
-            {
-                if (_pickerStatus[0].SelectedValue is not null
-                    && _pickerStatus[1].SelectedValue is not null)
-                {
-                    Close();
-                }
-                // if the other DatePickerInput is disabled, then close picker panel
-                else if (IsDisabled(Math.Abs(index - 1)))
-                {
-                    Close();
-                }
+                array.SetValue(arrayDefault.GetValue(otherIndex), otherIndex);
             }
 
             var startDate = array.GetValue(0) as DateTime?;
@@ -507,6 +492,15 @@ namespace AntDesign
             if (_isNotifyFieldChanged && (Form?.ValidateOnChange == true))
             {
                 EditContext?.NotifyFieldChanged(FieldIdentifier);
+            }
+
+            _pickerStatus[index].IsValueSelected = true;
+
+            if (closeDropdown && !HasTimeInput
+                && _pickerStatus[index].SelectedValue is not null
+                && (_pickerStatus[otherIndex].SelectedValue is not null || IsDisabled(otherIndex)))
+            {
+                Close();
             }
         }
 

--- a/components/date-picker/internal/DatePickerBase.cs
+++ b/components/date-picker/internal/DatePickerBase.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -462,7 +462,7 @@ namespace AntDesign
             return Task.CompletedTask;
         }
 
-        protected virtual async Task OnSelect(DateTime date, int index, bool switchFocus = true, bool closeDropdown = true)
+        protected virtual async Task OnSelect(DateTime date, int index)
         {
             _duringManualInput = false;
 
@@ -478,33 +478,30 @@ namespace AntDesign
                     {
                         if (IsValidRange(date, index))
                         {
-                            var otherIndex = Math.Abs(index - 1);
 
+                            ChangeValue(date, index, false);
+
+                            var otherIndex = Math.Abs(index - 1);
                             if (_pickerStatus[otherIndex].SelectedValue is not null)
                             {
-                                ChangeValue(_pickerStatus[otherIndex].SelectedValue.Value, otherIndex, closeDropdown);
+                                ChangeValue(_pickerStatus[otherIndex].SelectedValue.Value, otherIndex, true);
                             }
-
-                            ChangeValue(date, index, closeDropdown);
                         }
                     }
                 }
                 else if (!HasTimeInput)
                 {
-                    ChangeValue(date, index, closeDropdown);
+                    ChangeValue(date, index, true);
                 }
 
                 // auto focus the other input
-                if (switchFocus)
+                if (IsRange && !HasTimeInput)
                 {
-                    if (IsRange && !HasTimeInput)
-                    {
-                        await SwitchFocus(index);
-                    }
-                    else
-                    {
-                        await Focus(index);
-                    }
+                    await SwitchFocus(index);
+                }
+                else
+                {
+                    await Focus(index);
                 }
             }
             else
@@ -829,7 +826,7 @@ namespace AntDesign
             if (string.IsNullOrEmpty(Format))
                 format = _pickerStatus[index].InitPicker switch
                 {
-                    DatePickerType.Week => $"{Locale.Lang.YearFormat}-{CultureInfo.Calendar.GetWeekOfYear(value,CultureInfo.DateTimeFormat.CalendarWeekRule, Locale.FirstDayOfWeek)}'{Locale.Lang.Week}'",
+                    DatePickerType.Week => $"{Locale.Lang.YearFormat}-{CultureInfo.Calendar.GetWeekOfYear(value, CultureInfo.DateTimeFormat.CalendarWeekRule, Locale.FirstDayOfWeek)}'{Locale.Lang.Week}'",
                     DatePickerType.Quarter => $"{Locale.Lang.YearFormat}-{DateHelper.GetDayOfQuarter(value)}",
                     _ => InternalFormat,
                 };


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

Fixes #3303 when OnOpenChange called twice on close

### 💡 Background and solution



### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
