### PR TITLE
fix: Broken components search

### DIFF
--- a/site/AntDesign.Docs/Demos/Components/Overview/demo/Overview.razor
+++ b/site/AntDesign.Docs/Demos/Components/Overview/demo/Overview.razor
@@ -87,7 +87,7 @@
 
         IList<DemoMenuItem> result = new List<DemoMenuItem>();
 
-        foreach (var item in menuItems)
+        foreach (var item in menuItems.Where(mi => mi.Children != null))
         {
             var lst = item.Children.Where(x => x.Title.Contains(value, StringComparison.OrdinalIgnoreCase)).ToArray();
 

--- a/site/AntDesign.Docs/Pages/Static/Components/Overview.razor
+++ b/site/AntDesign.Docs/Pages/Static/Components/Overview.razor
@@ -108,7 +108,7 @@
 
         IList<DemoMenuItem> result = new List<DemoMenuItem>();
 
-        foreach (var item in menuItems)
+        foreach (var item in menuItems.Where(mi => mi.Children != null))
         {
             var lst = item.Children.Where(x => x.Title.Contains(value, StringComparison.OrdinalIgnoreCase)).ToArray();
 


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

Component search is broken because `Children` can be `null`, additional `Where` fixes that.

Now in documentation:

https://github.com/user-attachments/assets/9c9538d0-3891-4482-9c29-2621ee540df8

After fix:


https://github.com/user-attachments/assets/121bdb08-d92c-4350-b848-e235dcc879c1



### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
