### PR TITLE
feat(module: select) Add FilterExpression on select for customize how to filter when searching

### DIFF
--- a/components/select/Select.razor.cs
+++ b/components/select/Select.razor.cs
@@ -241,7 +241,7 @@ namespace AntDesign
         /// </summary>
         [Parameter] public Action<string> OnSearch { get; set; }
 
-        [Parameter] public Func<string, string, CultureInfo, bool> FilterExpression { get; set; } = (label, searchValue, cultureInfo) => label.Contains(searchValue, StringComparison.InvariantCultureIgnoreCase);
+        [Parameter] public Func<string, string, bool> FilterExpression { get; set; } = (label, searchValue) => label.Contains(searchValue, StringComparison.InvariantCultureIgnoreCase);
 
         [Parameter] public string PopupContainerMaxHeight { get; set; } = "256px";
 
@@ -1307,7 +1307,7 @@ namespace AntDesign
                 bool firstDone = false;
                 foreach (var item in SelectOptionItems)
                 {
-                    if (FilterExpression(item.Label, searchValue, CultureInfo))
+                    if (FilterExpression(item.Label, searchValue))
                     {
                         if (!firstDone)
                         {
@@ -1353,7 +1353,7 @@ namespace AntDesign
             {
                 if (!(CustomTagSelectOptionItem != null && item.Equals(CustomTagSelectOptionItem))) //ignore if analyzing CustomTagSelectOptionItem
                 {
-                    if (FilterExpression(item.Label, searchValue, CultureInfo))
+                    if (FilterExpression(item.Label, searchValue))
                     {
                         if (item.Label.Equals(searchValue, StringComparison.InvariantCulture))
                         {

--- a/components/select/Select.razor.cs
+++ b/components/select/Select.razor.cs
@@ -241,7 +241,7 @@ namespace AntDesign
         /// </summary>
         [Parameter] public Action<string> OnSearch { get; set; }
 
-        [Parameter] public Func<string, string, bool> FilterExpression { get; set; } = (label, searchValue) => label.Contains(searchValue, StringComparison.InvariantCultureIgnoreCase);
+        [Parameter] public Func<SelectOptionItem<TItemValue, TItem>, string, bool> FilterExpression { get; set; } = (item, searchValue) => item.Label.Contains(searchValue, StringComparison.InvariantCultureIgnoreCase);
 
         [Parameter] public string PopupContainerMaxHeight { get; set; } = "256px";
 
@@ -1307,7 +1307,7 @@ namespace AntDesign
                 bool firstDone = false;
                 foreach (var item in SelectOptionItems)
                 {
-                    if (FilterExpression(item.Label, searchValue))
+                    if (FilterExpression(item, searchValue))
                     {
                         if (!firstDone)
                         {
@@ -1353,7 +1353,7 @@ namespace AntDesign
             {
                 if (!(CustomTagSelectOptionItem != null && item.Equals(CustomTagSelectOptionItem))) //ignore if analyzing CustomTagSelectOptionItem
                 {
-                    if (FilterExpression(item.Label, searchValue))
+                    if (FilterExpression(item, searchValue))
                     {
                         if (item.Label.Equals(searchValue, StringComparison.InvariantCulture))
                         {

--- a/components/select/Select.razor.cs
+++ b/components/select/Select.razor.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -239,6 +240,8 @@ namespace AntDesign
         /// Callback function that is fired when input changed.
         /// </summary>
         [Parameter] public Action<string> OnSearch { get; set; }
+
+        [Parameter] public Func<string, string, CultureInfo, bool> FilterExpression { get; set; } = (label, searchValue, cultureInfo) => label.Contains(searchValue, StringComparison.InvariantCultureIgnoreCase);
 
         [Parameter] public string PopupContainerMaxHeight { get; set; } = "256px";
 
@@ -1304,7 +1307,7 @@ namespace AntDesign
                 bool firstDone = false;
                 foreach (var item in SelectOptionItems)
                 {
-                    if (item.Label.Contains(searchValue, StringComparison.InvariantCultureIgnoreCase))
+                    if (FilterExpression(item.Label, searchValue, CultureInfo))
                     {
                         if (!firstDone)
                         {
@@ -1350,7 +1353,7 @@ namespace AntDesign
             {
                 if (!(CustomTagSelectOptionItem != null && item.Equals(CustomTagSelectOptionItem))) //ignore if analyzing CustomTagSelectOptionItem
                 {
-                    if (item.Label.Contains(searchValue, StringComparison.InvariantCultureIgnoreCase))
+                    if (FilterExpression(item.Label, searchValue, CultureInfo))
                     {
                         if (item.Label.Equals(searchValue, StringComparison.InvariantCulture))
                         {

--- a/site/AntDesign.Docs/Demos/Components/Select/demo/SearchFilterCustomize.razor
+++ b/site/AntDesign.Docs/Demos/Components/Select/demo/SearchFilterCustomize.razor
@@ -1,0 +1,68 @@
+@using System.Globalization
+
+<Select TItem="Person"
+	TItemValue="string"
+	DataSource="@_persons"
+		@bind-Value="@_selectedValue"
+		LabelName="@nameof(Person.Name)"
+		ValueName="@nameof(Person.Value)"
+		Placeholder="Select a person"
+		DefaultActiveFirstOption="false"
+		EnableSearch
+		OnBlur="OnBlur"
+		OnFocus="OnFocus"
+		OnSelectedItemChanged="OnSelectedItemChangedHandler"
+		OnSearch="OnSearch"
+		FilterExpression="(label, searchValue, cultureInfo)	=> cultureInfo.CompareInfo.IndexOf(label, searchValue, CompareOptions.IgnoreNonSpace | CompareOptions.IgnoreCase) >= 0">
+</Select>
+<br /><br />
+<p>
+	Selected Value: @_selectedValue <br />
+	Selected Item Name: @_selectedItem?.Name
+</p>
+
+@code
+{
+	class Person
+	{
+		public string Value { get; set; }
+		public string Name { get; set; }
+	}
+
+	List<Person> _persons;
+	string _selectedValue;
+	Person _selectedItem;
+
+	protected override void OnInitialized()
+	{
+		_persons = new List<Person>
+		{
+			new Person { Value = "jack", Name = "Jack" },
+			new Person { Value = "lucy", Name = "Lucy" },
+			new Person { Value = "tom" , Name = "Tom" },
+			new Person { Value = "hernan" , Name = "Hernán" },
+			new Person { Value = "marino" , Name = "Mariño" },
+		};
+	}
+
+	private void OnSelectedItemChangedHandler(Person value)
+	{
+		_selectedItem = value;
+		Console.WriteLine($"selected: ${value?.Name}");
+	}
+
+	private void OnBlur()
+	{
+		Console.WriteLine("blur");
+	}
+
+	private void OnFocus()
+	{
+		Console.WriteLine("focus");
+	}
+
+	private void OnSearch(string value)
+	{
+		Console.WriteLine($"search: {value}");
+	}
+}

--- a/site/AntDesign.Docs/Demos/Components/Select/demo/SearchFilterCustomize.razor
+++ b/site/AntDesign.Docs/Demos/Components/Select/demo/SearchFilterCustomize.razor
@@ -13,7 +13,7 @@
 		OnFocus="OnFocus"
 		OnSelectedItemChanged="OnSelectedItemChangedHandler"
 		OnSearch="OnSearch"
-		FilterExpression="(label, searchValue) => CultureInfo.CurrentCulture.CompareInfo.IndexOf(label, searchValue, CompareOptions.IgnoreNonSpace | CompareOptions.IgnoreCase) >= 0">
+		FilterExpression="(item, searchValue) => CultureInfo.CurrentCulture.CompareInfo.IndexOf(item.Label, searchValue, CompareOptions.IgnoreNonSpace | CompareOptions.IgnoreCase) >= 0">
 </Select>
 <br /><br />
 <p>

--- a/site/AntDesign.Docs/Demos/Components/Select/demo/SearchFilterCustomize.razor
+++ b/site/AntDesign.Docs/Demos/Components/Select/demo/SearchFilterCustomize.razor
@@ -13,7 +13,7 @@
 		OnFocus="OnFocus"
 		OnSelectedItemChanged="OnSelectedItemChangedHandler"
 		OnSearch="OnSearch"
-		FilterExpression="(label, searchValue, cultureInfo)	=> cultureInfo.CompareInfo.IndexOf(label, searchValue, CompareOptions.IgnoreNonSpace | CompareOptions.IgnoreCase) >= 0">
+		FilterExpression="(label, searchValue) => CultureInfo.CurrentCulture.CompareInfo.IndexOf(label, searchValue, CompareOptions.IgnoreNonSpace | CompareOptions.IgnoreCase) >= 0">
 </Select>
 <br /><br />
 <p>

--- a/site/AntDesign.Docs/Demos/Components/Select/demo/search-filter-customize.md
+++ b/site/AntDesign.Docs/Demos/Components/Select/demo/search-filter-customize.md
@@ -1,0 +1,14 @@
+---
+order: 2
+title:
+  zh-CN: 使用自定义过滤器选择
+  en-US: Select with custom filter
+---
+
+## zh-CN
+
+使用自定义过滤器搜索选项，忽略非空格字符。
+
+## en-US
+
+Search the options using custom filter ignoring non space characters.

--- a/site/AntDesign.Docs/Demos/Components/Select/doc/index.en-US.md
+++ b/site/AntDesign.Docs/Demos/Components/Select/doc/index.en-US.md
@@ -39,6 +39,7 @@ Select component to select value from options.
 | DropdownRender | Customize dropdown content. | Renderfragment | - |  |
 | SearchDebounceMilliseconds | Delays the processing of the search input event until the user has stopped typing for a predetermined amount of time | int        |  250         |
 | EnableSearch | Indicates whether the search function is active or not. Always `true` for mode `tags`. | bool | false |  |
+| FilterExpression | Customize the logic to filter when searching. | Func<string, string, CultureInfo, bool> | (label, searchValue, cultureInfo) => label.Contains(searchValue, StringComparison.InvariantCultureIgnoreCase) |  |
 | GroupName | The name of the property to be used as a group indicator. If the value is set, the entries are displayed in groups. Use additional `SortByGroup` and `SortByLabel`. | string | - |  |
 | HideSelected | Hides the selected items when they are selected. | bool | false |  |
 | IgnoreItemChanges | Is used to increase the speed. If you expect changes to the label name, group name or disabled indicator, disable this property. | bool | true |  |

--- a/site/AntDesign.Docs/Demos/Components/Select/doc/index.en-US.md
+++ b/site/AntDesign.Docs/Demos/Components/Select/doc/index.en-US.md
@@ -39,7 +39,7 @@ Select component to select value from options.
 | DropdownRender | Customize dropdown content. | Renderfragment | - |  |
 | SearchDebounceMilliseconds | Delays the processing of the search input event until the user has stopped typing for a predetermined amount of time | int        |  250         |
 | EnableSearch | Indicates whether the search function is active or not. Always `true` for mode `tags`. | bool | false |  |
-| FilterExpression | Customize the logic to filter when searching. | Func<string, string, CultureInfo, bool> | (label, searchValue, cultureInfo) => label.Contains(searchValue, StringComparison.InvariantCultureIgnoreCase) |  |
+| FilterExpression | Customize the logic to filter when searching. | Func<string, string, bool> | (label, searchValue) => label.Contains(searchValue, StringComparison.InvariantCultureIgnoreCase) |  |
 | GroupName | The name of the property to be used as a group indicator. If the value is set, the entries are displayed in groups. Use additional `SortByGroup` and `SortByLabel`. | string | - |  |
 | HideSelected | Hides the selected items when they are selected. | bool | false |  |
 | IgnoreItemChanges | Is used to increase the speed. If you expect changes to the label name, group name or disabled indicator, disable this property. | bool | true |  |

--- a/site/AntDesign.Docs/Demos/Components/Select/doc/index.en-US.md
+++ b/site/AntDesign.Docs/Demos/Components/Select/doc/index.en-US.md
@@ -39,7 +39,7 @@ Select component to select value from options.
 | DropdownRender | Customize dropdown content. | Renderfragment | - |  |
 | SearchDebounceMilliseconds | Delays the processing of the search input event until the user has stopped typing for a predetermined amount of time | int        |  250         |
 | EnableSearch | Indicates whether the search function is active or not. Always `true` for mode `tags`. | bool | false |  |
-| FilterExpression | Customize the logic to filter when searching. | Func<string, string, bool> | (label, searchValue) => label.Contains(searchValue, StringComparison.InvariantCultureIgnoreCase) |  |
+| FilterExpression | Customize the logic to filter when searching. | Func<SelectOptionItem<TItemValue, TItem>, string, bool> | (item, searchValue) => item.Label.Contains(searchValue, StringComparison.InvariantCultureIgnoreCase) |  |
 | GroupName | The name of the property to be used as a group indicator. If the value is set, the entries are displayed in groups. Use additional `SortByGroup` and `SortByLabel`. | string | - |  |
 | HideSelected | Hides the selected items when they are selected. | bool | false |  |
 | IgnoreItemChanges | Is used to increase the speed. If you expect changes to the label name, group name or disabled indicator, disable this property. | bool | true |  |

--- a/site/AntDesign.Docs/Demos/Components/Select/doc/index.zh-CN.md
+++ b/site/AntDesign.Docs/Demos/Components/Select/doc/index.zh-CN.md
@@ -39,7 +39,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/_0XzgOis7/Select.svg
 | DropdownRender | 自定义下拉框内容 | Renderfragment | - |  |
 | SearchDebounceMilliseconds |推迟对搜索输入事件的处理，直到用户停止输入一个预定的时间。 | int        | 250    |
 | EnableSearch | 指示搜索功能是否处于活动状态。 对于Mode = `tags` 始终为 `true`。 | bool | false |  |
-| FilterExpression | 自定义搜索时过滤的逻辑。 | Func<string, string, bool> | (label, searchValue) => label.Contains(searchValue, StringComparison.InvariantCultureIgnoreCase) |  |
+| FilterExpression | 自定义搜索时过滤的逻辑。 | Func<SelectOptionItem<TItemValue, TItem>, string, bool> | (item, searchValue) => item.Label.Contains(searchValue, StringComparison.InvariantCultureIgnoreCase) |  |
 | GroupName | 用作组指示符的属性的名称。 如果设置了该值，则条目将按组显示。 使用额外的 `SortByGroup` 和 `SortByLabel`. | string | - |  |
 | HideSelected | 是否隐藏选中项. | bool | false |  |
 | IgnoreItemChanges |用于提高速度。 如果希望更改标签名称、组名称或禁用指示器，请禁用此属性。 | bool | true |  |

--- a/site/AntDesign.Docs/Demos/Components/Select/doc/index.zh-CN.md
+++ b/site/AntDesign.Docs/Demos/Components/Select/doc/index.zh-CN.md
@@ -39,7 +39,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/_0XzgOis7/Select.svg
 | DropdownRender | 自定义下拉框内容 | Renderfragment | - |  |
 | SearchDebounceMilliseconds |推迟对搜索输入事件的处理，直到用户停止输入一个预定的时间。 | int        | 250    |
 | EnableSearch | 指示搜索功能是否处于活动状态。 对于Mode = `tags` 始终为 `true`。 | bool | false |  |
-| FilterExpression | 自定义搜索时过滤的逻辑。 | Func<string, string, CultureInfo, bool> | (label, searchValue, cultureInfo) => label.Contains(searchValue, StringComparison.InvariantCultureIgnoreCase) |  |
+| FilterExpression | 自定义搜索时过滤的逻辑。 | Func<string, string, bool> | (label, searchValue) => label.Contains(searchValue, StringComparison.InvariantCultureIgnoreCase) |  |
 | GroupName | 用作组指示符的属性的名称。 如果设置了该值，则条目将按组显示。 使用额外的 `SortByGroup` 和 `SortByLabel`. | string | - |  |
 | HideSelected | 是否隐藏选中项. | bool | false |  |
 | IgnoreItemChanges |用于提高速度。 如果希望更改标签名称、组名称或禁用指示器，请禁用此属性。 | bool | true |  |

--- a/site/AntDesign.Docs/Demos/Components/Select/doc/index.zh-CN.md
+++ b/site/AntDesign.Docs/Demos/Components/Select/doc/index.zh-CN.md
@@ -39,6 +39,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/_0XzgOis7/Select.svg
 | DropdownRender | 自定义下拉框内容 | Renderfragment | - |  |
 | SearchDebounceMilliseconds |推迟对搜索输入事件的处理，直到用户停止输入一个预定的时间。 | int        | 250    |
 | EnableSearch | 指示搜索功能是否处于活动状态。 对于Mode = `tags` 始终为 `true`。 | bool | false |  |
+| FilterExpression | 自定义搜索时过滤的逻辑。 | Func<string, string, CultureInfo, bool> | (label, searchValue, cultureInfo) => label.Contains(searchValue, StringComparison.InvariantCultureIgnoreCase) |  |
 | GroupName | 用作组指示符的属性的名称。 如果设置了该值，则条目将按组显示。 使用额外的 `SortByGroup` 和 `SortByLabel`. | string | - |  |
 | HideSelected | 是否隐藏选中项. | bool | false |  |
 | IgnoreItemChanges |用于提高速度。 如果希望更改标签名称、组名称或禁用指示器，请禁用此属性。 | bool | true |  |

--- a/tests/AntDesign.Tests/Select/Select.FilterExpression.Tests.razor
+++ b/tests/AntDesign.Tests/Select/Select.FilterExpression.Tests.razor
@@ -1,0 +1,138 @@
+﻿@using AntDesign.Core.JsInterop.Modules.Components;
+@using System.Globalization
+@inherits AntDesignTestBase
+@code {
+    record Person(int Id, string Name);
+
+    List<Person> _persons = new List<Person>
+    {
+        new Person(1, "John"),
+        new Person(2, "Lucy"),
+        new Person(3, "Jack"),
+        new Person(4, "Emily"),
+        new Person(5, "Hernán"),
+        new Person(6, "Mariño"),
+    };
+
+
+    public Select_FilterExpression_Tests(bool useMoq = false) : base(useMoq)
+    {
+        JSInterop.Setup<AntDesign.JsInterop.DomRect>(JSInteropConstants.GetBoundingClientRect, _ => true)
+            .SetResult(new AntDesign.JsInterop.DomRect());
+    }
+
+    [Theory]
+    [InlineData("nán", 1, new string[] { "Hernán" })]
+    [InlineData("a", 2, new string[] { "Jack", "Mariño" })]
+    [InlineData("l", 2, new string[] { "Lucy", "Emily" })]
+    [InlineData("m", 2, new string[] { "Emily", "Mariño" })]
+    [InlineData("oHn", 1, new string[] { "John" })]
+    [InlineData("ó", 0, new string[0])]
+    public void Will_found_using_default_filter_expression(string text, int count, string[] namesFound)
+    {
+        JSInterop.SetupVoid("AntDesign.interop.eventHelper.addPreventKeys", _ => true);
+        JSInterop.SetupVoid("AntDesign.interop.domManipulationHelper.focus", _ => true);
+        JSInterop
+            .Setup<OverlayPosition>("AntDesign.interop.overlayHelper.addOverlayToContainer", _ => true)
+            .SetResult(new OverlayPosition
+                {
+                    Bottom = 10,
+                    Left = 10,
+                    Right = 10,
+                    Top = 10,
+                    Placement = Placement.TopLeft,
+                    ZIndex = 100
+                });
+
+        var searchComplete = false;
+
+        var cut = Render<AntDesign.Select<Person, Person>>(
+            @<AntDesign.Select
+                EnableSearch=true
+                SearchDebounceMilliseconds=0
+                OnSearch="(search) => { searchComplete = true; }"
+                TItemValue="Person"
+                TItem="Person">
+                <SelectOptions>
+                    @foreach (var item in _persons)
+                    {
+                        <SelectOption @key="item"
+                              TItemValue="Person"
+                              TItem="Person"
+                              Value=@item
+                              Label=@item.Name />
+                    }
+                </SelectOptions>
+            </AntDesign.Select>
+        );
+
+        cut.Find("input[type=search]").Input(text);
+        cut.Find(".ant-select-item-option").Click();
+        cut.WaitForState(() => searchComplete);
+
+        var foundItems = cut.Instance.SelectOptionItems.Where(x=> !x.IsHidden).ToList();
+        foundItems.Count.Should().Be(count);
+        for (int i = 0; i < foundItems.Count; i++)
+        {
+            foundItems[i].Item.Name.Should().Be(namesFound[i]);
+        }
+    }
+
+    [Theory]
+    [InlineData("nan", 1, new string[] { "Hernán" })]
+    [InlineData("oHn", 1, new string[] { "John" })]
+    [InlineData("n", 3, new string[] { "John", "Hernán", "Mariño" })]
+    [InlineData("cy", 1, new string[] { "Lucy" })]
+    [InlineData("l", 2, new string[] { "Lucy", "Emily" })]
+    [InlineData("á", 3, new string[] { "Jack", "Hernán", "Mariño" })]
+    [InlineData("s", 0, new string[0])]
+    public void Will_found_using_custom_filter_expression(string text, int count, string[] namesFound)
+    {
+        JSInterop.SetupVoid("AntDesign.interop.eventHelper.addPreventKeys", _ => true);
+        JSInterop.SetupVoid("AntDesign.interop.domManipulationHelper.focus", _ => true);
+        JSInterop
+        .Setup<OverlayPosition>("AntDesign.interop.overlayHelper.addOverlayToContainer", _ => true)
+        .SetResult(new OverlayPosition
+                {
+                    Bottom = 10,
+                    Left = 10,
+                    Right = 10,
+                    Top = 10,
+                    Placement = Placement.TopLeft,
+                    ZIndex = 100
+                });
+
+        var searchComplete = false;
+
+        var cut = Render<AntDesign.Select<Person, Person>>(
+            @<AntDesign.Select EnableSearch=true
+                                SearchDebounceMilliseconds=0
+                                OnSearch="(search) => { searchComplete = true; }"
+                                TItemValue="Person"
+                                TItem="Person"
+                                FilterExpression="(item, searchValue) => CultureInfo.CurrentCulture.CompareInfo.IndexOf(item.Label, searchValue, CompareOptions.IgnoreNonSpace | CompareOptions.IgnoreCase) >= 0">
+                    <SelectOptions>
+                        @foreach (var item in _persons)
+                    {
+                        <SelectOption @key="item"
+                                    TItemValue="Person"
+                                    TItem="Person"
+                                    Value=@item
+                                    Label=@item.Name />
+                    }
+                    </SelectOptions>
+                </AntDesign.Select>
+        );
+
+        cut.Find("input[type=search]").Input(text);
+        cut.Find(".ant-select-item-option").Click();
+        cut.WaitForState(() => searchComplete);
+
+        var foundItems = cut.Instance.SelectOptionItems.Where(x => !x.IsHidden).ToList();
+        foundItems.Count.Should().Be(count);
+        for (int i = 0; i < foundItems.Count; i++)
+        {
+            foundItems[i].Item.Name.Should().Be(namesFound[i]);
+        }
+    }
+}


### PR DESCRIPTION
### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [x] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 💡 Background and solution

In spanish and other language you have characters like áéíóúñ and more, that for searching hide if you use the simple character.
By default it continue working like before but now you can pass a function to personalize how to compare the values and have more liberty to customize it by your requirements.

### 📝 Changelog

Added parameter FilterExpression for customize how to filter the labels in a select, is optional and by default work like before, no need to change anything.

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
