### PR TITLE
Striped property has been added to the Table component

### DIFF
--- a/components/table/Table.razor.cs
+++ b/components/table/Table.razor.cs
@@ -239,6 +239,14 @@ namespace AntDesign
         public bool Bordered { get; set; } = false;
 
         /// <summary>
+        /// Striped table or not
+        /// </summary>
+        /// <default value="false" />
+        [Parameter]
+        [PublicApi("1.1.0")]
+        public bool Striped { get; set; } = false;
+
+        /// <summary>
         /// Set horizontal scrolling, can also be used to specify the width of the scrolling area, can be set as pixel value, percentage
         /// </summary>
         [Parameter]
@@ -822,6 +830,7 @@ namespace AntDesign
             ClassMapper.Add(prefixCls)
                 .If($"{prefixCls}-fixed-header", () => ScrollY != null)
                 .If($"{prefixCls}-bordered", () => Bordered)
+                .If($"{prefixCls}-striped", () => Striped)
                 .If($"{prefixCls}-small", () => Size == TableSize.Small)
                 .If($"{prefixCls}-middle", () => Size == TableSize.Middle)
                 .If($"{prefixCls}-fixed-column {prefixCls}-scroll-horizontal", () => ScrollX != null)

--- a/components/table/style/patch.less
+++ b/components/table/style/patch.less
@@ -94,6 +94,12 @@
     }
 }
 
+.@{table-prefix-cls}.@{table-prefix-cls}-striped {
+    tr:nth-child(2n) {
+        background-color: @table-header-bg;
+    }
+}
+
 tr.@{table-prefix-cls}-grouping-footer > td {
     padding: 0;
     line-height: inherit;


### PR DESCRIPTION
### 🔗 Related issue link

Please see the related issue : [#4371](https://github.com/ant-design-blazor/ant-design-blazor/issues/4371)

I've added the **Striped** property to the **Table** component and now we can use **Striped** or **Striped="@true"** for this purpose.
And there is what is expected :

![image](https://github.com/user-attachments/assets/fdc2090e-76f7-496f-933b-cfcee4b44958)

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

- Striped property has been added to the Table component

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- Doc is not updated yet
- Demo is not updated yet
- Changelog is provided
