### PR TITLE
build: remove source link pakcge

### DIFF
--- a/components/AntDesign.csproj
+++ b/components/AntDesign.csproj
@@ -86,7 +86,6 @@
   
   <ItemGroup>
     <PackageReference Include="OneOf" Version="2.1.155" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [x] Other (dotnet build)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->


Starting with .NET 8, Source Link for the following source control providers is included in the .NET SDK and enabled by default

see details: https://github.com/dotnet/sourcelink?tab=readme-ov-file#using-source-link-in-net-projects

and verified the git info still exists when removed the source link package

![image](https://github.com/user-attachments/assets/7ff5441e-6965-44e6-b3a8-40aeb5859b27)


### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Remove  `Microsoft.SourceLink.GitHub` package reference     |
| 🇨🇳 Chinese |     移除 `Microsoft.SourceLink.GitHub` 包引用      |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
