### PR TITLE
Fix exception when uploading a file without an extension 

### DIFF
--- a/components/upload/UploadButton.razor.cs
+++ b/components/upload/UploadButton.razor.cs
@@ -137,7 +137,7 @@ namespace AntDesign.Internal
             foreach (var fileItem in flist)
             {
                 var fileName = fileItem.FileName;
-                fileItem.Ext = fileItem.FileName.Substring(fileName.LastIndexOf('.'));
+                fileItem.Ext = System.IO.Path.GetExtension(fileItem.FileName);
                 var id = Guid.NewGuid().ToString();
                 if (Upload.BeforeUpload != null && !Upload.BeforeUpload.Invoke(fileItem))
                 {

--- a/tests/AntDesign.Tests/Upload/UploadTests.razor
+++ b/tests/AntDesign.Tests/Upload/UploadTests.razor
@@ -1,4 +1,7 @@
-﻿@inherits AntDesignTestBase
+﻿@using System.IO
+@using AngleSharp.Html.Dom
+@using AngleSharp.Io.Dom
+@inherits AntDesignTestBase
 @code {
     [Fact]
     public void Renders_basic_upload()
@@ -59,5 +62,22 @@
               <div class="ant-upload-list ant-upload-list-text">
               </div>
           </span>);
+    }
+
+    [Fact]
+    public async Task Handles_filenames_without_extension()
+    {
+        JSInterop.SetupVoid(JSInteropConstants.AddFileClickEventListener, _ => true);
+        JSInterop.SetupVoid(JSInteropConstants.UploadFile, _ => true).SetCanceled();
+        JSInterop.SetupVoid(JSInteropConstants.ClearFile, _ => true);
+
+        JSInterop.Setup<List<UploadFileItem>>(JSInteropConstants.GetFileInfo, _ => true).SetResult(new List<UploadFileItem> { new UploadFileItem { FileName = "test" } });
+
+        var cut = Context.Render(@<Upload>some content</Upload>);
+
+        var inputElement = ((AngleSharpWrappers.HtmlInputElementWrapper)cut.Find("input")).WrappedElement;
+        
+        Func<Task> act = () => inputElement.ChangeAsync(new ChangeEventArgs() { Value = "ignored" });
+        await act.Should().NotThrowAsync();
     }
 }


### PR DESCRIPTION
Fix UploadButton to use System.IO.Path.GetExtension instead of Substring to support filenames without extensions

<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
https://github.com/ant-design-blazor/ant-design-blazor/issues/3553

### 💡 Background and solution

Uploading a file that does not have a file extension using the Upload[button] component results in the following exception being thrown:

```
blazor.webassembly.js:1 crit: Microsoft.AspNetCore.Components.WebAssembly.Rendering.WebAssemblyRenderer[100]
      Unhandled exception rendering component: ArgumentOutOfRange_Generic_MustBeNonNegative, startIndex, -1 Arg_ParamName_Name, startIndex
      ArgumentOutOfRange_ActualValue, -1
System.ArgumentOutOfRangeException: ArgumentOutOfRange_Generic_MustBeNonNegative, startIndex, -1 Arg_ParamName_Name, startIndex
ArgumentOutOfRange_ActualValue, -1
   at AntDesign.Internal.UploadButton.FileNameChanged(ChangeEventArgs e)
   at Microsoft.AspNetCore.Components.ComponentBase.CallStateHasChangedOnAsyncCompletion(Task task)
   at Microsoft.AspNetCore.Components.RenderTree.Renderer.GetErrorHandledTask(Task , ComponentState )
```

This is happening because the UploadButton component uses Substring based on the position of the last `.`, which is `-1` when no `.` is present. This PR fixes this by using the built-in `System.IO.Path.GetExtension` method instead, which better expresses intent and is not affected by this bug.

~There are no existing test cases covering this code path and I struggled to create one, but would be happy to add one with assistance.~

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fixed exception when uploading a file without an extension |
| 🇨🇳 Chinese |  修复了上传没有扩展名的文件时出现的异常 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
