### PR TITLE
Modify the upload component to support Put upload

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -224,7 +224,7 @@ csharp_preserve_single_line_statements = true
 dotnet_diagnostic.CS1591.severity = none
 
 # IDE1006: Naming Styles
-dotnet_diagnostic.IDE1006.severity = error
+dotnet_diagnostic.IDE1006.severity = warning
 
 # CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive).
 dotnet_diagnostic.CS8509.severity = error
@@ -232,23 +232,23 @@ dotnet_diagnostic.CS8509.severity = error
 # CA2007: Consider calling ConfigureAwait on the awaited task
 dotnet_diagnostic.CA2007.severity = none
 
-# CA2227: ¼¯ºÏÊôĞÔÓ¦ÎªÖ»¶Á
+# CA2227: é›†åˆå±æ€§åº”ä¸ºåªè¯»
 dotnet_diagnostic.CA2227.severity = none
 
-# CA1303: Çë²»Òª½«ÎÄ±¾×÷Îª±¾µØ»¯²ÎÊı´«µİ
+# CA1303: è¯·ä¸è¦å°†æ–‡æœ¬ä½œä¸ºæœ¬åœ°åŒ–å‚æ•°ä¼ é€’
 dotnet_diagnostic.CA1303.severity = none
 
-# CA2208: ÕıÈ·ÊµÀı»¯²ÎÊıÒì³£
+# CA2208: æ­£ç¡®å®ä¾‹åŒ–å‚æ•°å¼‚å¸¸
 dotnet_diagnostic.CA2208.severity = none
 
-# CA1819: ÊôĞÔ²»Ó¦·µ»ØÊı×é
+# CA1819: å±æ€§ä¸åº”è¿”å›æ•°ç»„
 dotnet_diagnostic.CA1819.severity = none
 
-# CA2225: ÔËËã·ûÖØÔØ¾ßÓĞÃüÃûµÄ±¸ÓÃÏî
+# CA2225: è¿ç®—ç¬¦é‡è½½å…·æœ‰å‘½åçš„å¤‡ç”¨é¡¹
 dotnet_diagnostic.CA2225.severity = none
 
-# CA1308: ½«×Ö·û´®¹æ·¶»¯Îª´óĞ´
+# CA1308: å°†å­—ç¬¦ä¸²è§„èŒƒåŒ–ä¸ºå¤§å†™
 dotnet_diagnostic.CA1308.severity = none
 
-# CA1040: ±ÜÃâÊ¹ÓÃ¿Õ½Ó¿Ú
+# CA1040: é¿å…ä½¿ç”¨ç©ºæ¥å£
 dotnet_diagnostic.CA1040.severity = none

--- a/components/core/JsInterop/modules/components/uploadHelper.ts
+++ b/components/core/JsInterop/modules/components/uploadHelper.ts
@@ -86,8 +86,7 @@ export class uploadHelper {
 
     var file = element.files[index];
     if (method.toLowerCase() === 'put') {
-      req.setRequestHeader('Content-type', '');
-      req.send(new Blob[file]);
+        req.send(file);
     } else {
       let formData = new FormData();
       var size = file.size;

--- a/components/core/JsInterop/modules/components/uploadHelper.ts
+++ b/components/core/JsInterop/modules/components/uploadHelper.ts
@@ -58,15 +58,6 @@ export class uploadHelper {
   }
 
   static uploadFile(element, index, data, headers, fileId, url, name, instance, percentMethod, successMethod, errorMethod, method: string) {
-    let formData = new FormData();
-    var file = element.files[index];
-    var size = file.size;
-    formData.append(name, file);
-    if (data != null) {
-      for (var key in data) {
-        formData.append(key, data[key]);
-      }
-    }
     const req = new XMLHttpRequest()
     req.onreadystatechange = function () {
       if (req.readyState === 4) {
@@ -92,6 +83,21 @@ export class uploadHelper {
         req.setRequestHeader(header, headers[header]);
       }
     }
-    req.send(formData)
+
+    var file = element.files[index];
+    if (method.toLowerCase() === 'put') {
+      req.setRequestHeader('Content-type', '');
+      req.send(new Blob[file]);
+    } else {
+      let formData = new FormData();
+      var size = file.size;
+      formData.append(name, file);
+      if (data != null) {
+        for (var key in data) {
+          formData.append(key, data[key]);
+        }
+      }
+      req.send(formData)
+    }
   }
 }

--- a/site/AntDesign.Docs/Demos/Components/Upload/demo/HttpPutUpload.razor
+++ b/site/AntDesign.Docs/Demos/Components/Upload/demo/HttpPutUpload.razor
@@ -1,0 +1,41 @@
+<Upload Action="@_uploadUrl"
+        Name="files"
+        Method="PUT"
+        BeforeUpload="BeforeUpload"
+        OnSingleCompleted="OnSingleCompleted">
+    <Button Icon="upload">
+        <span>Click to Upload</span>
+    </Button>
+</Upload>
+
+@code {
+    private string _uploadUrl = "https://www.mocky.io/v2/5cc8019d300000980a055e76";
+
+    bool BeforeUpload(UploadFileItem file)
+    {
+        // obtains the upload URL from the backend interface
+        // _uploadUrl = GetUploadUrl();
+        return true;
+    }
+
+    void OnSingleCompleted(UploadInfo fileinfo)
+    {
+        if (fileinfo.File.State == UploadState.Success)
+        {
+            var result = fileinfo.File.GetResponse<ResponseModel>();
+            fileinfo.File.Url = result.url;
+        }
+    }
+
+    public class ResponseModel
+    {
+        public string name { get; set; }
+
+        public string status { get; set; }
+
+        public string url { get; set; }
+
+        public string thumbUrl { get; set; }
+    }
+
+}

--- a/site/AntDesign.Docs/Demos/Components/Upload/demo/httpPutUpload.md
+++ b/site/AntDesign.Docs/Demos/Components/Upload/demo/httpPutUpload.md
@@ -1,0 +1,16 @@
+---
+order: 9
+title:
+  zh-CN: Put方式上传
+  en-US: Http Put Upload
+---
+
+## zh-CN
+
+有些业务系统后端接口采用HttpPut方式接收前端上传的文件，HttpPut方式只能上传单个文件，文件流数据被存放在了Body中，我们只需要将上传组件的Method属性值设置为Put就可以实现这一功能。
+阿里云的OSS产品就是采用HttpPut方式，为了安全，前端上传文件之前，先从后端接口获取到上传Url，前端通过put方式将文件流上传到该Url接口。
+
+## en-US
+
+Some business system back-end interfaces use HttpPut mode to receive front-end uploaded files, HttpPut mode can only upload a single file, file stream data is stored in Body, we only need to set the Method property value of the upload component to Put to achieve this function.
+Alibaba Cloud's OSS products use the HttpPut method, for security, before uploading the file, the frontend obtains the upload URL from the backend interface, and the frontend uploads the file stream to the URL interface through the put mode.


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 日常 bug 修复

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
1.上传组件对于HttpPut上传方式不支持，而有些业务系统后端接口采用HttpPut方式接收前端上传的文件。
2.通过修改uploadHelper.ts文件代码，根据method属性值来区分对待post和put方式上传。

### 📝 更新日志怎么写？

<!--
> 从用户角度描述具体变化，以及可能的 breaking change 和其他风险？
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |  The upload component supports Http Put upload        |
| 🇨🇳 中文 |   上传组件支持Http Put方式上传       |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [√] 文档已补充或无须补充
- [√] 代码演示已提供或无须提供
- [√] Changelog 已提供或无须提供