### PR TITLE
chore: reduce nuget package size by copying intellisense files before build

### DIFF
--- a/components/AntDesign.csproj
+++ b/components/AntDesign.csproj
@@ -25,15 +25,17 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <DocumentationFile>./LocalizedIntellisenseFiles/$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
-  
+
   <ItemGroup>
-    <TfmSpecificPackageFile Include="LocalizedIntellisenseFiles\**\*.xml" Exclude="LocalizedIntellisenseFiles/$(AssemblyName).xml" PackagePath="/lib/$(TargetFramework)" />
+    <Content Include="LocalizedIntellisenseFiles\**\*.xml" Exclude="LocalizedIntellisenseFiles/$(AssemblyName).xml" PackagePath="/content/LocalizedIntellisenseFiles" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <!-- The nuget package icon -->
     <None Include="..\README.md" Pack="true" PackagePath="" />
     <None Include="logo.png" Pack="true" PackagePath="" />
+
+    <Content Include="AntDesign.targets" PackagePath="build\$(PackageId).targets" />
   </ItemGroup>
 
   <ItemGroup>
@@ -83,7 +85,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="OneOf" Version="2.1.155" />
   </ItemGroup>

--- a/components/AntDesign.targets
+++ b/components/AntDesign.targets
@@ -1,0 +1,23 @@
+﻿<Project>
+  <PropertyGroup>
+    <AntDesignNugetLibRoot>$(MSBuildThisFileDirectory)..\lib</AntDesignNugetLibRoot>
+  </PropertyGroup>
+
+  <!--only copy at debug mode-->
+  <Target Name="_CopyAntDesignLocalizedIntellisenseFiles"
+          BeforeTargets="BeforeBuild"
+          Condition="'$(Configuration)' == 'Debug'"
+          Inputs="$(MSBuildThisFileDirectory)..\content\LocalizedIntellisenseFiles\**\*.xml"
+          Outputs="$(AntDesignNugetLibRoot)\netstandard2.1\**\*.xml;$(AntDesignNugetLibRoot)\net5.0\**\*.xml;$(AntDesignNugetLibRoot)\net6.0\**\*.xml;$(AntDesignNugetLibRoot)\net7.0\**\*.xml;$(AntDesignNugetLibRoot)\net8.0\**\*.xml">
+    <ItemGroup>
+      <LocalizedIntellisenseFilesSourceFiles Include="$(MSBuildThisFileDirectory)..\content\LocalizedIntellisenseFiles\**\*.xml" />
+    </ItemGroup>
+
+    <!--add tfms-->
+    <Copy SourceFiles="@(LocalizedIntellisenseFilesSourceFiles)" DestinationFolder="$(AntDesignNugetLibRoot)\netstandard2.1\%(RecursiveDir)" SkipUnchangedFiles="true" ContinueOnError="true" />
+    <Copy SourceFiles="@(LocalizedIntellisenseFilesSourceFiles)" DestinationFolder="$(AntDesignNugetLibRoot)\net5.0\%(RecursiveDir)" SkipUnchangedFiles="true" ContinueOnError="true" />
+    <Copy SourceFiles="@(LocalizedIntellisenseFilesSourceFiles)" DestinationFolder="$(AntDesignNugetLibRoot)\net6.0\%(RecursiveDir)" SkipUnchangedFiles="true" ContinueOnError="true" />
+    <Copy SourceFiles="@(LocalizedIntellisenseFilesSourceFiles)" DestinationFolder="$(AntDesignNugetLibRoot)\net7.0\%(RecursiveDir)" SkipUnchangedFiles="true" ContinueOnError="true" />
+    <Copy SourceFiles="@(LocalizedIntellisenseFilesSourceFiles)" DestinationFolder="$(AntDesignNugetLibRoot)\net8.0\%(RecursiveDir)" SkipUnchangedFiles="true" ContinueOnError="true" />
+  </Target>
+</Project>


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在一个维护者审核通过后合并。
请确保填写以下 pull request 的信息，谢谢！~

请尽量使用英语，因为我们有来自全球的贡献者，使用英语会让您的问题和需求得到更迅速的响应和解决。
推荐使用：https://cn.bing.com/translator

Please use English as much as possible, as we have contributors from all over the world,
using English will allow your questions and needs to be responded to and resolved more quickly.

[[English Template / 英文模板](?expand=1)]
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式改进
- [X] 包体积优化
- [ ] 性能优化
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
[Issue](https://github.com/stratosblue/IntelliSenseLocalizer/issues/11)

### 💡 需求背景和解决方案
在nuget包的每个 `TargetFramework` 中都包含本地化智能感知文件有一点浪费资源。通过在nuget包中存放一份本地化智能感知文件，使用 `targets` 来复制到最终目录能够减小其空间占用
- 仅在`Debug`模式下会进行复制
- 仅在`Build`之前进行复制
  - 未`Build`引用包的项目之前不会有本地化提示
  - 已存在的文件会自动跳过

### 📝 更新日志怎么写？

<!--
> 从用户角度描述具体变化，以及可能的 breaking change 和其他风险？
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | reduce nuget package size by copying intellisense files before build         |
| 🇨🇳 中文 | 通过在构建时复制本地化智能感知文件来减小nuget包大小         |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [X] 文档已补充或无须补充
- [X] 代码演示已提供或无须提供
- [X] Changelog 已提供或无须提供
