### PR TITLE
fix:(module:datepicker): ArgumentOutOfRangeException in TimePicker

### DIFF
--- a/components/date-picker/internal/DatePickerBase.cs
+++ b/components/date-picker/internal/DatePickerBase.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -1096,7 +1096,12 @@ namespace AntDesign
 
             currentValue = InternalConvert.ToDateTimeOffset(CurrentValue);
 
-            var offset = defaultValue?.Offset ?? currentValue?.Offset ?? DateTimeOffset.Now.Offset;
+            var offset = TimeSpan.Zero;
+
+            if (InternalConvert.IsDateTimeOffsetType<TValue>())
+            {
+                offset = defaultValue?.Offset ?? currentValue?.Offset ?? TimeSpan.Zero;
+            }
 
             newValue = new DateTimeOffset(DateTime.SpecifyKind(value, DateTimeKind.Unspecified), offset);
         }

--- a/components/date-picker/internal/InternalConvert.cs
+++ b/components/date-picker/internal/InternalConvert.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 
 namespace AntDesign.Internal;
@@ -158,7 +158,6 @@ internal static class InternalConvert
 
     public static bool IsNullable<TValue>()
     {
-
         Type type = typeof(TValue);
         if (type.IsAssignableFrom(typeof(DateTime?)) || type.IsAssignableFrom(typeof(DateTime?[]))
             || type.IsAssignableFrom(typeof(DateTimeOffset?)) || type.IsAssignableFrom(typeof(DateTimeOffset?[])))
@@ -253,6 +252,16 @@ internal static class InternalConvert
         throw new NotSupportedException($"{type.FullName} not supported");
     }
 
+    internal static bool IsDateTimeOffsetType<TValue>()
+    {
+        var type = typeof(TValue);
+
+        return type.IsAssignableFrom(typeof(DateTimeOffset))
+                || type.IsAssignableFrom(typeof(DateTimeOffset?))
+                || type.IsAssignableFrom(typeof(DateTimeOffset[]))
+                || type.IsAssignableFrom(typeof(DateTimeOffset?[]));
+    }
+
     public static DateTime SetKind<TValue>(DateTime input)
     {
         var type = typeof(TValue);
@@ -293,9 +302,13 @@ internal static class InternalConvert
         if (input == DateTime.MaxValue)
             return DateTimeOffset.MaxValue;
 
+        if (input.Date == DateTime.MinValue.Date)
+            return new DateTimeOffset(DateTime.SpecifyKind(input, DateTimeKind.Unspecified), TimeSpan.Zero);
+
         if (input.Kind == DateTimeKind.Unspecified)
             return new DateTimeOffset(input, TimeSpan.Zero);
 
         return new DateTimeOffset(input);
     }
+
 }

--- a/tests/AntDesign.Tests/DatePicker/DatePickerTestData.cs
+++ b/tests/AntDesign.Tests/DatePicker/DatePickerTestData.cs
@@ -20,6 +20,8 @@ public static class DatePickerTestData
             yield return new object?[] { new DateOnly?() };
             yield return new object[] { DateOnly.FromDateTime(DateTime.Now) };
             yield return new object[] { new DateOnly?(DateOnly.FromDateTime(DateTime.Now)) };
+            yield return new object[] { TimeOnly.FromDateTime(DateTime.Now) };
+            yield return new object[] { new TimeOnly(0, 0, 0) };
 #endif
         }
     }
@@ -102,6 +104,20 @@ public static class DatePickerTestData
             yield return new object[] { new DateOnly(2020, 4, 5), "yyyy-MM-dd", "en-GB", "2020-04-05" };
             yield return new object[] { new DateOnly(2020, 4, 5), "dd/MM/yyyy", "en-US", "05/04/2020" };
             yield return new object[] { new DateOnly(2020, 4, 5), "MM/dd/yyyy", "en-US", "04/05/2020" };
+#endif
+        }
+    }
+
+    public static IEnumerable<object?[]> TimePickerData
+    {
+        get
+        {
+            yield return new object[] { DateTime.Now };
+            yield return new object[] { DateTimeOffset.Now };
+
+#if NET6_0_OR_GREATER
+            yield return new object[] { TimeOnly.FromDateTime(DateTime.Now) };
+            yield return new object[] { new TimeOnly(0, 0, 0) };
 #endif
         }
     }

--- a/tests/AntDesign.Tests/DatePicker/TimePickerTests.razor
+++ b/tests/AntDesign.Tests/DatePicker/TimePickerTests.razor
@@ -1,0 +1,36 @@
+﻿@using AntDesign.Core.JsInterop.Modules.Components
+@inherits AntDesignTestBase
+
+@code {
+
+    [Theory]
+    [MemberData(nameof(DatePickerTestData.TimePickerData), MemberType = typeof(DatePickerTestData))]
+    public void DefaultValue_applied_to_value<T>(T defaultValue)
+    {
+        JSInterop.SetupVoid(JSInteropConstants.AddPreventKeys, _ => true);
+
+        var cut = Render<AntDesign.TimePicker<T>>(
+			@<TimePicker TValue="T" DefaultValue="@defaultValue" />);
+
+        cut.Instance.Value.Should().Be(defaultValue);
+    }
+
+#if NET6_0_OR_GREATER
+    [Theory]
+    [MemberData(nameof(DatePickerTestData.TimePickerData), MemberType = typeof(DatePickerTestData))]
+    public async Task Nullable_TimePicker_Accepts_Input<T>(T inputValue)
+    {
+        JSInterop.SetupVoid(JSInteropConstants.AddPreventKeys, _ => true);
+
+        var cut = Render<AntDesign.TimePicker<TimeOnly?>>(
+			@<TimePicker TValue="TimeOnly?" />);
+
+        var input = cut.Find("input");
+        var inputAsString = $"{inputValue:HH:mm:ss}";
+        await input.InputAsync(new ChangeEventArgs() { Value = inputAsString });
+        await input.KeyDownAsync(new KeyboardEventArgs() { Key = "Enter" });
+
+        $"{cut.Instance.Value:HH:mm:ss}".Should().Be(inputAsString);
+    }
+#endif
+}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

#3498 

### 💡 Background and solution

The ArgumentOutOfRangeException occurs in the TimePicker when internally converting DateTime.MinValue with DateTimeKind.Local to the DateTimeOffset. The solution is to change DateTime.Kind to Unspecified during the conversion.

### 📝 Changelog

Fixes System.ArgumentOutOfRangeException: The UTC time represented when the offset is applied must be between year 0 and 10,000. (Parameter 'offset') in the TimePicker. 

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
