### PR TITLE
fix(module: drawer): leaves a shadow after being closed

### DIFF
--- a/components/drawer/Drawer.razor.cs
+++ b/components/drawer/Drawer.razor.cs
@@ -388,13 +388,13 @@ namespace AntDesign
                     }
                 case ComponentStatus.Closing:
                     {
-                        StateHasChanged();
                         if (!_hasInvokeClosed)
                         {
                             await HandleClose();
                         }
 
                         _status = ComponentStatus.Closed;
+                        StateHasChanged();
                         break;
                     }
             }


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

### 💡 Background and solution

部分情况下，关闭Drawer，触发StateHasChanged的时机不正常，导致Drawer z-index异常(InnerZIndexStyle不更新)，例如：下图中，Drawer关闭后，仍然可以看到它的阴影
![20250327233938_rec_](https://github.com/user-attachments/assets/a37b49c0-3693-4c03-afc3-21c7de4a9b64)

![image](https://github.com/user-attachments/assets/6e1546ca-26b9-48fc-8b79-662511ff2bb7)


### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix z-index exception when closing Drawer  |
| 🇨🇳 Chinese |  修复关闭Drawer时，z-index异常  |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
