### PR TITLE
fix(module: InputNumber): Fix nullable floating types not round with "Precision" set

### DIFF
--- a/components/input-number/InputNumber.razor.cs
+++ b/components/input-number/InputNumber.razor.cs
@@ -213,7 +213,7 @@ namespace AntDesign
             _equalToFunc = fexpEqualTo.Compile();
 
             //四舍五入 rounding
-            if (_floatTypes.Contains(_surfaceType))
+            if (_floatTypes.Contains(underlyingType))
             {
                 ParameterExpression num = Expression.Parameter(_surfaceType, "num");
                 ParameterExpression decimalPlaces = Expression.Parameter(typeof(int), "decimalPlaces");

--- a/tests/AntDesign.Tests/InputNumber/InputNumberTests.razor
+++ b/tests/AntDesign.Tests/InputNumber/InputNumberTests.razor
@@ -15,7 +15,7 @@
         Func<string, string> parser = v => Regex.Replace(v, @"\$\s?|(,*)", "");
 
         var cut = Render<AntDesign.InputNumber<double>>(
-	@<AntDesign.InputNumber @ref="@input" Formatter="formatter" Parser="parser" DefaultValue="1000d" />
+            @<AntDesign.InputNumber @ref="@input" Formatter="formatter" Parser="parser" DefaultValue="1000d"/>
         );
         //Act
         cut.Find("input").Change("$ 10");
@@ -34,8 +34,8 @@
         AntDesign.InputNumber<double>? input = null;
 
         var cut = Render<AntDesign.InputNumber<double>>(
-        @<AntDesign.InputNumber @ref="@input" Step="0.00001" />
-    );
+            @<AntDesign.InputNumber @ref="@input" Step="0.00001"/>
+        );
         //Act
         var inputElement = cut.Find("input");
         inputElement.KeyDown(Key.Up);
@@ -58,8 +58,8 @@
 
         var bindValue = 0d;
         var cut = Render<AntDesign.InputNumber<double>>(
-        @<AntDesign.InputNumber @ref="@input" Precision="@precision" @bind-Value="bindValue" CultureInfo="CultureInfo.InvariantCulture" />
-    );
+            @<AntDesign.InputNumber @ref="@input" Precision="@precision" @bind-Value="bindValue" CultureInfo="CultureInfo.InvariantCulture"/>
+        );
         //Act
         var inputElement = cut.Find("input");
         inputElement.Input(value);
@@ -67,6 +67,33 @@
 
         //Assert
         inputElement.GetAttribute("value").Should().Be($"{expected}");
-        bindValue.Should().Equals(double.Parse(expected, CultureInfo.InvariantCulture));
+        bindValue.Should().Be(double.Parse(expected, CultureInfo.InvariantCulture));
+    }
+
+    [Theory]
+    [InlineData(2, "1", "1.00")]
+    [InlineData(2, "1.1", "1.10")]
+    [InlineData(2, "0.123", "0.12")]
+    [InlineData(2, "0.1277", "0.13")]
+    public void InputNumber_value_nullable_should_have_precision(int precision, string value, string expected)
+    {
+        //Arrange
+#pragma warning disable CS0618 // Type or member is obsolete
+        JSInterop.SetupVoid(JSInteropConstants.Focus, _ => true).SetVoidResult();
+#pragma warning restore CS0618 // Type or member is obsolete
+        AntDesign.InputNumber<double?>? input = null;
+
+        double? bindValue = default;
+        var cut = Render<AntDesign.InputNumber<double?>>(
+            @<AntDesign.InputNumber @ref="@input" Precision="@precision" @bind-Value="bindValue" CultureInfo="CultureInfo.InvariantCulture"/>
+        );
+        //Act
+        var inputElement = cut.Find("input");
+        inputElement.Input(value);
+        inputElement.Blur();
+
+        //Assert
+        inputElement.GetAttribute("value").Should().Be($"{expected}");
+        bindValue.Should().Be(double.Parse(expected, CultureInfo.InvariantCulture));
     }
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
Fixes: https://github.com/ant-design-blazor/ant-design-blazor/issues/3867

### 💡 Background and solution
The `if` check uses `_surfaceType` to set the round function which does not account for nullable floating types. 
https://github.com/ant-design-blazor/ant-design-blazor/blob/a53a8e24fc0df29a80f7fc6c0a52d8329b718fe0/components/input-number/InputNumber.razor.cs#L216

This PR fixes this by using `underlyingType`. Additionally, a test is added for it.


<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
