### PR TITLE
Remove the branch filter since it is meant to work from pull requests

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -5,7 +5,6 @@ name: Preview Deploy
 on:
   workflow_run:
     workflows: ["Preview Build"]
-    branches: master
     types:
       - completed
 


### PR DESCRIPTION
/cc @ElderJames

Post fix for #4557. The branch filter is not needed since it has to run on pull requests. Sorry about that.