### PR TITLE
feat(module: select): Introduce SearchInput parameter for setting seach input manually

### DIFF
--- a/components/select/Select.razor.cs
+++ b/components/select/Select.razor.cs
@@ -437,9 +437,12 @@ namespace AntDesign
                 await OnValueChangeAsync(_selectedValue);
             }
             
-            if(_searchInputHasChanged && !string.IsNullOrEmpty(_searchValue))
+            if(_searchInputHasChanged)
             {
-                FilterOptionItems(_searchValue);
+                if(string.IsNullOrEmpty(_searchValue))
+                    ResetOptionItems();
+                else
+                    FilterOptionItems(_searchValue);
             }
             
             await base.OnParametersSetAsync();
@@ -1202,14 +1205,19 @@ namespace AntDesign
             }
             else
             {
-                UnhideSelectOptions();
-                if (SelectMode == SelectMode.Tags && CustomTagSelectOptionItem is not null)
-                {
-                    SelectOptionItems.Remove(CustomTagSelectOptionItem);
-                    CustomTagSelectOptionItem = null;
-                }
+                ResetOptionItems();
             }
             OnSearch?.Invoke(_searchValue);
+        }
+
+        private void ResetOptionItems()
+        {
+            UnhideSelectOptions();
+            if (SelectMode == SelectMode.Tags && CustomTagSelectOptionItem is not null)
+            {
+                SelectOptionItems.Remove(CustomTagSelectOptionItem);
+                CustomTagSelectOptionItem = null;
+            }
         }
 
         private async Task TokenizeSearchedPhrase(string searchValue)

--- a/components/select/Select.razor.cs
+++ b/components/select/Select.razor.cs
@@ -1311,7 +1311,7 @@ namespace AntDesign
             }
         }
 
-        private void FilterTagsOptionItems(string searchValue)
+        protected override void FilterTagsOptionItems(string searchValue)
         {
             SelectOptionItem<TItemValue, TItem> activeCanditate = null;
             List<SelectOptionItem<TItemValue, TItem>> selectOptionItems;

--- a/components/select/Select.razor.cs
+++ b/components/select/Select.razor.cs
@@ -263,6 +263,24 @@ namespace AntDesign
                 }
             }
         }
+        
+        private bool _searchInputHasChanged;
+
+        /// <summary>
+        /// Get or set the search input.
+        /// Using this property will deactivate the internal management of the input value (e.g. clearing it).
+        /// </summary>
+        [Parameter]
+        public string SearchInput
+        {
+            get => _searchValue;
+            set
+            {
+                _manageSearchInputExternally = true;
+                _searchInputHasChanged = _searchValue != value;
+                _searchValue = value;
+            }
+        }
 
         /// <summary>
         /// Specifies the label property in the option object. If use this property, should not use <see cref="LabelName"/>
@@ -418,6 +436,12 @@ namespace AntDesign
 
                 await OnValueChangeAsync(_selectedValue);
             }
+            
+            if(_searchInputHasChanged && !string.IsNullOrEmpty(_searchValue))
+            {
+                FilterOptionItems(_searchValue);
+            }
+            
             await base.OnParametersSetAsync();
         }
 

--- a/components/select/SelectBase.razor.cs
+++ b/components/select/SelectBase.razor.cs
@@ -263,6 +263,10 @@ namespace AntDesign
 
         internal virtual SelectMode SelectMode => Mode.ToSelectMode();
 
+        // When the search input is managed externally (via the SearchValue parameter), it's imporant that the
+        // component itself doesn't try to manage the search input on its own (e.g. clearing it when an item is selected).
+        protected bool _manageSearchInputExternally = false;
+
         /// <summary>
         ///     Currently active (highlighted) option.
         ///     It does not have to be equal to selected option.
@@ -760,6 +764,9 @@ namespace AntDesign
                 return;
             }
 
+            if (_manageSearchInputExternally)
+                return;
+            
             _searchValue = string.Empty;
             _prevSearchValue = string.Empty;
 
@@ -958,8 +965,11 @@ namespace AntDesign
                 }
             }
 
-            _searchValue = string.Empty;
-            _prevSearchValue = string.Empty;
+            if (!_manageSearchInputExternally)
+            {
+                _searchValue = string.Empty;
+                _prevSearchValue = string.Empty;
+            }
         }
 
         /// <summary>

--- a/components/select/SelectBase.razor.cs
+++ b/components/select/SelectBase.razor.cs
@@ -904,6 +904,15 @@ namespace AntDesign
                 await InvokeValuesChanged(selectOption);
                 await UpdateOverlayPositionAsync();
             }
+            
+            // The tag filters have to be re-applied after removing/adding a tag as the searchValue is not cleared
+            // when SearchInput in the Select is set. Otherwise, the input remains, but the filters would not correspond to it 
+            if(SelectMode == SelectMode.Tags && _manageSearchInputExternally)
+                FilterTagsOptionItems(_searchValue);
+        }
+
+        protected virtual void FilterTagsOptionItems(string searchValue)
+        {
         }
 
         protected async Task InvokeValuesChanged(SelectOptionItem<TItemValue, TItem> newSelection = null)

--- a/components/select/SelectBase.razor.cs
+++ b/components/select/SelectBase.razor.cs
@@ -263,7 +263,7 @@ namespace AntDesign
 
         internal virtual SelectMode SelectMode => Mode.ToSelectMode();
 
-        // When the search input is managed externally (via the SearchValue parameter), it's imporant that the
+        // When the search input is managed externally (via the SearchInput parameter in the Select), it's important that the
         // component itself doesn't try to manage the search input on its own (e.g. clearing it when an item is selected).
         protected bool _manageSearchInputExternally = false;
 
@@ -905,7 +905,7 @@ namespace AntDesign
                 await UpdateOverlayPositionAsync();
             }
             
-            // The tag filters have to be re-applied after removing/adding a tag as the searchValue is not cleared
+            // The tag filters have to be re-applied after removing/adding a tag as the _searchValue is not cleared
             // when SearchInput in the Select is set. Otherwise, the input remains, but the filters would not correspond to it 
             if(SelectMode == SelectMode.Tags && _manageSearchInputExternally)
                 FilterTagsOptionItems(_searchValue);

--- a/components/select/internal/SelectContent.razor.cs
+++ b/components/select/internal/SelectContent.razor.cs
@@ -74,7 +74,6 @@ namespace AntDesign.Select.Internal
                 }
                 
                 _inputString = value;
-                StateHasChanged();
             }
         }
         [Parameter] public int SearchDebounceMilliseconds { get; set; }

--- a/components/select/internal/SelectContent.razor.cs
+++ b/components/select/internal/SelectContent.razor.cs
@@ -60,7 +60,23 @@ namespace AntDesign.Select.Internal
         [Parameter] public EventCallback<FocusEventArgs> OnBlur { get; set; }
         [Parameter] public EventCallback<MouseEventArgs> OnClearClick { get; set; }
         [Parameter] public EventCallback<SelectOptionItem<TItemValue, TItem>> OnRemoveSelected { get; set; }
-        [Parameter] public string SearchValue { get; set; }
+        [Parameter] public string SearchValue
+        {
+            get => _inputString;
+            set
+            {
+                // While the debouncer is still active, the outer select doesn't have the latest input yet.
+                // A re-render would then bring the old value back into the input field, only until the debouncer is finished
+                // and updates the outer Select with the latest input. This would make the value in the input field flicker.
+                if (_debounceTimer is not null)
+                {
+                    return;
+                }
+                
+                _inputString = value;
+                StateHasChanged();
+            }
+        }
         [Parameter] public int SearchDebounceMilliseconds { get; set; }
         [Inject] private IDomEventListener DomEventListener { get; set; }
 

--- a/site/AntDesign.Docs/Demos/Components/Select/doc/index.en-US.md
+++ b/site/AntDesign.Docs/Demos/Components/Select/doc/index.en-US.md
@@ -71,6 +71,7 @@ Select component to select value from options.
 | PopupContainerMaxHeight | The maximum height of the popup container. | string | `256px` |  |
 | PopupContainerSelector | Use this to fix overlay problems e.g. #area | string | body |  |
 | PrefixIcon | The custom prefix icon. For mode `multiple` and `tags` visible only when no data selected. | RenderFragment | - |  |
+| SearchInput | Used for setting the search input manually. Using this property will deactivate the internal management of the input value (e.g. clearing it). | string | - |  |
 | SelectOptions | Used for rendering select options manually. | RenderFragment | - |  |
 | ShowArrowIcon | Whether to show the drop-down arrow | bool | true |  |
 | ShowSearchIcon | Whether show search input in single mode. | bool | true |  |

--- a/site/AntDesign.Docs/Demos/Components/Select/doc/index.zh-CN.md
+++ b/site/AntDesign.Docs/Demos/Components/Select/doc/index.zh-CN.md
@@ -71,6 +71,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/_0XzgOis7/Select.svg
 | PopupContainerMaxHeight | 弹出容器的最大高度. | string | `256px` |  |
 | PopupContainerSelector | 使用它来修复覆盖问题，例如 #area | string | body |  |
 | PrefixIcon | 自定义前缀图标。 对于模式 `multiple` 和 `tags` 仅在未选择数据时可见. | RenderFragment | - |  |
+| SearchInput |  | string | - |  |
 | SelectOptions | 用于手动渲染选择Option. | RenderFragment | - |  |
 | ShowArrowIcon | 是否显示下拉小箭头 | bool | true |  |
 | ShowSearchIcon | 使单选模式可搜索 | bool | true |  |

--- a/tests/AntDesign.Tests/Select/Actions/Select.OnUnfocus.Tests.razor
+++ b/tests/AntDesign.Tests/Select/Actions/Select.OnUnfocus.Tests.razor
@@ -1,0 +1,76 @@
+@using AngleSharp.Css.Values
+@using AntDesign.Core.JsInterop.Modules.Components
+@using AntDesign.Internal
+@inherits AntDesignTestBase
+
+@code {
+    
+    record Person(int Id, string Name);
+    
+    List<Person> _persons = new List<Person>
+    {
+        new Person(1, "John"),
+        new Person(2, "Lucy"),
+        new Person(3, "Jack"),
+        new Person(4, "Emily"),
+    };
+
+    public Select_OnUnfocus_Tests()
+    {
+        JSInterop.Setup<AntDesign.JsInterop.DomRect>(JSInteropConstants.GetBoundingClientRect, _ => true)
+            .SetResult(new AntDesign.JsInterop.DomRect());
+        JSInterop.SetupVoid(JSInteropConstants.AddPreventKeys, _ => true).SetVoidResult();
+        JSInterop.SetupVoid(JSInteropConstants.DomMainpulationHelper.Focus, _ => true).SetVoidResult();
+        JSInterop.SetupVoid(JSInteropConstants.AddPreventEnterOnOverlayVisible, _ => true).SetVoidResult();
+        JSInterop.Setup<OverlayPosition>(JSInteropConstants.OverlayComponentHelper.AddOverlayToContainer, _ => true)
+            .SetResult(new OverlayPosition());
+#if !NET6_0_OR_GREATER
+        JSInterop.SetupVoid(JSInteropConstants.Focus, _ => true).SetVoidResult();
+#endif
+    }
+
+    [Fact]
+    public async Task Will_reset_search_input_and_filter_on_unfocus()
+    {
+        // Arrange
+        var cut = Render<AntDesign.Select<int, Person>>(
+            @<AntDesign.Select DataSource="@_persons"
+                               LabelName="@nameof(Person.Name)"
+                               ValueName="@nameof(Person.Id)"
+                               EnableSearch="true"
+                               TItem="Person"
+                               TItemValue="int">
+            </AntDesign.Select>
+        );
+        
+        var trigger = cut.FindComponent<OverlayTrigger>();
+        await cut.InvokeAsync(() => trigger.Instance.OnVisibleChange.InvokeAsync(true));
+        
+        var input = cut.Find(".ant-select-selection-search-input");
+        input.Input("J");
+        
+        // we have to wait for the search to be finished. As the search does not trigger a re-render in the end,
+        // we can't use any cut.Wait... operations.
+        await Task.Delay(400);
+        // trigger re-render after _searchValue in Select was updated. This does not trigger a re-render on its own
+        cut.Render();
+
+        // after the search has been executed, and we triggered the re-render, the input value should have been correctly re-set
+        input.GetAttribute("value").Should().Be("J");
+        
+        
+        // Act
+        await cut.InvokeAsync(() => trigger.Instance.OnVisibleChange.InvokeAsync(false));
+
+        // Assert
+        cut.WaitForAssertion(
+            () => input.GetAttribute("value").Should().BeEmpty(),
+            TimeSpan.FromSeconds(1));
+        
+        var items = cut.FindAll(".ant-select-item-option")
+            .Where(x => !x.Attributes["style"]?.Value.Trim().Contains("display:none") ?? true)
+            .ToList();
+        items.Should().HaveCount(4);
+    }
+    
+}

--- a/tests/AntDesign.Tests/Select/Select.SearchInput.Tests.razor
+++ b/tests/AntDesign.Tests/Select/Select.SearchInput.Tests.razor
@@ -363,7 +363,6 @@
                                SearchInput="Fi">
             </AntDesign.Select>
         );
-        var trigger = cut.FindComponent<OverlayTrigger>();
         
         // Act
         cut.SetParametersAndRender(param => param.Add(p => p.SearchInput, string.Empty));
@@ -376,6 +375,80 @@
         items[0].GetElementsByClassName("ant-select-item-option-content")[0].TextContent.Trim().Should().Be("First");
         items[1].GetElementsByClassName("ant-select-item-option-content")[0].TextContent.Trim().Should().Be("Second");
         items[2].GetElementsByClassName("ant-select-item-option-content")[0].TextContent.Trim().Should().Be("Third");
+    }
+
+    [Fact]
+    public async Task Filter_items_and_custom_tag_after_creating_custom_tag()
+    {
+        // Arrange
+        var cut = Render<AntDesign.Select<string, Tag>>(
+            @<AntDesign.Select DataSource="@_tags"
+                               Mode="tags"
+                               LabelName="@nameof(Tag.Label)"
+                               ValueName="@nameof(Tag.Value)"
+                               EnableSearch="true"
+                               TItem="Tag"
+                               TItemValue="string"
+                               SearchInput="Fi">
+            </AntDesign.Select>
+        );
+        
+        // Act
+        cut.FindAll(".ant-select-item-option")
+            .Single(x => x.GetElementsByClassName("ant-select-item-option-content")[0].TextContent.Trim() == "Fi")
+            .Click();
+        
+        cut.Render();
+        
+        cut.WaitForAssertion(() => cut.FindAll(".ant-select-selection-overflow-item").Should().HaveCount(2));
+
+        // Assert
+        var items = cut.FindAll(".ant-select-item-option")
+            .Where(x => !x.Attributes["style"]?.Value.Trim().Contains("display:none") ?? true)
+            .ToList();
+        items.Should().HaveCount(2);
+        items[0].GetElementsByClassName("ant-select-item-option-content")[0].TextContent.Trim().Should().Be("First");
+        items[1].GetElementsByClassName("ant-select-item-option-content")[0].TextContent.Trim().Should().Be("Fi");
+    }
+
+    [Fact]
+    public async Task Filter_items_and_custom_tag_on_removing_custom_tag()
+    {
+        // Arrange
+        var cut = Render<AntDesign.Select<string, Tag>>(
+            @<AntDesign.Select DataSource="@_tags"
+                               Mode="tags"
+                               LabelName="@nameof(Tag.Label)"
+                               ValueName="@nameof(Tag.Value)"
+                               EnableSearch="true"
+                               TItem="Tag"
+                               TItemValue="string"
+                               SearchInput="Fi">
+            </AntDesign.Select>
+        );
+        
+        cut.FindAll(".ant-select-item-option")
+            .Single(x => x.GetElementsByClassName("ant-select-item-option-content")[0].TextContent.Trim() == "Fi")
+            .Click();
+        
+        cut.Render();
+        
+        cut.WaitForAssertion(() => cut.FindAll(".ant-select-selection-overflow-item").Should().HaveCount(2));
+        
+        // Act
+        cut.FindAll(".ant-select-selection-item")
+            .Single(x => x.GetElementsByClassName("ant-select-selection-item-content").Any(y => y.TextContent.Trim() == "Fi"))
+            .GetElementsByClassName("ant-select-selection-item-remove")
+            .Single()
+            .MouseDown();
+        
+        // Assert
+        var items = cut.FindAll(".ant-select-item-option")
+            .Where(x => !x.Attributes["style"]?.Value.Trim().Contains("display:none") ?? true)
+            .ToList();
+        items.Should().HaveCount(2);
+        items[0].GetElementsByClassName("ant-select-item-option-content")[0].TextContent.Trim().Should().Be("First");
+        items[1].GetElementsByClassName("ant-select-item-option-content")[0].TextContent.Trim().Should().Be("Fi");
     }
     
 }

--- a/tests/AntDesign.Tests/Select/Select.SearchInput.Tests.razor
+++ b/tests/AntDesign.Tests/Select/Select.SearchInput.Tests.razor
@@ -130,7 +130,7 @@
     [Fact]
     public async Task Filter_items_on_first_render()
     {
-        // Arrange
+        // Act
         var cut = Render<AntDesign.Select<int, Person>>(
             @<AntDesign.Select DataSource="@_persons"
                                LabelName="@nameof(Person.Name)"
@@ -142,8 +142,6 @@
             </AntDesign.Select>
         );
         
-        // Act
-        
         // Assert
         var items = cut.FindAll(".ant-select-item-option")
             .Where(x => !x.Attributes["style"]?.Value.Trim().Contains("display:none") ?? true)
@@ -152,6 +150,33 @@
         items[0].GetElementsByClassName("ant-select-item-option-content")[0].TextContent.Trim().Should().Be("John");
     }
 
+    [Theory]
+    [InlineData("default")]
+    [InlineData("multiple")]
+    public async Task Reset_filtered_items_on_setting_empty_search_input(string mode)
+    {
+        // Arrange
+        var cut = Render<AntDesign.Select<int, Person>>(
+            @<AntDesign.Select DataSource="@_persons"
+                               Mode="@mode"
+                               LabelName="@nameof(Person.Name)"
+                               ValueName="@nameof(Person.Id)"
+                               EnableSearch="true"
+                               TItem="Person"
+                               TItemValue="int"
+                               SearchInput="Jo">
+            </AntDesign.Select>
+        );
+        
+        // Act
+        cut.SetParametersAndRender(param => param.Add(p => p.SearchInput, string.Empty));
+        
+        // Assert
+        var items = cut.FindAll(".ant-select-item-option")
+            .Where(x => !x.Attributes["style"]?.Value.Trim().Contains("display:none") ?? true)
+            .ToList();
+        items.Should().HaveCount(4);
+    }
 
     [Fact]
     public async Task Will_not_filter_items_when_search_input_is_null()
@@ -279,6 +304,78 @@
             .ToList();
         items.Should().HaveCount(1);
         items[0].GetElementsByClassName("ant-select-item-option-content")[0].TextContent.Trim().Should().Be("John");
+    }
+    
+    class Tag
+    {
+        public string Value { get; set; }
+        public string Label { get; set; }
+    }
+
+    List<Tag> _tags = new List<Tag>
+    {
+        new Tag() { Value = "first", Label = "First" },
+        new Tag() { Value = "second", Label = "Second" },
+        new Tag() { Value = "third", Label = "Third" }
+    };
+
+    [Fact]
+    public async Task Filter_items_and_create_tag_when_changing_search_input()
+    {
+        // Arrange
+        var cut = Render<AntDesign.Select<string, Tag>>(
+            @<AntDesign.Select DataSource="@_tags"
+                               Mode="tags"
+                               LabelName="@nameof(Tag.Label)"
+                               ValueName="@nameof(Tag.Value)"
+                               EnableSearch="true"
+                               TItem="Tag"
+                               TItemValue="string"
+                               SearchInput="Fi">
+            </AntDesign.Select>
+        );
+        var trigger = cut.FindComponent<OverlayTrigger>();
+        
+        // Act
+        await cut.InvokeAsync(() => trigger.Instance.OnVisibleChange.InvokeAsync(false));
+        
+        // Assert
+        var items = cut.FindAll(".ant-select-item-option")
+            .Where(x => !x.Attributes["style"]?.Value.Trim().Contains("display:none") ?? true)
+            .ToList();
+        items.Should().HaveCount(2);
+        items[0].GetElementsByClassName("ant-select-item-option-content")[0].TextContent.Trim().Should().Be("First");
+        items[1].GetElementsByClassName("ant-select-item-option-content")[0].TextContent.Trim().Should().Be("Fi");
+    }
+
+    [Fact]
+    public async Task Reset_filtered_items_and_clear_custom_tag_on_setting_empty_search_input()
+    {
+        // Arrange
+        var cut = Render<AntDesign.Select<string, Tag>>(
+            @<AntDesign.Select DataSource="@_tags"
+                               Mode="tags"
+                               LabelName="@nameof(Tag.Label)"
+                               ValueName="@nameof(Tag.Value)"
+                               EnableSearch="true"
+                               TItem="Tag"
+                               TItemValue="string"
+                               SearchInput="Fi">
+            </AntDesign.Select>
+        );
+        var trigger = cut.FindComponent<OverlayTrigger>();
+        
+        // Act
+        cut.SetParametersAndRender(param => param.Add(p => p.SearchInput, string.Empty));
+        
+        // Assert
+        var items = cut.FindAll(".ant-select-item-option")
+            .Where(x => !x.Attributes["style"]?.Value.Trim().Contains("display:none") ?? true)
+            .ToList();
+        items.Should().HaveCount(3);
+        items[0].GetElementsByClassName("ant-select-item-option-content")[0].TextContent.Trim().Should().Be("First");
+        items[1].GetElementsByClassName("ant-select-item-option-content")[0].TextContent.Trim().Should().Be("Second");
+        items[2].GetElementsByClassName("ant-select-item-option-content")[0].TextContent.Trim().Should().Be("Third");
     }
     
 }

--- a/tests/AntDesign.Tests/Select/Select.SearchInput.Tests.razor
+++ b/tests/AntDesign.Tests/Select/Select.SearchInput.Tests.razor
@@ -169,7 +169,6 @@
             </AntDesign.Select>
         );
         
-        
         // Assert
         var items = cut.FindAll(".ant-select-item-option")
             .Where(x => !x.Attributes["style"]?.Value.Trim().Contains("display:none") ?? true)
@@ -197,6 +196,84 @@
         await cut.InvokeAsync(() => trigger.Instance.OnVisibleChange.InvokeAsync(false));
         
         // Assert
+        var items = cut.FindAll(".ant-select-item-option")
+            .Where(x => !x.Attributes["style"]?.Value.Trim().Contains("display:none") ?? true)
+            .ToList();
+        items.Should().HaveCount(1);
+        items[0].GetElementsByClassName("ant-select-item-option-content")[0].TextContent.Trim().Should().Be("John");
+    }
+
+    [Fact]
+    public async Task Will_not_reset_selected_item_when_search_input_changes()
+    {
+        // Arrange
+        int value = 0;
+        var cut = Render<AntDesign.Select<int, Person>>(
+            @<AntDesign.Select DataSource="@_persons"
+                               Mode="default"
+                               LabelName="@nameof(Person.Name)"
+                               ValueName="@nameof(Person.Id)"
+                               EnableSearch="true"
+                               @bind-value="@value"
+                               TItem="Person"
+                               TItemValue="int"
+                               SearchInput="Lu">
+            </AntDesign.Select>
+        );
+        
+        cut.FindAll(".ant-select-item-option")
+            .Single(x => !x.Attributes["style"]?.Value.Trim().Contains("display:none") ?? true)
+            .Click();
+        value.Should().Be(2);
+        
+        // Act
+        cut.SetParametersAndRender(param => param.Add(p => p.SearchInput, "Jo"));
+        
+        // Assert
+        value.Should().Be(2);
+        
+        var input = cut.Find(".ant-select-selection-search-input");
+        var inputValue = input.GetAttribute("value");
+        inputValue.Should().Be("Jo");
+        
+        var items = cut.FindAll(".ant-select-item-option")
+            .Where(x => !x.Attributes["style"]?.Value.Trim().Contains("display:none") ?? true)
+            .ToList();
+        items.Should().HaveCount(1);
+        items[0].GetElementsByClassName("ant-select-item-option-content")[0].TextContent.Trim().Should().Be("John");
+    }
+
+    [Fact]
+    public async Task Will_not_reset_selected_items_when_search_input_changes()
+    {
+        // Arrange
+        IEnumerable<int> values = new List<int>();
+        var cut = Render<AntDesign.Select<int, Person>>(
+            @<AntDesign.Select DataSource="@_persons"
+                               Mode="multiple"
+                               LabelName="@nameof(Person.Name)"
+                               ValueName="@nameof(Person.Id)"
+                               EnableSearch="true"
+                               @bind-values="@values"
+                               TItem="Person"
+                               TItemValue="int"
+                               SearchInput="Lu">
+            </AntDesign.Select>
+        );
+        
+        cut.Find(".ant-select-item-option").Click();
+        values.Should().HaveCount(1);
+        
+        // Act
+        cut.SetParametersAndRender(param => param.Add(p => p.SearchInput, "Jo"));
+        
+        // Assert
+        values.Should().HaveCount(1);
+        
+        var input = cut.Find(".ant-select-selection-search-input");
+        var inputValue = input.GetAttribute("value");
+        inputValue.Should().Be("Jo");
+        
         var items = cut.FindAll(".ant-select-item-option")
             .Where(x => !x.Attributes["style"]?.Value.Trim().Contains("display:none") ?? true)
             .ToList();

--- a/tests/AntDesign.Tests/Select/Select.SearchInput.Tests.razor
+++ b/tests/AntDesign.Tests/Select/Select.SearchInput.Tests.razor
@@ -1,0 +1,207 @@
+@using AntDesign.Core.JsInterop.Modules.Components
+@using AntDesign.Internal
+@using AntDesign.Select.Internal
+@inherits AntDesignTestBase
+
+@code{
+    
+    record Person(int Id, string Name);
+    
+    List<Person> _persons = new List<Person>
+    {
+        new Person(1, "John"),
+        new Person(2, "Lucy"),
+        new Person(3, "Jack"),
+        new Person(4, "Emily"),
+    };
+
+    public Select_SearchInput_Tests()
+    {
+        JSInterop.Setup<AntDesign.JsInterop.DomRect>(JSInteropConstants.GetBoundingClientRect, _ => true)
+            .SetResult(new AntDesign.JsInterop.DomRect());
+        JSInterop.SetupVoid(JSInteropConstants.AddPreventKeys, _ => true).SetVoidResult();
+        JSInterop.SetupVoid(JSInteropConstants.DomMainpulationHelper.Focus, _ => true).SetVoidResult();
+        JSInterop.SetupVoid(JSInteropConstants.AddPreventEnterOnOverlayVisible, _ => true).SetVoidResult();
+        JSInterop.Setup<OverlayPosition>(JSInteropConstants.OverlayComponentHelper.AddOverlayToContainer, _ => true)
+            .SetResult(new OverlayPosition());
+    }
+
+    [Fact]
+    public void Set_input_value_when_search_input_provided()
+    {
+        // Act
+        var cut = Render<AntDesign.Select<int, Person>>(
+            @<AntDesign.Select DataSource="@_persons"
+                               LabelName="@nameof(Person.Name)"
+                               ValueName="@nameof(Person.Id)"
+                               EnableSearch="true"
+                               TItem="Person"
+                               TItemValue="int"
+                               SearchInput="J">
+            </AntDesign.Select>
+        );
+        
+        
+        // Assert
+        var input = cut.Find(".ant-select-selection-search-input");
+        var inputValue = input.GetAttribute("value");
+        inputValue.Should().Be("J");
+    }
+
+    [Fact]
+    public void Update_input_value_when_search_input_updated()
+    {
+        // Arrange
+        var cut = Render<AntDesign.Select<int, Person>>(
+            @<AntDesign.Select DataSource="@_persons"
+                               LabelName="@nameof(Person.Name)"
+                               ValueName="@nameof(Person.Id)"
+                               EnableSearch="true"
+                               TItem="Person"
+                               TItemValue="int"
+                               SearchInput="J">
+            </AntDesign.Select>
+        );
+        
+        // Act
+        cut.SetParametersAndRender(param => param.Add(p => p.SearchInput, "Jo"));
+        
+        // Assert
+        var input = cut.Find(".ant-select-selection-search-input");
+        var inputValue = input.GetAttribute("value");
+        inputValue.Should().Be("Jo");
+    }
+
+    [Fact]
+    public async Task Filter_items_when_search_input_updated_while_in_focus()
+    {
+        // Arrange
+        var cut = Render<AntDesign.Select<int, Person>>(
+            @<AntDesign.Select DataSource="@_persons"
+                               LabelName="@nameof(Person.Name)"
+                               ValueName="@nameof(Person.Id)"
+                               EnableSearch="true"
+                               TItem="Person"
+                               TItemValue="int"
+                               SearchInput="J">
+            </AntDesign.Select>
+        );
+        
+        var trigger = cut.FindComponent<OverlayTrigger>();
+        await cut.InvokeAsync(() => trigger.Instance.OnVisibleChange.InvokeAsync(false));
+        
+        // Act
+        cut.SetParametersAndRender(param => param.Add(p => p.SearchInput, "Jo"));
+        
+        // Assert
+        var items = cut.FindAll(".ant-select-item-option")
+            .Where(x => !x.Attributes["style"]?.Value.Trim().Contains("display:none") ?? true)
+            .ToList();
+        items.Should().HaveCount(1);
+        items[0].GetElementsByClassName("ant-select-item-option-content")[0].TextContent.Trim().Should().Be("John");
+    }
+
+    [Fact]
+    public async Task Filter_items_when_search_input_updated_while_not_in_focus()
+    {
+        // Arrange
+        var cut = Render<AntDesign.Select<int, Person>>(
+            @<AntDesign.Select DataSource="@_persons"
+                               LabelName="@nameof(Person.Name)"
+                               ValueName="@nameof(Person.Id)"
+                               EnableSearch="true"
+                               TItem="Person"
+                               TItemValue="int"
+                               SearchInput="J">
+            </AntDesign.Select>
+        );
+        
+        // Act
+        cut.SetParametersAndRender(param => param.Add(p => p.SearchInput, "Jo"));
+        
+        // Assert
+        var items = cut.FindAll(".ant-select-item-option")
+            .Where(x => !x.Attributes["style"]?.Value.Trim().Contains("display:none") ?? true)
+            .ToList();
+        items.Should().HaveCount(1);
+        items[0].GetElementsByClassName("ant-select-item-option-content")[0].TextContent.Trim().Should().Be("John");
+    }
+
+    [Fact]
+    public async Task Filter_items_on_first_render()
+    {
+        // Arrange
+        var cut = Render<AntDesign.Select<int, Person>>(
+            @<AntDesign.Select DataSource="@_persons"
+                               LabelName="@nameof(Person.Name)"
+                               ValueName="@nameof(Person.Id)"
+                               EnableSearch="true"
+                               TItem="Person"
+                               TItemValue="int"
+                               SearchInput="Jo">
+            </AntDesign.Select>
+        );
+        
+        // Act
+        
+        // Assert
+        var items = cut.FindAll(".ant-select-item-option")
+            .Where(x => !x.Attributes["style"]?.Value.Trim().Contains("display:none") ?? true)
+            .ToList();
+        items.Should().HaveCount(1);
+        items[0].GetElementsByClassName("ant-select-item-option-content")[0].TextContent.Trim().Should().Be("John");
+    }
+
+
+    [Fact]
+    public async Task Will_not_filter_items_when_search_input_is_null()
+    {
+        // Act
+        string? input = null;
+        var cut = Render<AntDesign.Select<int, Person>>(
+            @<AntDesign.Select DataSource="@_persons"
+                               LabelName="@nameof(Person.Name)"
+                               ValueName="@nameof(Person.Id)"
+                               EnableSearch="true"
+                               TItem="Person"
+                               TItemValue="int"
+                               SearchInput="@input">
+            </AntDesign.Select>
+        );
+        
+        
+        // Assert
+        var items = cut.FindAll(".ant-select-item-option")
+            .Where(x => !x.Attributes["style"]?.Value.Trim().Contains("display:none") ?? true)
+            .ToList();
+        items.Should().HaveCount(4);
+    }
+
+    [Fact]
+    public async Task Will_not_reset_filtered_items_when_exiting_focus()
+    {
+        // Arrange
+        var cut = Render<AntDesign.Select<int, Person>>(
+            @<AntDesign.Select DataSource="@_persons"
+                               LabelName="@nameof(Person.Name)"
+                               ValueName="@nameof(Person.Id)"
+                               EnableSearch="true"
+                               TItem="Person"
+                               TItemValue="int"
+                               SearchInput="Jo">
+            </AntDesign.Select>
+        );
+        var trigger = cut.FindComponent<OverlayTrigger>();
+        
+        // Act
+        await cut.InvokeAsync(() => trigger.Instance.OnVisibleChange.InvokeAsync(false));
+        
+        // Assert
+        var items = cut.FindAll(".ant-select-item-option")
+            .Where(x => !x.Attributes["style"]?.Value.Trim().Contains("display:none") ?? true)
+            .ToList();
+        items.Should().HaveCount(1);
+        items[0].GetElementsByClassName("ant-select-item-option-content")[0].TextContent.Trim().Should().Be("John");
+    }
+    
+}

--- a/tests/AntDesign.Tests/Select/Select.SelectOptions.Tests.razor
+++ b/tests/AntDesign.Tests/Select/Select.SelectOptions.Tests.razor
@@ -214,5 +214,57 @@
         // All items except John should be visible because John is selected and HideSelected is true
         cut.FindAll(".ant-select-item-option").Where(x => !x.Attributes["style"]?.Value?.Trim()?.Contains("display:none") ?? true).Count().Should().Be(3);
     }
-}
+
+    [Theory]
+    [InlineData("default")]
+    [InlineData("multiple")]
+    public void Will_reset_search_input_when_item_selected(string mode)
+    {
+        JSInterop.SetupVoid("AntDesign.interop.eventHelper.addPreventKeys", _ => true);
+        JSInterop.SetupVoid("AntDesign.interop.domManipulationHelper.focus", _ => true);
+        JSInterop
+            .Setup<OverlayPosition>("AntDesign.interop.overlayHelper.addOverlayToContainer", _ => true)
+            .SetResult(new OverlayPosition
+            {
+                Bottom = 10,
+                Left = 10,
+                Right = 10,
+                Top = 10,
+                Placement = Placement.TopLeft,
+                ZIndex = 100
+            });
+
+        IEnumerable<Person> values = new List<Person>();
+        var itemsChanged = false;
+
+        var cut = Render<AntDesign.Select<Person, Person>>(
+            @<AntDesign.Select Mode=@mode
+                               EnableSearch=true
+                               HideSelected=true
+                               SearchDebounceMilliseconds=0
+                               OnSelectedItemChanged="() => { itemsChanged = true; }"
+                               OnSelectedItemsChanged="() => { itemsChanged = true; }"
+                               TItemValue="Person"
+                               TItem="Person"
+                               @bind-Values="@values">
+                <SelectOptions>
+                    @foreach (var item in _persons)
+                    {
+                        <SelectOption @key="item"
+                                      TItemValue="Person"
+                                      TItem="Person"
+                                      Value=@item
+                                      Label=@item.Name />
+                    }
+                </SelectOptions>
+            </AntDesign.Select>
+        );
+
+        var input = cut.Find("input[type=search]");
+        input.Input("John");
+        cut.Find(".ant-select-item-option").Click();
+        cut.WaitForState(() => itemsChanged);
+
+        input.GetAttribute("value").Should().BeEmpty();
+    }
 }


### PR DESCRIPTION
### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

I need to manage the search input that's displayed in the Select outside the component, see #4231.

### 💡 Background and solution

This PR introduces the `SearchInput` parameter that lets the user set the search input from outside, which brings one big important note: If this parameter is set, we cannot manage this value on the inside anymore (e.g. clear it on selecting a value or on unfocus), but the user has to do it on their own. Otherwise, we'd get conflicting states inside the component and outside of it (you'll see this especially in the `SelectBase` when the `_searchValue` is only cleared if `_manageSearchInputExternally` is `false`).
However, I tried to keep the changes a non-invasive as possible.

I'm conflicted as to naming the parameter `SearchInput` or `SearchValue`. The latter would conform to the existing backing field, whereas the former is more user-friendly in my opinion. Let me know what you think.

I tried to write a test for ever test case there is, but maybe double-check if I forgot some.
I also did intensive manual testing with all three Select types (default, multiple, tags) to make sure this works.
There are no breaking changes.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Add SearchInput property that lets the user set & manage the search input outside the component |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
