### PR TITLE
DatePicker Now button breaks when using ShowTime and ChangeOnClose #3…

### DIFF
--- a/components/date-picker/internal/DatePickerBase.cs
+++ b/components/date-picker/internal/DatePickerBase.cs
@@ -674,7 +674,10 @@ namespace AntDesign
         {
             if (ChangeOnClose && _duringManualInput)
             {
-                ChangeValue(_pickerStatus[index].SelectedValue.Value);
+                if (_pickerStatus[index].SelectedValue is not null)
+                {
+                    ChangeValue(_pickerStatus[index].SelectedValue.Value);
+                }
             }
         }
 

--- a/site/AntDesign.Docs/Demos/Components/DatePicker/demo/Mask.razor
+++ b/site/AntDesign.Docs/Demos/Components/DatePicker/demo/Mask.razor
@@ -8,4 +8,4 @@
 <br />
 <RangePicker TValue="DateOnly?[]" Format="dd-MM-yyyy" Mask="dd-MM-yyyy" Placeholder="@("dd-MM-yyyy")" />
 <br />
-<DatePicker TValue="DateTime?" ShowTime="@true" Format="yyyy-MM-ddTHH:mm ss" Mask="yyyy-MM-ddTHH:mm ss" Placeholder="@("yyyy-MM-ddTHH:mm ss")"/>
+<DatePicker TValue="DateTime?" ShowTime="@true" Format="yyyy-MM-ddTHH:mm ss" Mask="yyyy-MM-ddTHH:mm ss" ChangeOnClose Placeholder="@("yyyy-MM-ddTHH:mm ss")"/>


### PR DESCRIPTION
…770 Fixed

<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
https://github.com/ant-design-blazor/ant-design-blazor/issues/3770
### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->
Fix null reference exception
### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->
Fix DatePicker Now button breaks when using ShowTime and ChangeOnClos
| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix DatePicker Now button breaks when using ShowTime and ChangeOnClose     |
| 🇨🇳 Chinese |     修复DatePicker Now按钮在使用ShowTime时中断，并在关闭时更改      |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
