### PR TITLE
fix default scroll style

### DIFF
--- a/components/core/Extensions/ServiceCollectionExtensions.cs
+++ b/components/core/Extensions/ServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System.Globalization;
 using System.Text.Encodings.Web;
 using AntDesign;
+using AntDesign.core.Services;
 using AntDesign.Filters;
 using AntDesign.Internal;
 using AntDesign.JsInterop;
@@ -39,6 +40,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.TryAddScoped<ConfigService>();
             services.TryAddScoped<ReuseTabsService>();
             services.TryAddScoped<IFieldFilterTypeResolver, DefaultFieldFilterTypeResolver>();
+            services.TryAddScoped<ClientDimensionService>();
 
             CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.CurrentCulture;
 

--- a/components/core/JsInterop/JSInteropConstants.cs
+++ b/components/core/JsInterop/JSInteropConstants.cs
@@ -191,6 +191,7 @@ namespace AntDesign
             public static string InvokeTabKey => $"{FUNC_PREFIX}invokeTabKey";
             public static string DisableBodyScroll => $"{FUNC_PREFIX}disableBodyScroll";
             public static string EnableBodyScroll => $"{FUNC_PREFIX}enableBodyScroll";
+            public static string GetScrollBarSize => $"{FUNC_PREFIX}getScrollBarSize";
         }
 
         public static class StyleHelper

--- a/components/core/Services/ClientDimensionService.cs
+++ b/components/core/Services/ClientDimensionService.cs
@@ -1,0 +1,22 @@
+﻿using System.Threading.Tasks;
+using Microsoft.JSInterop;
+
+namespace AntDesign.core.Services;
+
+public class ClientDimensionService
+{
+    private double? _scrollBarSize;
+    private readonly IJSRuntime _js;
+
+    public ClientDimensionService(IJSRuntime js)
+    {
+        _js = js;
+    }
+
+    public async Task<double> GetScrollBarSizeAsync()
+    {
+        _scrollBarSize ??= await _js.InvokeAsync<double>(JSInteropConstants.DomMainpulationHelper.GetScrollBarSize, false);
+
+        return _scrollBarSize.Value;
+    }
+}

--- a/components/table/ColumnBase.cs
+++ b/components/table/ColumnBase.cs
@@ -210,7 +210,7 @@ namespace AntDesign
 
             if (IsHeader && Table.ScrollY != null && Table.ScrollX != null && Fixed == "right")
             {
-                fixedWidths = fixedWidths.Append($"{(CssSizeLength)Table.ScrollBarWidth}");
+                fixedWidths = fixedWidths.Append($"{(CssSizeLength)Table.RealScrollBarSize}");
             }
 
             var fixedWidth = fixedWidths.Length switch

--- a/components/table/ITable.cs
+++ b/components/table/ITable.cs
@@ -40,6 +40,8 @@ namespace AntDesign
 
         internal string ScrollBarWidth { get; }
 
+        internal string RealScrollBarSize { get; }
+
         internal int ExpandIconColumnIndex { get; }
 
         internal int TreeExpandIconColumnIndex { get; }

--- a/components/table/Table.razor
+++ b/components/table/Table.razor
@@ -50,7 +50,7 @@
                                         @header()
                                     </table>
                                 </div>
-                                <div class="ant-table-body" @ref="_tableBodyRef" style="@(ScrollX!=null?" overflow: auto scroll;":"overflow-y: scroll;") max-height: @((CssSizeLength)ScrollY); @(UseItemsProvider?$"min-height:{(CssSizeLength)ScrollY};":"") --scrollbar-width: @((CssSizeLength)_scrollBarWidth);">
+                                <div class="ant-table-body" @ref="_tableBodyRef" style="@(ScrollX!=null?" overflow: auto scroll;":"overflow-y: scroll;") max-height: @((CssSizeLength)ScrollY); @(UseItemsProvider?$"min-height:{(CssSizeLength)ScrollY};":"") @(ScrollBarWidth == null ? "" : $"--scrollbar-width: {(CssSizeLength)_scrollBarWidth};")">
                                     <table style="@(ScrollX!=null?$"width: {(CssSizeLength)ScrollX}; min-width: 100%;":"") @TableLayoutStyle" @ref="_tableRef">
                                         @colGroup(this, false)
                                         <tbody class="ant-table-tbody">
@@ -70,7 +70,7 @@
                             }
                             else if (ScrollX != null)
                             {
-                                <div class="ant-table-content" @ref="_tableBodyRef" style="overflow: auto hidden; --scrollbar-width: @((CssSizeLength)_scrollBarWidth);">
+                                <div class="ant-table-content" @ref="_tableBodyRef" style="overflow: auto hidden; @(ScrollBarWidth == null ? "" : $"--scrollbar-width: {(CssSizeLength)_scrollBarWidth};")">
                                     <table style="width: @((CssSizeLength)ScrollX); min-width: 100%; @TableLayoutStyle;" @ref="_tableRef">
                                         @colGroup(this, true)
                                         @header()
@@ -92,7 +92,7 @@
                             else
                             {
                                 <div class="ant-table-content">
-                                    <table style="@TableLayoutStyle;--scrollbar-width: @((CssSizeLength)_scrollBarWidth);" @ref="_tableRef">
+                                    <table style="@TableLayoutStyle;@(ScrollBarWidth == null ? "" : $"--scrollbar-width: {(CssSizeLength)_scrollBarWidth};")" @ref="_tableRef">
                                         @colGroup(this, true)
                                         @header()
                                         <tbody class="ant-table-tbody">
@@ -164,6 +164,7 @@
 
     static RenderFragment colGroup(Table<TItem> table, bool header)
     {
+        var realSize = (CssSizeLength)((table as ITable).RealScrollBarSize);
         return @<colgroup>
                 <CascadingValue Name="IsColGroup" Value="true" IsFixed>
                 @if (_fieldModel is not null)
@@ -173,7 +174,7 @@
                 </CascadingValue>
                 @if (table.ScrollY != null && header)
                 {
-                    <col style="width: @((CssSizeLength)table.ScrollBarWidth); min-width: @((CssSizeLength)table.ScrollBarWidth);" />
+                    <col style="width: @realSize; min-width: @realSize;" />
                 }
             </colgroup>;
     }

--- a/components/table/Table.razor.cs
+++ b/components/table/Table.razor.cs
@@ -212,8 +212,8 @@ namespace AntDesign
         private bool _waitingDataSourceReload;
         private bool _waitingReloadAndInvokeChange;
         private bool _treeMode;
-        private string _scrollBarWidth = "17px";
-
+        private string _scrollBarWidth;
+        private string _realScrollBarSize = "15px";
         private bool _hasFixLeft;
         private bool _hasFixRight;
         private int _treeExpandIconColumnIndex;
@@ -254,6 +254,7 @@ namespace AntDesign
         string ITable.ScrollX => ScrollX;
         string ITable.ScrollY => ScrollY;
         string ITable.ScrollBarWidth => _scrollBarWidth;
+        string ITable.RealScrollBarSize => _realScrollBarSize;
         int ITable.ExpandIconColumnIndex => ExpandIconColumnIndex + (_selection != null && _selection.ColIndex <= ExpandIconColumnIndex ? 1 : 0);
         int ITable.TreeExpandIconColumnIndex => _treeExpandIconColumnIndex;
         bool ITable.HasExpandTemplate => ExpandTemplate != null;
@@ -633,6 +634,23 @@ namespace AntDesign
             InitializePagination();
 
             FieldFilterTypeResolver ??= InjectedFieldFilterTypeResolver;
+        }
+
+        public override async Task SetParametersAsync(ParameterView parameters)
+        {
+            if (parameters.TryGetValue<string>(nameof(ScrollBarWidth), out var value))
+            {
+                if (value is null)
+                {
+                    var scrollBarSize = await JsInvokeAsync<double>(JSInteropConstants.DomMainpulationHelper.GetScrollBarSize, false);
+                    _realScrollBarSize = $"{scrollBarSize}px";
+                }
+                else
+                {
+                    _realScrollBarSize = value;
+                }
+            }
+            await base.SetParametersAsync(parameters);
         }
 
         protected override void OnParametersSet()

--- a/site/AntDesign.Docs/Demos/Components/Table/demo/FixedColumnsHeader.razor
+++ b/site/AntDesign.Docs/Demos/Components/Table/demo/FixedColumnsHeader.razor
@@ -1,5 +1,5 @@
 ﻿@using System.ComponentModel
-<Table DataSource="data" PageSize="10" ScrollX="1500" ScrollY="300" ScrollBarWidth="5px">
+<Table DataSource="data" PageSize="10" ScrollX="1500" ScrollY="300" >
     <PropertyColumn Property="c=>c.Name" Width="100" Fixed="left" />
     <PropertyColumn Property="c=>c.Age" Width="100" Fixed="left" />
     <PropertyColumn Property="c=>c.Address" Width="150" Title="Column 1" />


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

Table scroll style is not consistent with the browser default style.
![3e440311cd35ff6b50e292b45cff799c](https://github.com/ant-design-blazor/ant-design-blazor/assets/22974175/00a247c3-c536-4526-946b-a64ba2cb6f72)


### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->
In order to solve the issue of misplacement of table fixed columns, a property called `ScrollBarWidth `was added. 
By reading the source codes of `antd` and `ant design vue`, I found that we can get the scrollbar size in the browser by calling js method.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->
I kept the ScrollBarWidth attribute and made it null by default, in which case the scroll bar style is consistent with the browser default style.
![image](https://github.com/ant-design-blazor/ant-design-blazor/assets/22974175/b686b4e6-73a9-4271-916c-c45da41c64a9)

and we can still set this property manually.
![image](https://github.com/ant-design-blazor/ant-design-blazor/assets/22974175/b327bb1d-4143-4125-8f61-44a4938d0b4c)


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   fix default ScrollBar style in Table   |
| 🇨🇳 Chinese |  修复Table中默认滚动条样式  |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
