### PR TITLE
Fix clearing input in Select when value selected via search

### DIFF
--- a/components/select/internal/SelectContent.razor.cs
+++ b/components/select/internal/SelectContent.razor.cs
@@ -298,6 +298,7 @@ namespace AntDesign.Select.Internal
         internal void ClearSearch()
         {
             _inputString = string.Empty;
+            StateHasChanged();
         }
 
         private void SetInputWidth()

--- a/tests/AntDesign.Tests/Select/Select.Value.Tests.razor
+++ b/tests/AntDesign.Tests/Select/Select.Value.Tests.razor
@@ -150,6 +150,38 @@
         };
 
     }
+    
+    [Fact]
+    public void Select_Must_Set_SelectedValue_After_Select_In_DropDown()
+    {
+        var dataSource = new PersonNullable[]
+        {
+            new("1", "test"),
+            new("2", "qqqq")
+        };
+        
+        var cut = Render<AntDesign.Select<string, PersonNullable>>(
+            @<AntDesign.Select TItem="PersonNullable" TItemValue="string" DataSource="@dataSource"
+                               LabelName="@nameof(PersonNullable.Name)"
+                               ValueName="@nameof(PersonNullable.Id)"
+                               AllowClear>
+            </AntDesign.Select>);
+        cut.Render();
+        
+        // Act
+        var input = cut.Find("input");
+        input.Input("t");
+        cut.WaitForElements("div.ant-select-item-option-content");
+        var dropDownItems = cut.FindAll("div.ant-select-item-option-content");
+        var firstItem = dropDownItems.First();
+        firstItem.Click();
+        
+        // Arrange
+        cut.WaitForElement("span.ant-select-selection-item");
+        var selectedLabel = cut.Find("span.ant-select-selection-item");
+        selectedLabel.GetAttribute("title").Should().Be("test");
+        input.GetAttribute("value").Should().BeEmpty();
+    }
 
 /*
     [Theory]


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

Fix clearing input in Select when value selected via search

Need to update Blazor state

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix clearing input in Select when value selected via search     |
| 🇨🇳 Chinese |       修正通过搜索选择值时在选择中清除输入    |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
