### PR TITLE
Fix label in SegmentedOption

### DIFF
--- a/components/segmented/SegmentedOption.cs
+++ b/components/segmented/SegmentedOption.cs
@@ -10,6 +10,6 @@ namespace AntDesign
 {
     public record struct SegmentedOption<TValue>(TValue Value, string Label = null, bool Disabled = false)
     {
-        public string Label { get; set; } = Value.ToString();
+        public string Label { get; set; } = Label ?? Value.ToString();
     }
 }


### PR DESCRIPTION
It self explain, but: new `SegmentedOption<int>(1, "one")` will render "1" instead of "one" which is a label i set