### PR TITLE
End col inline style with semicolon

### DIFF
--- a/components/grid/Col.razor.cs
+++ b/components/grid/Col.razor.cs
@@ -180,12 +180,12 @@ namespace AntDesign
                 {
                     if (Regex.Match(str, "^\\d+(\\.\\d+)?(px|em|rem|%)$").Success)
                     {
-                        return $"flex: 0 0 {str}";
+                        return $"flex: 0 0 {str};";
                     }
 
-                    return $"flex: {str}";
+                    return $"flex: {str};";
                 },
-                num => $"flex: {num} {num} auto");
+                num => $"flex: {num} {num} auto;");
         }
 
         protected override void OnInitialized()


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [X] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->
When specifying the `Flex` attribute on a grid col, it is rendered as an inline style with no ending semicolon. This can cause issues if a user also specifies their own styling. For example:
```razor
<GridCol Flex="@("auto")" Style="display: flex; align-items: center;">
```
Will render as:
```html
<div class="ant-col" style=" flex: auto display: flex; align-items: center;">
```

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] Changelog is provided or not needed
