### PR TITLE
fix(module: menu): MenuItem IsSelected visual state for non-default use cases

### DIFF
--- a/components/menu/MenuItem.razor.cs
+++ b/components/menu/MenuItem.razor.cs
@@ -152,10 +152,8 @@ namespace AntDesign
             if (!skipParentSelection)
                 ParentMenu?.Select(isInitializing);
 
-            // fixed https://github.com/ant-design-blazor/ant-design-blazor/issues/3204
-            // It seems that the `StateHasChanged()` call in parent menu doesn't work correctly when the menuitem was warpped by a tooltip.
-            if (ShowTooltip)
-                StateHasChanged();
+            // It seems that the `StateHasChanged()` call in parent menu doesn't work correctly when the menuitem was wrapped by any other component than a menu.
+            StateHasChanged();
         }
 
         public void Deselect(bool sameParentAsSelected = false)
@@ -165,10 +163,8 @@ namespace AntDesign
             if (!sameParentAsSelected)
                 ParentMenu?.Deselect();
 
-            // fixed https://github.com/ant-design-blazor/ant-design-blazor/issues/3204
-            // It seems that the `StateHasChanged()` call in parent menu doesn't work correctly when the menuitem was warpped by a tooltip.
-            if (ShowTooltip)
-                StateHasChanged();
+            // It seems that the `StateHasChanged()` call in parent menu doesn't work correctly when the menuitem was wrapped by any other component than a menu.
+            StateHasChanged();
         }
     }
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [X] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
There is no issue for this bug

### 💡 Background and solution
I was wrapping my menu items into their own components for reuse. After this, the menu items selection was not updated properly.
I recorded a minimal set of examples (the no content case was discovered during testing for this fix):
![menu_without_fix](https://github.com/ant-design-blazor/ant-design-blazor/assets/139224358/6331c80c-bc51-4caf-aab4-30bb492d48c8)

The StateHasChanged, which is called on the hosting menu, not the MenuItem itself, does not seem to trigger the css classes to be refetched by Blazor. Issue #3204 maybe related to this.

After some testing, I decided to just call the StateHasChanged on the MenuItem when Select/Deselect is called. After all, these methods only get called when the active state was actually changed. Which fixed the issue:
![menu_with_fix](https://github.com/ant-design-blazor/ant-design-blazor/assets/139224358/cda2c1dc-5149-484c-9c17-e35ada03fa24)

Minimal example code:
![image](https://github.com/ant-design-blazor/ant-design-blazor/assets/139224358/31693952-9e83-41bd-8afb-ccdc339a3e7a)



### 📝 Changelog
| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | MenuItem's `IsSelected` visual state is now correctly updated, when it's wrapped into a component or has no child content |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] Changelog is provided or not needed
