### PR TITLE
feat(module: input): Bring DefaultToEmptyString parameter to Input from TextArea

### DIFF
--- a/components/input/Input.cs
+++ b/components/input/Input.cs
@@ -276,6 +276,14 @@ namespace AntDesign
         [Parameter]
         public string Width { get; set; }
 
+        /// <summary>
+        /// When true, value will be set to empty string.
+        /// When false, value will be set to <c>null</c> when content is empty or whitespace. 
+        /// </summary>
+        /// <default value="false"/>
+        [Parameter]
+        public bool DefaultToEmptyString { get; set; }
+
         protected Dictionary<string, object> Attributes { get; set; }
 
         protected ForwardRef WrapperRefBack { get; set; }
@@ -658,6 +666,18 @@ namespace AntDesign
             }
 
             base.OnCurrentValueChange(value);
+        }
+
+        protected override bool TryParseValueFromString(string value, out TValue result, out string validationErrorMessage)
+        {
+            if (string.IsNullOrWhiteSpace(value) && DefaultToEmptyString && typeof(TValue) == typeof(string))
+            {
+                result = (TValue)(object)string.Empty;
+                validationErrorMessage = null;
+                return true;
+            }
+
+            return base.TryParseValueFromString(value, out result, out validationErrorMessage);
         }
 
         /// <summary>

--- a/components/input/TextArea.razor.cs
+++ b/components/input/TextArea.razor.cs
@@ -47,14 +47,6 @@ namespace AntDesign
         }
 
         /// <summary>
-        /// When true, value will be set to empty string.
-        /// When false, value will be set to <c>null</c> when content is empty or whitespace. 
-        /// </summary>
-        /// <default value="false"/>
-        [Parameter]
-        public bool DefaultToEmptyString { get; set; }
-
-        /// <summary>
         /// Allow growing, but stop when visible rows = MaxRows (will not grow further).
         /// </summary>
         /// <default value="uint.MaxValue"/>
@@ -252,21 +244,6 @@ namespace AntDesign
         {
             base.OnCurrentValueChange(value);
             _inputString = value;
-        }
-
-        protected override bool TryParseValueFromString(string value, out string result, out string validationErrorMessage)
-        {
-            validationErrorMessage = null;
-            if (string.IsNullOrWhiteSpace(value))
-            {
-                if (DefaultToEmptyString)
-                    result = string.Empty;
-                else
-                    result = default;
-                return true;
-            }
-            result = value;
-            return true;
         }
 
         protected override void Dispose(bool disposing)

--- a/tests/AntDesign.Tests/Input/InputTests.razor
+++ b/tests/AntDesign.Tests/Input/InputTests.razor
@@ -309,8 +309,8 @@
         var cut = Render<AntDesign.Input<string>>(@<AntDesign.Input @bind-Value="@value" DefaultToEmptyString="true" />);
 
         //Act
-        cut.Find("input").Input("");
-        cut.Find("input").Change("");
+        cut.Find("input").Input(null);
+        cut.Find("input").Change(null);
 
         //Assert
         cut.Instance.Value.Should().Be(string.Empty);
@@ -325,8 +325,8 @@
         var cut = Render<AntDesign.Input<string>>(@<AntDesign.Input @bind-Value="@value" DefaultToEmptyString="false" />);
 
         //Act
-        cut.Find("input").Input("");
-        cut.Find("input").Change("");
+        cut.Find("input").Input(null);
+        cut.Find("input").Change(null);
 
         //Assert
         cut.Instance.Value.Should().BeNull();

--- a/tests/AntDesign.Tests/Input/InputTests.razor
+++ b/tests/AntDesign.Tests/Input/InputTests.razor
@@ -300,4 +300,36 @@
         //Assert
         classList.Contains("test-wrapper-class").Should().BeTrue();
     }
+
+    [Fact]
+    public void Input_DefaultToEmptyString_True_Returns_EmptyString()
+    {
+        //Arrange
+        string? value = "test";
+        var cut = Render<AntDesign.Input<string>>(@<AntDesign.Input @bind-Value="@value" DefaultToEmptyString="true" />);
+
+        //Act
+        cut.Find("input").Input("");
+        cut.Find("input").Change("");
+
+        //Assert
+        cut.Instance.Value.Should().Be(string.Empty);
+        value.Should().Be(string.Empty);
+    }
+
+    [Fact]
+    public void Input_DefaultToEmptyString_False_Returns_Null()
+    {
+        //Arrange
+        string? value = "test";
+        var cut = Render<AntDesign.Input<string>>(@<AntDesign.Input @bind-Value="@value" DefaultToEmptyString="false" />);
+
+        //Act
+        cut.Find("input").Input("");
+        cut.Find("input").Change("");
+
+        //Assert
+        cut.Instance.Value.Should().BeNull();
+        value.Should().BeNull();
+    }
 }


### PR DESCRIPTION
Updated the Input component to include a new parameter, DefaultToEmptyString, which controls whether the value is set to an empty string or null when the input is empty or whitespace. The TryParseValueFromString method has been overridden to implement this logic. Removed the DefaultToEmptyString parameter from the TextArea component. Added unit tests to verify the new behavior of the Input component.

<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
