### PR TITLE
Fix List order after datasource change

### DIFF
--- a/components/select/Select.razor.cs
+++ b/components/select/Select.razor.cs
@@ -657,7 +657,6 @@ namespace AntDesign
 
                         if (exists is null)
                         {
-                            SelectOptionItems.Remove(selectOption);
                             RemoveEqualityToNoValue(selectOption);
 
                             if (selectOption.IsSelected)
@@ -668,6 +667,7 @@ namespace AntDesign
                     }
                 }
             }
+            SelectOptionItems.Clear();
 
             //A simple approach to avoid unnecessary scanning through _selectedValues once
             //all of SelectOptionItem where already marked as selected
@@ -742,6 +742,7 @@ namespace AntDesign
                     updateSelectOption.IsDisabled = disabled;
                     updateSelectOption.GroupName = groupName;
                     updateSelectOption.IsHidden = isSelected && HideSelected;
+                    SelectOptionItems.Add(updateSelectOption);
                     if (isSelected)
                     {
                         if (!updateSelectOption.IsSelected)

--- a/components/select/Select.razor.cs
+++ b/components/select/Select.razor.cs
@@ -657,6 +657,10 @@ namespace AntDesign
 
                         if (exists is null)
                         {
+                            if (IgnoreItemChanges)
+                            {
+                                SelectOptionItems.Remove(selectOption);
+                            }
                             RemoveEqualityToNoValue(selectOption);
 
                             if (selectOption.IsSelected)
@@ -667,7 +671,10 @@ namespace AntDesign
                     }
                 }
             }
-            SelectOptionItems.Clear();
+            if (!IgnoreItemChanges)
+            {
+                SelectOptionItems.Clear();
+            }
 
             //A simple approach to avoid unnecessary scanning through _selectedValues once
             //all of SelectOptionItem where already marked as selected

--- a/tests/AntDesign.Tests/Select/Actions/Select.OnDataSourceChange.Tests.razor
+++ b/tests/AntDesign.Tests/Select/Actions/Select.OnDataSourceChange.Tests.razor
@@ -352,4 +352,94 @@
         selectedItem.TextContent.Trim().Should().Be("Lucy");
         value.Should().Be("Lucy");
     }
+
+    // Issues: #3750 & #3021 
+    // PR: #3806
+    [Fact]
+    public void Object_DataSource_change_replace_all_with_right_order()
+    {
+        //Arrange
+        JSInterop.Setup<AntDesign.JsInterop.DomRect>(JSInteropConstants.GetBoundingClientRect, _ => true)
+        .SetResult(new AntDesign.JsInterop.DomRect());
+        int value = 2;
+        List<Person> newPersons = new List<Person>
+        {
+        new Person(10, "Maria"),
+        new Person(11, "Lucas"),
+        new Person(12, "Erick"),
+        };
+        Action<int> ValueChanged = (v) => value = v;
+        var cut = Render<AntDesign.Select<int, Person>>(
+    @<AntDesign.Select DataSource="@_persons"
+                                   LabelName="@nameof(Person.Name)"
+                                   ValueName="@nameof(Person.Id)"
+                                   Value="@value"
+                                   ValueChanged="@ValueChanged"
+                                   IgnoreItemChanges="false"
+                                   AllowClear>
+    </AntDesign.Select>
+        );
+        //Act
+        cut.SetParametersAndRender(parameters =>
+            parameters
+                .Add(p => p.DataSource, newPersons)
+        );
+        //Assert
+        var options = cut.FindAll(".ant-select-item-option-content");
+        //Should not have any selected
+        cut.FindAll(".ant-select-selection-item").Should().BeEmpty();
+        options.Should().HaveCount(3);
+        //Check if it's in right order
+        for (int i = 0; i < options.Count; i++)
+        {
+            options[i].TextContent.Trim().Should().Be(newPersons[i].Name);
+        }
+    }
+
+    // Issues: #3750 & #3021
+    // PR: #3806
+    [Fact]
+    public void Object_DataSource_change_replace_some_with_right_order()
+    {
+        //Arrange
+        JSInterop.Setup<AntDesign.JsInterop.DomRect>(JSInteropConstants.GetBoundingClientRect, _ => true)
+    .SetResult(new AntDesign.JsInterop.DomRect());
+        int value = 2;
+        List<Person> newPersons = new List<Person>
+            {
+        new Person(2, "Lucy"),
+        new Person(4, "Emily"),
+        new Person(10, "Maria"),
+        new Person(11, "Lucas"),
+        new Person(12, "Erick"),
+            };
+        Action<int> ValueChanged = (v) => value = v;
+        var cut = Render<AntDesign.Select<int, Person>>(
+    @<AntDesign.Select DataSource="@_persons"
+                           LabelName="@nameof(Person.Name)"
+                           ValueName="@nameof(Person.Id)"
+                           Value="@value"
+                           ValueChanged="@ValueChanged"
+                           IgnoreItemChanges="false"
+                           AllowClear>
+    </AntDesign.Select>
+        );
+        //Act
+        cut.SetParametersAndRender(parameters =>
+            parameters
+                .Add(p => p.DataSource, newPersons)
+        );
+        //Assert
+        var options = cut.FindAll(".ant-select-item-option-content");
+        var selectedItem = cut.Find(".ant-select-selection-item");
+        options.Should().HaveCount(5);
+        //Check if it's in right order
+        for (int i = 0; i < options.Count; i++)
+        {
+            options[i].TextContent.Trim().Should().Be(newPersons[i].Name);
+        }
+        //Should maintain Lucy selected
+        selectedItem.TextContent.Trim().Should().Be("Lucy");
+        value.Should().Be(2);
+    }
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
#3750 and #3021

### 💡 Background and solution
In my project we have faced this issue mentioned above, so i have investigated the root cause.
Due to how HashSet works internally on .NET, when an item is removed from a HashSet (using the Remove method), the space allocation maybe still be there, so when a new item is added (using the Add method), it is not guaranteded to be inserted at the end of the HashSet, so it will not follow the order from the Datasource sent to the Select component, causing the bug.

The solution is to call the Clear method on the HashSet SelectOptionItems after storing all the existing options in the Dictionary, and add everything from the new Datasource, and keep the select state of existing items.

<!--
1. Describe the problem and the scenario.
3. GIF or snapshot should be provided if includes UI/interactive modification.
4. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
