### PR TITLE
(module: select) Fix scroll in select not working correctly when EnableVirtualization is true.

### DIFF
--- a/components/select/Select.razor
+++ b/components/select/Select.razor
@@ -66,7 +66,7 @@
                                         @{
                                             @if (!IsGroupingEnabled)
                                             {
-                                                @selectOptionsRender((this, SortedSelectOptionItems, ItemTemplate))                                                                                               
+                                                @selectOptionsRender((this, ItemTemplate))                                                                                               
                                             }
                                             else
                                             {
@@ -134,20 +134,20 @@
 
 @code
 {
-    static RenderFragment<(Select<TItemValue, TItem> select, IEnumerable<SelectOptionItem<TItemValue, TItem>> selectOptionItems, RenderFragment<TItem> itemTemplate)> selectOptionsRender = ctx =>
+    static RenderFragment<(Select<TItemValue, TItem> select, RenderFragment<TItem> itemTemplate)> selectOptionsRender = ctx =>
         @<Template>
 @{ #if NET5_0_OR_GREATER }
             @if(ctx.select.EnableVirtualization)
             {
                 <Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize 
-                    Items=@(ctx.selectOptionItems is ICollection<SelectOptionItem<TItemValue, TItem>> optionsCollection ? optionsCollection : ctx.selectOptionItems.ToList()) 
+                    Items=@ctx.select._filterOptionsVirtualization
                     ChildContent="optionRender(ctx.itemTemplate)"/>
             }
             else
             {
 #endif 
                 <ForeachLoop 
-                    Items=@(ctx.selectOptionItems is ICollection<SelectOptionItem<TItemValue, TItem>> optionsCollection ? optionsCollection : ctx.selectOptionItems.ToList()) 
+                    Items=@ctx.select.SortedSelectOptionItems
                     ChildContent="optionRender(ctx.itemTemplate)"/>
 #if NET5_0_OR_GREATER 
             }

--- a/components/select/Select.razor
+++ b/components/select/Select.razor
@@ -140,7 +140,7 @@
             @if(ctx.select.EnableVirtualization)
             {
                 <Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize 
-                    Items=@ctx.select._filterOptionsVirtualization
+                    Items=@ctx.select.SortedSelectOptionItems.Where(x => !x.IsHidden).ToList()
                     ChildContent="optionRender(ctx.itemTemplate)"/>
             }
             else

--- a/components/select/Select.razor.cs
+++ b/components/select/Select.razor.cs
@@ -38,8 +38,6 @@ namespace AntDesign
         /// </summary>
         [Parameter]
         public bool EnableVirtualization { get; set; }
-
-        protected internal List<SelectOptionItem<TItemValue, TItem>> _filterOptionsVirtualization = [];
 #endif
 
         private bool _dataSourceHasChanged = false;
@@ -768,10 +766,6 @@ namespace AntDesign
                     }
                 }
             }
-
-#if NET5_0_OR_GREATER
-            ResetFilterOptionsVirtualization();
-#endif
         }
 
         /// <summary>
@@ -1245,28 +1239,10 @@ namespace AntDesign
                     SelectOptionItems.Remove(CustomTagSelectOptionItem);
                     CustomTagSelectOptionItem = null;
                 }
-
-#if NET5_0_OR_GREATER
-                ResetFilterOptionsVirtualization();
-#endif
-
             }
             OnSearch?.Invoke(_searchValue);
         }
 
-#if NET5_0_OR_GREATER
-        private void ResetFilterOptionsVirtualization()
-        {
-            if (!EnableVirtualization)
-            {
-                return;
-            }
-
-            _filterOptionsVirtualization.Clear();
-            _filterOptionsVirtualization.Capacity = SelectOptionItems.Count;
-            _filterOptionsVirtualization.AddRange(SelectOptionItems);
-        }
-#endif
         private async Task TokenizeSearchedPhrase(string searchValue)
         {
             Dictionary<string, SelectOptionItem<TItemValue, TItem>> tokenItemMatch = new();
@@ -1325,9 +1301,6 @@ namespace AntDesign
         {
             if (SelectMode != SelectMode.Tags)
             {
-#if NET5_0_OR_GREATER
-                _filterOptionsVirtualization.Clear();
-#endif
                 bool firstDone = false;
                 foreach (var item in SelectOptionItems)
                 {
@@ -1353,13 +1326,6 @@ namespace AntDesign
                         }
                         item.IsActive = false;
                     }
-
-#if NET5_0_OR_GREATER
-                    if (EnableVirtualization && !item.IsHidden)
-                    {
-                        _filterOptionsVirtualization.Add(item);
-                    }
-#endif
                 }
             }
             else

--- a/components/select/Select.razor.cs
+++ b/components/select/Select.razor.cs
@@ -38,6 +38,8 @@ namespace AntDesign
         /// </summary>
         [Parameter]
         public bool EnableVirtualization { get; set; }
+
+        protected internal List<SelectOptionItem<TItemValue, TItem>> _filterOptionsVirtualization = [];
 #endif
 
         private bool _dataSourceHasChanged = false;
@@ -766,6 +768,10 @@ namespace AntDesign
                     }
                 }
             }
+
+#if NET5_0_OR_GREATER
+            ResetFilterOptionsVirtualization();
+#endif
         }
 
         /// <summary>
@@ -1239,10 +1245,28 @@ namespace AntDesign
                     SelectOptionItems.Remove(CustomTagSelectOptionItem);
                     CustomTagSelectOptionItem = null;
                 }
+
+#if NET5_0_OR_GREATER
+                ResetFilterOptionsVirtualization();
+#endif
+
             }
             OnSearch?.Invoke(_searchValue);
         }
 
+#if NET5_0_OR_GREATER
+        private void ResetFilterOptionsVirtualization()
+        {
+            if (!EnableVirtualization)
+            {
+                return;
+            }
+
+            _filterOptionsVirtualization.Clear();
+            _filterOptionsVirtualization.Capacity = SelectOptionItems.Count;
+            _filterOptionsVirtualization.AddRange(SelectOptionItems);
+        }
+#endif
         private async Task TokenizeSearchedPhrase(string searchValue)
         {
             Dictionary<string, SelectOptionItem<TItemValue, TItem>> tokenItemMatch = new();
@@ -1301,6 +1325,9 @@ namespace AntDesign
         {
             if (SelectMode != SelectMode.Tags)
             {
+#if NET5_0_OR_GREATER
+                _filterOptionsVirtualization.Clear();
+#endif
                 bool firstDone = false;
                 foreach (var item in SelectOptionItems)
                 {
@@ -1326,6 +1353,13 @@ namespace AntDesign
                         }
                         item.IsActive = false;
                     }
+
+#if NET5_0_OR_GREATER
+                    if (EnableVirtualization && !item.IsHidden)
+                    {
+                        _filterOptionsVirtualization.Add(item);
+                    }
+#endif
                 }
             }
             else

--- a/site/AntDesign.Docs/Demos/Components/Select/demo/BigData.razor
+++ b/site/AntDesign.Docs/Demos/Components/Select/demo/BigData.razor
@@ -13,6 +13,22 @@
 		EnableSearch
         EnableVirtualization>
 </Select>
+
+<Select Mode="default"
+        Placeholder="Please select"
+        DataSource="@_options"
+        @bind-Value="@_selectedValue"
+        LabelName="@nameof(LabeledValue.Label)"
+        ValueName="@nameof(LabeledValue.Value)"
+        DisabledName="@nameof(LabeledValue.Disabled)"
+        TItemValue="string"
+        TItem="LabeledValue"
+        OnSelectedItemChanged="OnSelectedItemChangedHandler"
+        EnableSearch
+        EnableVirtualization
+        Style="width: 100%; margin-top: 8px;">
+</Select>
+
 @code
 {
 	class LabeledValue
@@ -32,6 +48,7 @@
 	
     List<LabeledValue> _options;
 	IEnumerable<string> _selectedValues = new List<string> { "0a10", "0c12" };
+    string _selectedValue = "000";
     protected override void OnInitialized()
     {
         const int min = 0;
@@ -49,5 +66,9 @@
     private void OnSelectedItemsChangedHandler(IEnumerable<LabeledValue> values)
     {
         Console.WriteLine($"selected: ${string.Join(",", values.Select(x => x.Label))}");
+    }
+    private void OnSelectedItemChangedHandler(LabeledValue value)
+    {
+        Console.WriteLine($"selected: ${value.Label}");
     }
 }


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

#3460 Select Virtualization Bug
#3410 Select - Virtualization of 2000 items

### 💡 Background and solution

When Select filters options it not remove the option from the DOM it only hide it and leave it on the collection SelectOptionItems.

When passing all items include the hidden the virtualization component can't calculate the height of the scroll.

I create a member _filterOptionsVirtualization to store only the items that aren't hidden and refactor the template to use it, This way is a better more performant than recreating every time is renders.

I create another method to fill list with all the options when it start and when the search is clear to maintain the list that is needed because the virtualization component don't support IEnumerable and it was using .ToList every time it was rendered.

Please any suggestion or change to this solution is welcome... i only test it with the default type.

### 📝 Changelog

Fix search when virtualization is enabled.

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
