### PR TITLE
fix: add FlexGap.Normal to _gapMap dictionary (#4528)

### DIFF
--- a/components/flex/Flex.razor.cs
+++ b/components/flex/Flex.razor.cs
@@ -142,6 +142,7 @@ namespace AntDesign
 
         private static readonly Dictionary<FlexGap, string> _gapMap = new()
         {
+            [FlexGap.Normal] = "normal",
             [FlexGap.Small] = "small",
             [FlexGap.Middle] = "middle",
             [FlexGap.Large] = "large",


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [X] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

#4528 

### 💡 Background and solution

FlexGap.Normal was not present in _gapMap dictionary 

### 📝 Changelog


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  All Flex components that have the default FlexGap now no longer give an KeyNotFoundException |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [X] Changelog is provided or not needed
