### PR TITLE
Enable static pre-rendering on the Docs WebAssembly app

### DIFF
--- a/docs/faq.en-US.md
+++ b/docs/faq.en-US.md
@@ -19,7 +19,7 @@ And make sure that `#some-scroll-area` element is `position: relative` or `posit
 
 ### How do I modify the default theme of Ant Design?
 
-See: https://ant.design/docs/react/customize-theme .
+See: [https://ant.design/docs/react/customize-theme](https://ant.design/docs/react/customize-theme)
 
 ### Why does modifying props in mutable way not trigger a component update?
 

--- a/docs/faq.zh-CN.md
+++ b/docs/faq.zh-CN.md
@@ -19,7 +19,7 @@ title: 常见问题
 
 ### 如何修改 Ant Design 的默认主题？
 
-可以参考[定制主题](/docs/customize-theme)。
+可以参考[定制主题](https://ant.design/docs/react/customize-theme)。
 
 ### 如何修改 Ant Design 组件的默认样式？
 

--- a/site/AntDesign.Docs.Wasm/AntDesign.Docs.Wasm.csproj
+++ b/site/AntDesign.Docs.Wasm/AntDesign.Docs.Wasm.csproj
@@ -26,6 +26,10 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.0" PrivateAssets="all" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <BlazorWasmPrerenderingLocale>en-US</BlazorWasmPrerenderingLocale>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="BlazorWasmPreRendering.Build" Version="4.0.0" />
   </ItemGroup>

--- a/site/AntDesign.Docs.Wasm/AntDesign.Docs.Wasm.csproj
+++ b/site/AntDesign.Docs.Wasm/AntDesign.Docs.Wasm.csproj
@@ -27,7 +27,8 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <BlazorWasmPrerenderingLocale>en-US</BlazorWasmPrerenderingLocale>
+    <BlazorWasmPrerenderingLocale>en-US,zh-CN</BlazorWasmPrerenderingLocale>
+    <BlazorWasmPrerenderingUrlPathToExplicitFetch>/en-US;/zh-CN</BlazorWasmPrerenderingUrlPathToExplicitFetch>
   </PropertyGroup>
 
   <ItemGroup>

--- a/site/AntDesign.Docs.Wasm/AntDesign.Docs.Wasm.csproj
+++ b/site/AntDesign.Docs.Wasm/AntDesign.Docs.Wasm.csproj
@@ -27,6 +27,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="BlazorWasmPreRendering.Build" Version="4.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <EmscriptenEnvVars Include="PYTHONUTF8=1" />
     <ServiceWorker Include="wwwroot\service-worker.js" PublishedContent="wwwroot\service-worker.published.js" />
   </ItemGroup>

--- a/site/AntDesign.Docs.Wasm/AntDesign.Docs.Wasm.csproj
+++ b/site/AntDesign.Docs.Wasm/AntDesign.Docs.Wasm.csproj
@@ -29,6 +29,7 @@
   <PropertyGroup>
     <BlazorWasmPrerenderingLocale>en-US,zh-CN</BlazorWasmPrerenderingLocale>
     <BlazorWasmPrerenderingUrlPathToExplicitFetch>/en-US;/zh-CN</BlazorWasmPrerenderingUrlPathToExplicitFetch>
+    <BlazorWasmPrerenderingOutputStyle>AppendHtmlExtension</BlazorWasmPrerenderingOutputStyle>
   </PropertyGroup>
 
   <ItemGroup>

--- a/site/AntDesign.Docs.Wasm/Program.cs
+++ b/site/AntDesign.Docs.Wasm/Program.cs
@@ -28,9 +28,15 @@ namespace AntDesign.Docs.Wasm
 
             builder.Services.AddTransient(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 
-            builder.Services.AddAntDesignDocs();
+            ConfigureServices(builder.Services, builder.HostEnvironment.BaseAddress);
 
             await builder.Build().RunAsync();
+        }
+
+        private static void ConfigureServices(IServiceCollection services, string baseAddress)
+        {
+            services.AddTransient(sp => new HttpClient { BaseAddress = new Uri(baseAddress) });
+            services.AddAntDesignDocs();
         }
     }
 }

--- a/site/AntDesign.Docs.Wasm/Program.cs
+++ b/site/AntDesign.Docs.Wasm/Program.cs
@@ -28,15 +28,16 @@ namespace AntDesign.Docs.Wasm
 
             builder.Services.AddTransient(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 
-            ConfigureServices(builder.Services, builder.HostEnvironment.BaseAddress);
+            ConfigureServices(builder.Services, builder.HostEnvironment);
 
             await builder.Build().RunAsync();
         }
 
-        private static void ConfigureServices(IServiceCollection services, string baseAddress)
+        private static void ConfigureServices(IServiceCollection services, IWebAssemblyHostEnvironment hostEnvironment)
         {
-            services.AddTransient(sp => new HttpClient { BaseAddress = new Uri(baseAddress) });
+            services.AddTransient(sp => new HttpClient { BaseAddress = new Uri(hostEnvironment.BaseAddress) });
             services.AddAntDesignDocs();
+            Environment.SetEnvironmentVariable("DOTNET_ENVIRONMENT", hostEnvironment.Environment);
         }
     }
 }

--- a/site/AntDesign.Docs/Pages/Components.razor.cs
+++ b/site/AntDesign.Docs/Pages/Components.razor.cs
@@ -63,10 +63,11 @@ namespace AntDesign.Docs.Pages
         private string _currentPageName;
         private string _currentLocale;
 
-        protected override void OnInitialized()
+        protected override async Task OnInitializedAsync()
         {
             LocalizationService.LanguageChanged += OnLanguageChanged;
             NavigationManager.LocationChanged += OnLocationChanged;
+            await HandleNavigate(onInitialize: true);
         }
 
         private void OnLanguageChanged(object sender, CultureInfo args)
@@ -100,7 +101,7 @@ namespace AntDesign.Docs.Pages
             }
         }
 
-        private async Task HandleNavigate()
+        private async Task HandleNavigate(bool onInitialize = false)
         {
             var fullPageName = NavigationManager.ToBaseRelativePath(NavigationManager.Uri);
             fullPageName = fullPageName.IndexOf('/') > 0 ? fullPageName.Substring(fullPageName.IndexOf('/') + 1) : fullPageName;
@@ -115,21 +116,23 @@ namespace AntDesign.Docs.Pages
                 return;
             }
 
-            _currentPageName = fullPageName;
-            _currentLocale = Locale;
-
             if (fullPageName.Split("/").Length != 2)
             {
-                var menus = await DemoService.GetMenuAsync();
-                var current = menus.FirstOrDefault(x => x.Url == fullPageName.ToLowerInvariant());
-                var subPath = current.Children[0].Type == "menuItem" ? current.Children[0].Url : current.Children[0].Children[0].Url;
-                if (current != null)
+                if (!onInitialize)
                 {
-                    NavigationManager.NavigateTo($"{CurrentLanguage}/{subPath}");
+                    var menus = await DemoService.GetMenuAsync();
+                    var current = menus.FirstOrDefault(x => x.Url == fullPageName.ToLowerInvariant());
+                    var subPath = current.Children[0].Type == "menuItem" ? current.Children[0].Url : current.Children[0].Children[0].Url;
+                    if (current != null)
+                    {
+                        NavigationManager.NavigateTo($"{CurrentLanguage}/{subPath}");
+                    }
                 }
             }
             else
             {
+                _currentPageName = fullPageName;
+                _currentLocale = Locale;
                 _demoComponent = await DemoService.GetComponentAsync($"{fullPageName}");
                 StateHasChanged();
 
@@ -146,7 +149,7 @@ namespace AntDesign.Docs.Pages
 
         private async Task LoadDemos(string pageName)
         {
-            var showDemos = _demoComponent.DemoList?.Where(x => !x.Debug && !x.Docs.HasValue).OrderBy(x => x.Order) ?? Enumerable.Empty<DemoItem>();
+            var showDemos = _demoComponent?.DemoList?.Where(x => !x.Debug && !x.Docs.HasValue).OrderBy(x => x.Order) ?? Enumerable.Empty<DemoItem>();
             _anchors = showDemos.Select(x => (x.Name, x.Title)).ToArray();
             _demos = [];
             _filePaths = new() { _filePath };

--- a/site/AntDesign.Docs/Pages/Docs.razor.cs
+++ b/site/AntDesign.Docs/Pages/Docs.razor.cs
@@ -58,7 +58,11 @@ namespace AntDesign.Docs.Pages
                 var current = menus.FirstOrDefault(x => x.Url == newUrl);
                 if (current != null)
                 {
-                    NavigationManager.NavigateTo($"{CurrentLanguage}/{current.Children[0].Url}");
+                    var hostEnvironment = Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT");
+                    if (hostEnvironment != "Prerendering")
+                    {
+                        NavigationManager.NavigateTo($"{CurrentLanguage}/{current.Children[0].Url}");
+                    }
                 }
             }
         }

--- a/site/AntDesign.Docs/ServiceCollectionExtensions.cs
+++ b/site/AntDesign.Docs/ServiceCollectionExtensions.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Extensions.DependencyInjection
         public static IServiceCollection AddAntDesignDocs(this IServiceCollection services)
         {
             services.AddAntDesign();
+            services.AddSingleton<DemoServiceCache>();
             services.AddScoped<DemoService>();
             services.AddScoped<IconListService>();
             services.AddScoped<IPrismHighlighter, PrismHighlighter>();

--- a/site/AntDesign.Docs/Services/DemoServiceCache.cs
+++ b/site/AntDesign.Docs/Services/DemoServiceCache.cs
@@ -1,0 +1,73 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using AntDesign.Docs.Utils;
+
+namespace AntDesign.Docs.Services
+{
+    public class DemoServiceCache
+    {
+        private readonly ConcurrentCache<string, AsyncLazy<IDictionary<string, DemoComponent>>> _componentCache = new();
+        private readonly ConcurrentCache<string, AsyncLazy<DemoMenuItem[]>> _menuCache = new();
+        private readonly ConcurrentCache<string, AsyncLazy<DemoMenuItem[]>> _demoMenuCache = new();
+        private readonly ConcurrentCache<string, AsyncLazy<DemoMenuItem[]>> _docMenuCache = new();
+
+        private readonly HttpClient _httpClient;
+
+        public DemoServiceCache(HttpClient httpClient)
+        {
+            _httpClient = httpClient;
+        }
+
+        public void PreFetch(string language)
+        {
+            PreFetchDemoMenuItems(_menuCache, language, lang => $"_content/AntDesign.Docs/meta/menu.{lang}.json");
+            PreFetchDemoMenuItems(_demoMenuCache, language, lang => $"_content/AntDesign.Docs/meta/demos.{lang}.json");
+            PreFetchDemoMenuItems(_docMenuCache, language, lang => $"_content/AntDesign.Docs/meta/docs.{lang}.json");
+
+            _componentCache.GetOrAdd(language, (lang) => new(async () =>
+            {
+                var components = await _httpClient.GetFromJsonAsync<DemoComponent[]>($"_content/AntDesign.Docs/meta/components.{lang}.json");
+                return components.ToDictionary(x => $"{x.Category.ToLower()}/{x.Title.ToLower()}", x => x);
+            }));
+        }
+
+        private async void PreFetchDemoMenuItems(ConcurrentCache<string, AsyncLazy<DemoMenuItem[]>> cache, string language, Func<string, string> srcUrl)
+        {
+            cache.GetOrAdd(language, (lang) => new(async () =>
+            {
+                var items = await _httpClient.GetFromJsonAsync<DemoMenuItem[]>(srcUrl(lang));
+                return items;
+            }));
+        }
+
+        public async Task<DemoMenuItem[]> GetMenuAsync(string language)
+        {
+            return _menuCache.TryGetValue(language, out var menuItems) ? await menuItems : Array.Empty<DemoMenuItem>();
+        }
+
+        public async Task<DemoMenuItem[]> GetDemoMenuAsync(string language)
+        {
+            return _demoMenuCache.TryGetValue(language, out var menuItems) ? await menuItems : Array.Empty<DemoMenuItem>();
+        }
+
+        public async Task<DemoMenuItem[]> GetDocMenuAsync(string language)
+        {
+            return _docMenuCache.TryGetValue(language, out var menuItems) ? await menuItems : Array.Empty<DemoMenuItem>();
+        }
+
+        public async Task<DemoComponent> GetComponentAsync(string language, string componentName)
+        {
+            return _componentCache.TryGetValue(language, out var component)
+            ? (await component).TryGetValue(componentName.ToLower(), out var demoComponent) ? demoComponent : null
+            : null;
+        }
+    }
+}


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [X] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

There is no related issue. See also: https://x.com/shunjiey/status/1833658288208310406.

### 💡 Background and solution

The Docs WebAssembly app is not SEO-friendly because each document page is not pre-rendered. So, I tried to enable the build-time static pre-rendering by using the ["BlazorWasmPreRendering.Build"](https://www.nuget.org/packages/BlazorWasmPreRendering.Build) NuGet package.

### 📝 Changelog

There are no changes from the component user's perspective. This pull request only affects the infrastructure of the document site.

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] Changelog is provided or not needed
