### PR TITLE
perf(module: tag): use generic color dictionary and improve code quality

### DIFF
--- a/components/core/Base/AntDomComponentBase.cs
+++ b/components/core/Base/AntDomComponentBase.cs
@@ -74,10 +74,14 @@ namespace AntDesign
             get => _style;
             set
             {
-                _style = value;
-                if (!string.IsNullOrWhiteSpace(_style) && !_style.EndsWith(";"))
+                if (string.IsNullOrWhiteSpace(value))
                 {
-                    _style += ";";
+                    _style = string.Empty;
+                }
+                else
+                {
+                    var trimmed = value.Trim();
+                    _style = trimmed.EndsWith(';') ? trimmed : trimmed + ";";
                 }
             }
         }

--- a/components/core/Extensions/StringBuilderExtensions.cs
+++ b/components/core/Extensions/StringBuilderExtensions.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text;
+
+namespace AntDesign.Core.Extensions;
+
+internal static class StringBuilderExtensions
+{
+    /// <summary>
+    /// Append text if condition is <c>true</c>
+    /// </summary>
+    /// <param name="source"></param>
+    /// <param name="text"></param>
+    /// <param name="condition"></param>
+    /// <returns></returns>
+    public static StringBuilder AppendIf(this StringBuilder source, string text, bool condition)
+    {
+        if (condition)
+        {
+            source.Append(text);
+        }
+        return source;
+    }
+
+    public static StringBuilder AppendIfNotNullOrEmpty(this StringBuilder source, string text) => AppendIf(source, text, !string.IsNullOrEmpty(text));
+
+    public static StringBuilder AppendIfNotNullOrWhiteSpace(this StringBuilder source, string text) => AppendIf(source, text, !string.IsNullOrWhiteSpace(text));
+}

--- a/tests/AntDesign.Tests/Icon/IconServiceTests.cs
+++ b/tests/AntDesign.Tests/Icon/IconServiceTests.cs
@@ -44,21 +44,21 @@ namespace AntDesign.Tests.Icon
         }
 
         [Theory]
-        [MemberData(nameof(InvalidIconTestData))]
-        public void InvalidIconNameOrTypeShouldReturnNull(string iconName, IconThemeType type)
+        [InlineData(IconThemeType.Outline, "bad-icon")]
+        public void InvalidIconNameOrTypeShouldReturnNull(IconThemeType themeType, string iconName)
         {
-            IconService.GetIconImg(iconName, type).Should().BeNull();
+            IconService.GetIconImg(iconName, themeType).Should().BeNull();
         }
 
         [Fact]
         public void GetAllIconsShouldReturnDictionaryKeyedByThemeType()
         {
-            IconService.GetAllIcons().Keys.Should().BeEquivalentTo(new[]
-            {
+            IconService.GetAllIcons().Keys.Should().BeEquivalentTo(
+            [
                 IconThemeType.Outline,
                 IconThemeType.Fill,
                 IconThemeType.TwoTone
-            });
+            ]);
         }
 
         [Theory]
@@ -71,7 +71,7 @@ namespace AntDesign.Tests.Icon
         }
 
         [Theory]
-        [InlineData(IconThemeType.Outline, "alert", false)]
+        [InlineData(IconThemeType.Outline, "alert", true)]
         [InlineData(IconThemeType.Outline, "bad-icon", false)]
         [InlineData(IconThemeType.TwoTone, "bad-icon", false)]
         [InlineData(IconThemeType.TwoTone, "alert", true)]
@@ -89,18 +89,6 @@ namespace AntDesign.Tests.Icon
                     yield return new object[] { singleIconName, type };
                 }
             }
-        }
-
-        public static IEnumerable<object[]> InvalidIconTestData()
-        {
-            // Bad icon, correct type
-            yield return new object[] { "bad-icon-name", IconThemeType.TwoTone };
-
-            // Correct icon, bad type
-            yield return new object[] { "alert", default(IconThemeType) };
-
-            // Bad icon, bad type
-            yield return new object[] { "bad-icon-name", default(IconThemeType) };
         }
     }
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [x] Performance optimization
- [ ] Refactoring
- [x] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

Improve the current impl of `Tag`.

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

The tag currently still store the preset colors with `HashTable` after adding `TagColor` enums, which is not suggested by .NET now.

This PR replaces `HashTable` with the generic `Dictionary` and improves the code quality about resolving the color related properties.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Optimize the `Tag` implement  |
| 🇨🇳 Chinese |  优化`Tag`组件代码实现   |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
