### PR TITLE
feat(module: form): GenerateFormItem support recognize ReadOnlyAttribute to set component's disabled

### DIFF
--- a/components/form/GenerateFormItem.razor.cs
+++ b/components/form/GenerateFormItem.razor.cs
@@ -295,6 +295,8 @@ public partial class GenerateFormItem<TModel> : ComponentBase
         var funcType = typeof(Func<>);
         var constructedFuncType = funcType.MakeGenericType(property.PropertyType);
 
+        var isReadOnly = property.GetCustomAttribute<ReadOnlyAttribute>()?.IsReadOnly ?? false;
+
         return builder =>
         {
             builder.OpenComponent(0, constructedType);
@@ -303,6 +305,7 @@ public partial class GenerateFormItem<TModel> : ComponentBase
                 new Action<object>(o => property.SetValue(model, o)));
             builder.AddAttribute(2, "ValueChanged", eventCallback);
             builder.AddAttribute(3, "ValueExpression", Expression.Lambda(constructedFuncType, exp));
+            if (isReadOnly) builder.AddAttribute(4, "Disabled", isReadOnly);
             builder.CloseComponent();
         };
     }

--- a/site/AntDesign.Docs/Demos/Components/Form/demo/GenerateFormItem_.razor
+++ b/site/AntDesign.Docs/Demos/Components/Form/demo/GenerateFormItem_.razor
@@ -7,11 +7,11 @@
       OnFinishFailed="OnFinishFailed"
       LabelColSpan="8"
       WrapperColSpan="16">
-    <GenerateFormItem TModel="Model" Definitions="Definitions" ValidateRules="ValidateRules" NotGenerate="NotGenerate"/>
+    <GenerateFormItem TModel="Model" Definitions="Definitions" ValidateRules="ValidateRules" NotGenerate="NotGenerate" />
     <FormItem Label="ListTestOutOfGenerate">
         <Select @bind-Values="@context.I" Style="width: 120px;" TItemValue="string" TItem="string">
             <SelectOptions>
-                <SelectOption Value="@("lucy")" Label="Lucy"/>
+                <SelectOption Value="@("lucy")" Label="Lucy" />
             </SelectOptions>
         </Select>
     </FormItem>
@@ -42,7 +42,7 @@
 
         [DisplayName("NumericTestNullable")] public decimal? F { get; set; }
 
-        [DisplayName("EnumTest")] [Required] public TestEnum G { get; set; }
+        [DisplayName("EnumTest")][Required] public TestEnum G { get; set; }
 
         [DisplayName("EnumTestNullable")] public TestEnum? H { get; set; }
 
@@ -51,6 +51,9 @@
         public IEnumerable<string> I { get; set; }
 
         [DisplayName("DefinitionsTest")] public string J { get; set; }
+
+        [DisplayName("ReadOnlyTest"), ReadOnly(true)]
+        public string K { get; set; }
 
         // [ValidateComplexType]
         public ModelChild ModelChild { get; set; }
@@ -84,7 +87,7 @@
         [Required] public IEnumerable<string> II { get; set; }
 
         public string JJ { get; set; }
-        
+
         // [ValidateComplexType]
         public ModelChild2 ModelChild2 { get; set; }
     }
@@ -95,28 +98,28 @@
     }
 
     private Model model = new Model()
-    {
-        ModelChild = new ModelChild()
-        {
-            ModelChild2 = new ModelChild2()
-        }
-    };
+            {
+                ModelChild = new ModelChild()
+                {
+                    ModelChild2 = new ModelChild2()
+                }
+            };
 
     public FormValidationRule[]? ValidateRules(string structurePath)
     {
         if (structurePath == "A")
         {
             return new FormValidationRule[]
-            {
+        {
                 new FormValidationRule { Required = true, Min = 5, Max = 10 }
-            };
+        };
         }
         if (structurePath == "ModelChild.AA")
         {
             return new FormValidationRule[]
-            {
+        {
                 new FormValidationRule { Required = true, Max = 10 }
-            };
+        };
         }
 
         return null;
@@ -127,18 +130,18 @@
         if (structurePath == "J")
         {
             return @<Select @bind-Value="model.J" Style="width: 120px;" TItemValue="string" TItem="string">
-                <SelectOptions>
-                    <SelectOption Value="@("lucy")" Label="Lucy"/>
-                </SelectOptions>
-            </Select>;
+                        <SelectOptions>
+                            <SelectOption Value="@("lucy")" Label="Lucy" />
+                        </SelectOptions>
+                    </Select>;
         }
         if (structurePath == "ModelChild.JJ")
         {
             return @<Select @bind-Value="model.ModelChild.JJ" Style="width: 120px;" TItemValue="string" TItem="string">
-                <SelectOptions>
-                    <SelectOption Value="@("lucy")" Label="Lucy"/>
-                </SelectOptions>
-            </Select>;
+                        <SelectOptions>
+                            <SelectOption Value="@("lucy")" Label="Lucy" />
+                        </SelectOptions>
+                    </Select>;
         }
         return null;
     }

--- a/site/AntDesign.Docs/Demos/Components/Form/demo/GenerateFormItem_.razor
+++ b/site/AntDesign.Docs/Demos/Components/Form/demo/GenerateFormItem_.razor
@@ -42,7 +42,7 @@
 
         [DisplayName("NumericTestNullable")] public decimal? F { get; set; }
 
-        [DisplayName("EnumTest")][Required] public TestEnum G { get; set; }
+        [DisplayName("EnumTest")] [Required] public TestEnum G { get; set; }
 
         [DisplayName("EnumTestNullable")] public TestEnum? H { get; set; }
 
@@ -55,7 +55,6 @@
         [DisplayName("ReadOnlyTest"), ReadOnly(true)]
         public string K { get; set; }
 
-        // [ValidateComplexType]
         public ModelChild ModelChild { get; set; }
     }
 
@@ -98,28 +97,28 @@
     }
 
     private Model model = new Model()
-            {
-                ModelChild = new ModelChild()
-                {
-                    ModelChild2 = new ModelChild2()
-                }
-            };
+    {
+        ModelChild = new ModelChild()
+        {
+            ModelChild2 = new ModelChild2()
+        }
+    };
 
     public FormValidationRule[]? ValidateRules(string structurePath)
     {
         if (structurePath == "A")
         {
             return new FormValidationRule[]
-        {
+            {
                 new FormValidationRule { Required = true, Min = 5, Max = 10 }
-        };
+            };
         }
         if (structurePath == "ModelChild.AA")
         {
             return new FormValidationRule[]
-        {
+            {
                 new FormValidationRule { Required = true, Max = 10 }
-        };
+            };
         }
 
         return null;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | The `GenerateFormItem` automatically generates forms and recognizes the `ReadOnlyAttribute` in the `TModel` properties, making it effective. |
| 🇨🇳 Chinese | GenerateFormItem自动生成表单时，识别TModel属性中的ReadOnlyAttribute标识，并使其生效 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
