### PR TITLE
StringFieldFilterType implement TableFilterCompareOperator.NotContains

### DIFF
--- a/components/table/Filters/StringFieldFilterType.cs
+++ b/components/table/Filters/StringFieldFilterType.cs
@@ -24,6 +24,7 @@ namespace AntDesign.Filters
             TableFilterCompareOperator.Equals,
             TableFilterCompareOperator.NotEquals,
             TableFilterCompareOperator.Contains,
+            TableFilterCompareOperator.NotContains,
             TableFilterCompareOperator.StartsWith,
             TableFilterCompareOperator.EndsWith,
         };
@@ -61,6 +62,8 @@ namespace AntDesign.Filters
                     compareOperator, leftExpr, rightExpr),
                 TableFilterCompareOperator.Contains => NotNullAnd(GetMethodExpression(nameof(string.Contains),
                     lowerLeftExpr, lowerRightExpr)),
+                TableFilterCompareOperator.NotContains => NotNullAnd(Expression.Not(GetMethodExpression(nameof(string.Contains),
+                    lowerLeftExpr, lowerRightExpr))),
                 TableFilterCompareOperator.StartsWith => NotNullAnd(GetMethodExpression(nameof(string.StartsWith),
                     lowerLeftExpr, lowerRightExpr)),
                 TableFilterCompareOperator.EndsWith => NotNullAnd(GetMethodExpression(nameof(string.EndsWith),


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [x] Other (about what?)

### 🔗 Related issue link
[#4492 ](https://github.com/ant-design-blazor/ant-design-blazor/issues/4492)

### 💡 Background and solution
Be able to filter out rows from a table that contain a certain string value in a column.
Implement TableFilterCompareOperator.NotContains for StringFieldFilterType  

### 📝 Changelog


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Adds string table filter option Not Contains |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
