### PR TITLE
Move `Dialog` MaskClick Function into MouseUp Event Callback

### DIFF
--- a/components/modal/core/Dialog.razor
+++ b/components/modal/core/Dialog.razor
@@ -8,7 +8,6 @@
             <div class=@($"{Config.PrefixCls}-mask {GetMaskClsName()}") style="@Config.MaskStyle"></div>
         }
         <div tabindex="-1" class=@($"{Config.PrefixCls}-wrap {Config.GetWrapClassNameExtended(this.Status)}") role="dialog"
-             @onclick="@EventUtil.AsNonRenderingEventHandler(OnMaskClick)"
              @onmouseup="@EventUtil.AsNonRenderingEventHandler(OnMaskMouseUp)"
              @onkeydown="@(EventUtil.AsNonRenderingEventHandler<KeyboardEventArgs>(OnKeyDown))"
              style="@_wrapStyle">

--- a/components/modal/core/Dialog.razor
+++ b/components/modal/core/Dialog.razor
@@ -9,11 +9,13 @@
         }
         <div tabindex="-1" class=@($"{Config.PrefixCls}-wrap {Config.GetWrapClassNameExtended(this.Status)}") role="dialog"
              @onmouseup="@EventUtil.AsNonRenderingEventHandler(OnMaskMouseUp)"
+             @onmousedown="@EventUtil.AsNonRenderingEventHandler(OnMaskMouseDown)"
              @onkeydown="@(EventUtil.AsNonRenderingEventHandler<KeyboardEventArgs>(OnKeyDown))"
              style="@_wrapStyle">
             <div @ref="@_modal" role="document" 
                  class=@($"{Config.PrefixCls} {GetModalClsName()}")
                  @onclick:stopPropagation
+                 @onmousedown:stopPropagation
                  @onmousedown="@EventUtil.AsNonRenderingEventHandler(OnDialogMouseDown)"
                  style="@GetStyle()"
                  >

--- a/components/modal/core/Dialog.razor.cs
+++ b/components/modal/core/Dialog.razor.cs
@@ -159,6 +159,11 @@ namespace AntDesign
             _dialogMouseDown = true;
         }
 
+        private void OnMaskMouseDown()
+        {
+            _dialogMouseDown = false;
+        }
+
         private async Task OnMaskMouseUp()
         {
             if (Config.MaskClosable && !_dialogMouseDown)

--- a/components/modal/core/Dialog.razor.cs
+++ b/components/modal/core/Dialog.razor.cs
@@ -161,19 +161,11 @@ namespace AntDesign
 
         private async Task OnMaskMouseUp()
         {
-            if (Config.MaskClosable && _dialogMouseDown)
-            {
-                await Task.Delay(4);
-                _dialogMouseDown = false;
-            }
-        }
-
-        private async Task OnMaskClick()
-        {
             if (Config.MaskClosable && !_dialogMouseDown)
             {
                 await CloseAsync();
             }
+            _dialogMouseDown = false;
         }
 
         #endregion mask and dialog click event


### PR DESCRIPTION
Move `Dialog` MaskClick Function into MouseUp Event Callback

<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->
[Mousedown on the modal content and mouseup on the mask will sometimes close the modal #4272](https://github.com/ant-design-blazor/ant-design-blazor/issues/4272)
### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Move `Dialog` MaskClick Function into MouseUp Event Callback. Fixed #4272 |
| 🇨🇳 Chinese | 将 `Dialog` 遮罩层的点击事件功能移至鼠标松开回调。修复 #4272  |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
