### PR TITLE
fix: remove duplicated InternalsVisibleTo

### DIFF
--- a/components/Properties/AssemblyInfo.cs
+++ b/components/Properties/AssemblyInfo.cs
@@ -1,3 +1,0 @@
-﻿using System.Runtime.CompilerServices;
-
-[assembly: InternalsVisibleTo("AntDesign.Tests")]


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [x] Other (dotnet build)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

Since we already have `<InternalsVisibleTo Include="AntDesign.Tests" />` in project file, it would generate the `InternalsVisibleTo` assembly attribute, so there's no need to include the assembly attribute in the code

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Remove duplicated InternalsVisibleTo         |
| 🇨🇳 Chinese |     移除重复的 InternalsVisibleTo 设置      |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
