### PR TITLE
fix(module:select): Set parameters asynchronously

### DIFF
--- a/components/core/Base/AntInputComponentBase.cs
+++ b/components/core/Base/AntInputComponentBase.cs
@@ -283,6 +283,15 @@ namespace AntDesign
         }
 
         /// <summary>
+        /// When this method is called, Value is only has been modified, but the ValueChanged is not triggered, so the outside bound Value is not changed.
+        /// </summary>
+        /// <param name="value"></param>
+        protected virtual Task OnValueChangeAsync(TValue value)
+        {
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
         /// When this method is called, Value and CurrentValue have been modified, and the ValueChanged has been triggered, so the outside bound Value is changed.
         /// </summary>
         /// <param name="value"></param>

--- a/components/select/Select.razor.cs
+++ b/components/select/Select.razor.cs
@@ -412,7 +412,7 @@ namespace AntDesign
             base.OnInitialized();
         }
 
-        protected override void OnParametersSet()
+        protected override async Task OnParametersSetAsync()
         {
             EvaluateDataSourceChange();
             if (SelectOptions == null)
@@ -433,9 +433,9 @@ namespace AntDesign
                     EditContext?.NotifyFieldChanged(FieldIdentifier);
                 }
 
-                OnValueChange(_selectedValue);
+                await OnValueChangeAsync(_selectedValue);
             }
-            base.OnParametersSet();
+            await base.OnParametersSetAsync();
         }
 
         private void EvaluateDataSourceChange()
@@ -522,12 +522,12 @@ namespace AntDesign
                 {
                     if (LastValueBeforeReset is not null)
                     {
-                        OnValueChange(LastValueBeforeReset);
+                        await OnValueChangeAsync(LastValueBeforeReset);
                         LastValueBeforeReset = default;
                     }
                     else
                     {
-                        OnValueChange(Value);
+                        await OnValueChangeAsync(Value);
                     }
                 }
                 else
@@ -1078,17 +1078,14 @@ namespace AntDesign
         /// </summary>
         internal TItemValue LastValueBeforeReset { get; set; }
 
-        /// <summary>
-        /// The Method is called every time if the value of the @bind-Value was changed by the two-way binding.
-        /// </summary>
-        protected override void OnValueChange(TItemValue value)
+        protected override async Task OnValueChangeAsync(TItemValue value)
         {
             if (!_optionsHasInitialized) // This is important because otherwise the initial value is overwritten by the EventCallback of ValueChanged and would be NULL.
                 return;
 
             if (!_isValueEnum && !TypeDefaultExistsAsSelectOption && EqualityComparer<TItemValue>.Default.Equals(value, default))
             {
-                _ = InvokeAsync(() => OnInputClearClickAsync(new()));
+                await InvokeAsync(() => OnInputClearClickAsync(new()));
                 return;
             }
 
@@ -1103,21 +1100,20 @@ namespace AntDesign
 
                 if (!AllowClear)
                 {
-                    _ = TrySetDefaultValueAsync();
+                    await TrySetDefaultValueAsync();
                 }
                 else
                 {
                     //Reset value if not found - needed if value changed
                     //outside of the component
-                    _ = InvokeAsync(() => OnInputClearClickAsync(new()));
+                    await InvokeAsync(() => OnInputClearClickAsync(new()));
                 }
                 return;
             }
 
             if (result.IsDisabled)
             {
-                _ = TrySetDefaultValueAsync();
-
+                await TrySetDefaultValueAsync();
                 return;
             }
 
@@ -1128,7 +1124,7 @@ namespace AntDesign
             if (HideSelected)
                 result.IsHidden = true;
 
-            ValueChanged.InvokeAsync(result.Value);
+            await ValueChanged.InvokeAsync(result.Value);
         }
 
         /// <summary>

--- a/tests/AntDesign.Tests/Select/Select.Value.Tests.razor
+++ b/tests/AntDesign.Tests/Select/Select.Value.Tests.razor
@@ -183,6 +183,32 @@
         input.GetAttribute("value").Should().BeEmpty();
     }
 
+    [Fact] // Issue: #3875
+    public void Exceptions_thrown_from_Event_Callbacks_are_caught()
+    {
+        //Arrange
+        JSInterop.Setup<AntDesign.JsInterop.DomRect>(JSInteropConstants.GetBoundingClientRect, _ => true)
+            .SetResult(new AntDesign.JsInterop.DomRect());
+        Func<int, Task> ValueChanged = async v => await Task.FromException(new NotImplementedException());
+        var cut = Render<AntDesign.Select<int, Person>>(
+            @<AntDesign.Select DataSource="@_persons"
+                               LabelName="@nameof(Person.Name)"
+                               ValueName="@nameof(Person.Id)"
+                               Value="0"
+                               ValueChanged="@ValueChanged"
+                               AllowClear="false"
+             >
+            </AntDesign.Select>
+        );
+        Action setParametersAction = () => 
+            // Act
+            cut.SetParametersAndRender(parameters => parameters.Add(p => p.Value, _persons.Count - 1)
+        );
+
+        // Assert
+        setParametersAction.Should().Throw<NotImplementedException>();
+    }
+
 /*
     [Theory]
     [MemberData(nameof(AllowClearWithValueOnClearTheory))]


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

[https://github.com/ant-design-blazor/ant-design-blazor/issues/3875](https://github.com/ant-design-blazor/ant-design-blazor/issues/3875)

### 💡 Background and solution

Per the [Blazor docs ](https://learn.microsoft.com/en-us/aspnet/core/blazor/components/lifecycle?view=aspnetcore-8.0#after-parameters-are-set-onparameterssetasync), "Asynchronous work when applying parameters and property values must occur during the [OnParametersSetAsync](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.components.componentbase.onparameterssetasync) lifecycle event:"

The issue that this PR fixes is that the Select module was performing asynchronous operations during OnParametersSet, including calling user defined event callbacks. If those callbacks (or any other internal Ant code on the code path) threw any exceptions during that time, they would not be caught because there is no Task to catch them on.

This PR adds the AntInputComponentBase.OnValueChangeAsync method and updates the Select module to use OnParametersSetAsync instead of OnParametersSet with the new OnValueChangeAsync.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
