### PR TITLE
fix(module:datepicker): RangePicker focus not cleared

### DIFF
--- a/components/date-picker/DatePicker.Razor.cs
+++ b/components/date-picker/DatePicker.Razor.cs
@@ -140,10 +140,6 @@ namespace AntDesign
                     {
                         await OnSelect(_pickerStatus[0].SelectedValue.Value, 0);
                     }
-                    else if (AllowClear)
-                    {
-                        ClearValue();
-                    }
                     else if (isOverlayShown)
                     {
                         Close();

--- a/components/date-picker/RangePicker.razor.cs
+++ b/components/date-picker/RangePicker.razor.cs
@@ -145,7 +145,6 @@ namespace AntDesign
 
         private async Task OnInputClick(int index)
         {
-            _duringFocus = false;
             if (_duringManualInput)
             {
                 return;
@@ -300,7 +299,6 @@ namespace AntDesign
 
         private async Task OnFocus(int index)
         {
-            _duringFocus = true;
             if (index == 0)
             {
                 if (!_inputStart.IsOnFocused)
@@ -339,16 +337,11 @@ namespace AntDesign
                 }
             }
 
-            if (_duringFocus)
-            {
-                _duringFocus = false;
-                _shouldRender = false;
-                return;
-            }
-            if (_openingOverlay)
+            if (_openingOverlay || _dropDown.IsOverlayShow())
             {
                 return;
             }
+
             _duringManualInput = false;
             AutoFocus = false;
         }
@@ -713,12 +706,16 @@ namespace AntDesign
             return false;
         }
 
-        private void OverlayVisibleChange(bool visible)
+        private async Task OverlayVisibleChange(bool isVisible)
         {
             _openingOverlay = false;
-            _duringFocus = false;
-            OnOpenChange.InvokeAsync(visible);
-            InvokeInternalOverlayVisibleChanged(visible);
+            await OnOpenChange.InvokeAsync(isVisible);
+            InvokeInternalOverlayVisibleChanged(isVisible);
+            if (!isVisible)
+            {
+                var index = GetOnFocusPickerIndex();
+                await Focus(index);
+            }
         }
 
         private async Task OnSuffixIconClick()

--- a/components/date-picker/RangePicker.razor.cs
+++ b/components/date-picker/RangePicker.razor.cs
@@ -254,10 +254,6 @@ namespace AntDesign
                     {
                         await OnSelect(_pickerStatus[index].SelectedValue.Value, index);
                     }
-                    else if (AllowClear)
-                    {
-                        ClearValue(index);
-                    }
                     else if (isOverlayShown)
                     {
                         if (_pickerStatus[index].SelectedValue is null && _pickerStatus[index].IsValueSelected)

--- a/components/date-picker/internal/DatePickerBase.cs
+++ b/components/date-picker/internal/DatePickerBase.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -278,7 +278,6 @@ namespace AntDesign
         protected DatePickerInput _inputStart;
         protected DatePickerInput _inputEnd;
         protected OverlayTrigger _dropDown;
-        protected bool _duringFocus;
 
         protected string _activeBarStyle = "";
         protected string _rangeArrowStyle = "";

--- a/tests/AntDesign.Tests/DatePicker/RangePickerTests.razor
+++ b/tests/AntDesign.Tests/DatePicker/RangePickerTests.razor
@@ -369,53 +369,6 @@
         input[1].GetAttribute("value").Should().Be(endValueAsString);
         range[1].Should().Be(null);
     }
-    
-    [Fact]
-    public async Task Enter_Empty_Date_Should_Clear_Value_When_AllowClear()
-    {
-        //Arrange
-        JSInterop.SetupVoid(JSInteropConstants.AddPreventKeys, _ => true);
-        JSInterop.SetupVoid(JSInteropConstants.InvokeTabKey, _ => true);
-        JSInterop.SetupVoid(JSInteropConstants.Blur, _ => true);
-        JSInterop.Setup<OverlayPosition>(JSInteropConstants.OverlayComponentHelper.AddOverlayToContainer, _ => true)
-            .SetResult(new OverlayPosition());
-        JSInterop.Setup<HtmlElement>(JSInteropConstants.DomInfoHelper.GetInfo, _ => true);
-
-        var range = new DateTime?[]
-        {
-            DateTime.Now.Date,
-            DateTime.Now.Date.AddDays(1)
-        };
-        
-        var startValueAsString = string.Empty;
-        var endValueAsString = string.Empty;
-
-        //Act
-        var cut = Render<AntDesign.RangePicker<DateTime?[]>>
-            (@<RangePicker @bind-Value="range" AllowClear/>  );
-
-        //Act
-        var input = cut.FindAll("input");
-        
-        await input[0].InputAsync(new ChangeEventArgs { Value = "" });
-        input[0].KeyDown("ENTER");
-        
-        await input[1].InputAsync(new ChangeEventArgs { Value = "" });
-        input[1].KeyDown("ENTER");
-
-        //Assert
-        cut.WaitForState(() =>
-        {
-            input = cut.FindAll("input");
-            return input[0].GetAttribute("value") == startValueAsString &&
-                   input[1].GetAttribute("value") == endValueAsString;
-        }, TimeSpan.FromSeconds(2));
-        
-        cut.WaitForState(() =>
-        {
-            return range[0] == null && range[1] == null;
-        }, TimeSpan.FromSeconds(2));
-    }
 
     [Fact]
     public void ItShouldUseCustomSuffixIcon()


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

#3452

### 💡 Background and solution

This fixes two major issues:

- The issue when the focus is not removed from the RangePicker #3452

- Pressing the Enter or Tab key clears the selected value in the DatePicker and RangePicker. This was caused in the b329aa68d0f00c00eeefe8eb419f3a30e6a0d4af 


### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
