### PR TITLE
Adding WrapperClass for Input

### DIFF
--- a/components/input/Input.cs
+++ b/components/input/Input.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using AntDesign.Core.Documentation;
 using AntDesign.JsInterop;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
@@ -251,6 +252,17 @@ namespace AntDesign
         /// </summary>
         [Parameter]
         public string WrapperStyle { get; set; }
+
+        /// <summary>
+        /// Set Class of wrapper. Is used when component has visible: Prefix/Suffix
+        /// or has paramter set <seealso cref="AllowClear"/> or for components: <see cref="InputPassword"/>
+        /// and <see cref="Search"/>. In these cases, html span elements is used
+        /// to wrap the html input element.
+        /// <seealso cref="WrapperClass"/> is used on the span element.
+        /// </summary>
+        [Parameter]
+        [PublicApi("1.2.0")]
+        public string WrapperClass { get; set; }
 
         /// <summary>
         /// Show count of characters in the input
@@ -674,7 +686,7 @@ namespace AntDesign
             {
                 container = "groupWrapper";
                 builder.OpenElement(1, "span");
-                builder.AddAttribute(2, "class", GroupWrapperClass);
+                builder.AddAttribute(2, "class", string.Join(" ", GroupWrapperClass, WrapperClass));
                 builder.AddAttribute(3, "style", $"{WidthStyle} {WrapperStyle}");
                 builder.OpenElement(4, "span");
                 builder.AddAttribute(5, "class", $"{PrefixCls}-wrapper {PrefixCls}-group");

--- a/tests/AntDesign.Tests/Input/InputTests.razor
+++ b/tests/AntDesign.Tests/Input/InputTests.razor
@@ -286,6 +286,18 @@
         isValid.Should().Be(false);
         input?.ValidationMessages.Should().Contain("value field isn't valid.");
     }
-
     #endif
+
+    [Fact]
+    public void Input_WrapperClass_Test()
+    {
+        //Arrange
+        var cut = Render<AntDesign.Input<string>>(@<AntDesign.Input TValue="string" WrapperClass="test-wrapper-class"><AddOnAfter>AddOnAfter</AddOnAfter></AntDesign.Input>);
+
+        //Act
+        ITokenList classList = cut.Find("span.ant-input-group-wrapper").ClassList;
+
+        //Assert
+        classList.Contains("test-wrapper-class").Should().BeTrue();
+    }
 }


### PR DESCRIPTION
### 🤔 This is a ...
✅New feature


### 💡 Background and solution

Currently for **input** tags which have prefix and suffix does not have a feature to add  custom class to the **Wrapper Span**.
Suppose that there are a bunch of inputs in a form in the page which want to are expected to have same margins now we must use **WrapperStyle** for all of them with redundant styles.
Does it make sense to have a **WrapperClass** ?

### ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
✅Test Is Added
✅Doc is updated
✅Demo is updated
✅Changelog is provided
