### PR TITLE
Dev

### DIFF
--- a/components/core/DefaultValue/DefaultValueConfigService.cs
+++ b/components/core/DefaultValue/DefaultValueConfigService.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.Extensions.Options;
+
+namespace AntDesign
+{
+    public class DefaultValueConfigService
+    {
+        public DefaultValueOptions Options { get; }
+        public DefaultValueConfigService(IOptions<DefaultValueOptions> options)
+        {
+            Options = options.Value;
+        }
+    }
+}

--- a/components/core/DefaultValue/DefaultValueOptions.cs
+++ b/components/core/DefaultValue/DefaultValueOptions.cs
@@ -1,0 +1,10 @@
+﻿namespace AntDesign
+{
+    public class DefaultValueOptions
+    {
+        public InputDefaultValueOptions InputDefaultValue => InputDefaultValueOptions.Instance;
+        public DialogDefaultValueOptions DialogDefaultValue => DialogDefaultValueOptions.Instance;
+        public ConfirmDefaultValueOptions ConfirmDefaultValue => ConfirmDefaultValueOptions.Instance;
+        public ModalDefaultValueOptions ModalDefaultValue => ModalDefaultValueOptions.Instance;
+    }
+}

--- a/components/core/DefaultValue/Dialog/ConfirmDefaultValueOptions.cs
+++ b/components/core/DefaultValue/Dialog/ConfirmDefaultValueOptions.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using OneOf;
+
+namespace AntDesign
+{
+    public class ConfirmDefaultValueOptions
+    {
+        public OneOf<string, double>? Width { get; set; }
+        public bool? MaskClosable { get;set; }
+
+        private static Lazy<ConfirmDefaultValueOptions> _instance;
+        public static ConfirmDefaultValueOptions Instance => _instance.Value;
+        static ConfirmDefaultValueOptions()
+        {
+            _instance = new Lazy<ConfirmDefaultValueOptions>(new ConfirmDefaultValueOptions());
+        }
+        private ConfirmDefaultValueOptions() { }
+    }
+}

--- a/components/core/DefaultValue/Dialog/DialogDefaultValueOptions.cs
+++ b/components/core/DefaultValue/Dialog/DialogDefaultValueOptions.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Microsoft.AspNetCore.Components;
+using OneOf;
+
+namespace AntDesign
+{
+    public class DialogDefaultValueOptions
+    {
+        public bool? Centered { get; set; }
+        public bool? Keyboard { get; set; }
+        public bool? Mask { get; set; }
+        public int? ZIndex { get; set; }
+        public bool? Rtl { get; set; }
+        public OneOf<string, RenderFragment>? OkText { get; set; }
+        public OneOf<string, RenderFragment>? CancelText { get; set; }
+
+        private static Lazy<DialogDefaultValueOptions> _instance;
+        public static DialogDefaultValueOptions Instance => _instance.Value;
+        static DialogDefaultValueOptions()
+        {
+            _instance = new Lazy<DialogDefaultValueOptions>(new DialogDefaultValueOptions());
+        }
+        private DialogDefaultValueOptions() { }
+    }
+}

--- a/components/core/DefaultValue/Dialog/ModalDefaultValueOptions.cs
+++ b/components/core/DefaultValue/Dialog/ModalDefaultValueOptions.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using OneOf;
+
+namespace AntDesign
+{
+    public class ModalDefaultValueOptions
+    {
+        public OneOf<string, double>? Width { get; set; }
+        public bool? MaskClosable { get; set; }
+
+        private static Lazy<ModalDefaultValueOptions> _instance;
+        public static ModalDefaultValueOptions Instance => _instance.Value;
+        static ModalDefaultValueOptions()
+        {
+            _instance = new Lazy<ModalDefaultValueOptions>(new ModalDefaultValueOptions());
+        }
+        private ModalDefaultValueOptions() { }
+    }
+}

--- a/components/core/DefaultValue/InputDefaultValueOptions.cs
+++ b/components/core/DefaultValue/InputDefaultValueOptions.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace AntDesign
+{
+    public class InputDefaultValueOptions
+    {
+        public int? MaxLength { get; set; }
+        private static Lazy<InputDefaultValueOptions> _instance;
+        public static InputDefaultValueOptions Instance => _instance.Value;
+        static InputDefaultValueOptions()
+        {
+            _instance = new Lazy<InputDefaultValueOptions>(new InputDefaultValueOptions());
+        }
+        private InputDefaultValueOptions() { }
+    }
+}

--- a/components/core/Extensions/ServiceCollectionExtensions.cs
+++ b/components/core/Extensions/ServiceCollectionExtensions.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Extensions.DependencyInjection
                         s => HtmlEncoder.Default.Encode(s)))
             );
 
+            services.TryAddSingleton<DefaultValueConfigService>();
             services.TryAddSingleton<IComponentIdGenerator, GuidComponentIdGenerator>();
             services.TryAddScoped<IconService>();
             services.TryAddScoped<InteropService>();

--- a/components/icon/internal/IconStore.cs
+++ b/components/icon/internal/IconStore.cs
@@ -2432,7 +2432,7 @@ namespace AntDesign
 
             if (iconName.Equals(IconType.Outline.More) && iconTheme.Equals(IconThemeType.Outline))
             {
-                return "<svg xmlns=\"http://www.w3.org/2000/svg\" class=\"icon\" viewBox=\"0 0 1024 1024\"><path fill=\"#333\" d=\"M456 231a56 56 0 1 0 112 0 56 56 0 1 0-112 0zm0 280a56 56 0 1 0 112 0 56 56 0 1 0-112 0zm0 280a56 56 0 1 0 112 0 56 56 0 1 0-112 0z\"/></svg>";
+                return "<svg xmlns=\"http://www.w3.org/2000/svg\" class=\"icon\" viewBox=\"0 0 1024 1024\"><path d=\"M456 231a56 56 0 1 0 112 0 56 56 0 1 0-112 0zm0 280a56 56 0 1 0 112 0 56 56 0 1 0-112 0zm0 280a56 56 0 1 0 112 0 56 56 0 1 0-112 0z\"/></svg>";
             }
 
             if (iconName.Equals(IconType.Outline.NodeCollapse) && iconTheme.Equals(IconThemeType.Outline))

--- a/components/input/Input.cs
+++ b/components/input/Input.cs
@@ -32,7 +32,8 @@ namespace AntDesign
 
         [Inject]
         protected IDomEventListener DomEventListener { get; set; }
-
+        [Inject]
+        private DefaultValueConfigService DefaultValueConfigService { get; set; }
         /// <summary>
         /// The label text displayed before (on the left side of) the input field.
         /// </summary>
@@ -126,7 +127,7 @@ namespace AntDesign
         /// Max length
         /// </summary>
         [Parameter]
-        public int MaxLength { get; set; } = -1;
+        public int MaxLength { get; set; }
 
         /// <summary>
         /// Callback when input looses focus
@@ -388,7 +389,11 @@ namespace AntDesign
             SetClasses();
             StateHasChanged();
         }
-
+        public override Task SetParametersAsync(ParameterView parameters)
+        {
+            MaxLength = DefaultValueConfigService.Options.InputDefaultValue.MaxLength ?? -1;
+            return base.SetParametersAsync(parameters);
+        }
         protected override void OnParametersSet()
         {
             base.OnParametersSet();

--- a/components/modal/config/ConfirmOptions.cs
+++ b/components/modal/config/ConfirmOptions.cs
@@ -16,9 +16,8 @@ namespace AntDesign
     {
         public ConfirmOptions()
         {
-            Width = 416;
-            Mask = true;
-            MaskClosable = false;
+            Width =ConfirmDefaultValueOptions.Instance.Width??416;
+            MaskClosable = ConfirmDefaultValueOptions.Instance.MaskClosable??false;
             Locale = LocaleProvider.CurrentLocale.Confirm;
         }
 

--- a/components/modal/config/DialogOptionsBase.cs
+++ b/components/modal/config/DialogOptionsBase.cs
@@ -2,12 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Web;
 using OneOf;
 
 namespace AntDesign
@@ -58,6 +53,18 @@ namespace AntDesign
 
         #endregion
 
+        public DialogOptionsBase()
+        {
+            var congifInstance = DialogDefaultValueOptions.Instance;
+            Centered = congifInstance.Centered ?? false;
+            Keyboard = congifInstance.Keyboard ?? true;
+            Mask = congifInstance.Mask ?? true;
+            OkText = congifInstance.OkText ?? "OK";
+            CancelText = congifInstance.CancelText ?? "Cancel";
+            ZIndex = congifInstance.ZIndex ?? 1000;
+            Rtl = congifInstance.Rtl ?? false;
+        }
+
         /// <summary>
         /// class name prefix 
         /// </summary>
@@ -71,7 +78,7 @@ namespace AntDesign
         /// <summary>
         /// modal default footer cancel text
         /// </summary>
-        public OneOf<string, RenderFragment> CancelText { get; set; } = "Cancel";
+        public OneOf<string, RenderFragment> CancelText { get; set; }
 
         /// <summary>
         /// whether center display
@@ -86,12 +93,12 @@ namespace AntDesign
         /// <summary>
         /// Whether support press esc to close	
         /// </summary>
-        public bool Keyboard { get; set; } = true;
+        public bool Keyboard { get; set; }
 
         /// <summary>
         /// Whether show mask or not
         /// </summary>
-        public bool Mask { get; set; } = true;
+        public bool Mask { get; set; }
 
         /// <summary>
         /// Whether to close the modal dialog when the mask (area outside the modal) is clicked
@@ -111,7 +118,7 @@ namespace AntDesign
         /// <summary>
         /// Text of the OK button
         /// </summary>
-        public OneOf<string, RenderFragment> OkText { get; set; } = "OK";
+        public OneOf<string, RenderFragment> OkText { get; set; }
 
         /// <summary>
         /// Button type of the OK button
@@ -136,11 +143,11 @@ namespace AntDesign
         /// <summary>
         /// The z-index of the Modal
         /// </summary>
-        public int ZIndex { get; set; } = 1000;
+        public int ZIndex { get; set; }
 
         /// <summary>
         /// Is RTL
         /// </summary>
-        public bool Rtl { get; set; } = false;
+        public bool Rtl { get; set; }
     }
 }

--- a/components/modal/config/ModalOptions.cs
+++ b/components/modal/config/ModalOptions.cs
@@ -15,8 +15,8 @@ namespace AntDesign
         {
             _onCancel = DefaultOnCancelOrOk;
             _onOk = DefaultOnCancelOrOk;
-            Width = 520;
-            MaskClosable = true;
+            Width = ModalDefaultValueOptions.Instance.Width ?? 520;
+            MaskClosable = ModalDefaultValueOptions.Instance.MaskClosable ?? true;
         }
 
         internal ModalRef ModalRef { get; set; }


### PR DESCRIPTION
修复图标[More]更改主题颜色不生效的问题
支持通过下述方式配置控件的默认值：
builder.Services.Configure<DefaultValueOptions>((options) =>
{
    options.InputDefaultValue.MaxLength = 8;
    options.DialogDefaultValue.Centered = false;
    options.DialogDefaultValue.OkText = "确认";
    options.DialogDefaultValue.CancelText = "放弃";
    options.ConfirmDefaultValue.Width = 200;
    options.ModalDefaultValue.Width = 1000;
});