### PR TITLE
feat(module:tabs): Add StandaloneInCard parameter to Tabs component

### DIFF
--- a/components/tabs/Tabs.razor
+++ b/components/tabs/Tabs.razor
@@ -9,7 +9,7 @@
     <Template>
         @{
             this.Complete();
-            if (Card is null)
+            if (!IsTabbedCard)
             {
                 @RenderTabs
             }
@@ -88,7 +88,7 @@
                 }
             </div>
             <!--Tab content-->
-            @if (Card == null)
+            @if (!IsTabbedCard)
             {                
                 @RenderTabPanels                  
             }

--- a/components/tabs/Tabs.razor.cs
+++ b/components/tabs/Tabs.razor.cs
@@ -206,6 +206,13 @@ namespace AntDesign
         [Parameter]
         public bool Centered { get; set; }
 
+        /// <summary>
+        /// Whether to render the tabs standalone in a card, otherwise it will be rendered as a part of a TabbedCard by default.
+        /// </summary>
+        [PublicApi("1.4.1")]
+        [Parameter]
+        public bool StandaloneInCard { get; set; }
+
         [CascadingParameter]
         private Card Card { get; set; }
 
@@ -260,6 +267,8 @@ namespace AntDesign
 
         private bool IsOverflowed => _scrollListWidth <= _wrapperWidth;
 
+        private bool IsTabbedCard => Card != null && !StandaloneInCard;
+
         private readonly int _dropDownBtnWidth = 46;
         private readonly int _addBtnWidth = 40;
         private bool _shownDropdown;
@@ -283,8 +292,8 @@ namespace AntDesign
                 .If($"{PrefixCls}-line", () => Type == TabType.Line)
                 .If($"{PrefixCls}-editable-card", () => Type == TabType.EditableCard)
                 .If($"{PrefixCls}-card", () => Type.IsIn(TabType.EditableCard, TabType.Card))
-                .If($"{PrefixCls}-large", () => Size == TabSize.Large || (Card != null && Card.Size != CardSize.Small))
-                .If($"{PrefixCls}-head-tabs", () => Card != null)
+                .If($"{PrefixCls}-large", () => Size == TabSize.Large || (IsTabbedCard && Card.Size != CardSize.Small))
+                .If($"{PrefixCls}-head-tabs", () => IsTabbedCard)
                 .If($"{PrefixCls}-small", () => Size == TabSize.Small)
                 .If($"{PrefixCls}-no-animation", () => !Animated)
                 .If($"{PrefixCls}-centered", () => Centered)
@@ -308,7 +317,7 @@ namespace AntDesign
                 .Add($"{PrefixCls}-nav")
                 .If(TabBarClass, () => !string.IsNullOrWhiteSpace(TabBarClass));
 
-            if (Card is not null)
+            if (IsTabbedCard)
             {
                 Card.SetTabs(RenderTabs);
                 Card.SetTabPanels(RenderTabPanels);
@@ -549,13 +558,17 @@ namespace AntDesign
 
             _retryingGetSize = false;// each activation only can try once
             TryRenderInk();
-            if (Card?.Body == null)
+
+            if (IsTabbedCard)
             {
-                Card?.SetBody(EmptyRenderFragment);
-            }
-            else
-            {
-                Card?.InvokeStateHasChagned();
+                if (Card.Body == null)
+                {
+                    Card.SetBody(EmptyRenderFragment);
+                }
+                else
+                {
+                    Card.InvokeStateHasChagned();
+                }
             }
 
             // render the classname of the actived tab
@@ -781,7 +794,7 @@ namespace AntDesign
                 }
             }
 
-            if (Card is not null)
+            if (IsTabbedCard)
             {
                 Card.InvokeStateHasChagned();
             }

--- a/site/AntDesign.Docs/Demos/Components/Card/demo/Tabs1.md
+++ b/site/AntDesign.Docs/Demos/Components/Card/demo/Tabs1.md
@@ -7,9 +7,9 @@ title:
 
 ## zh-CN
 
-可承载更多内容。
+可承载更多内容。用 `StandaloneInCard` 属性可在 Card 中独立使用 Tabs，以避免与其他内容冲突。
 
 ## en-US
 
-More content can be hosted.
+More content can be hosted. Use the `StandaloneInCard` parameter to use Tabs independently in Card to avoid conflicts with other content.
 

--- a/site/AntDesign.Docs/Demos/Components/Card/demo/Tabs1.razor
+++ b/site/AntDesign.Docs/Demos/Components/Card/demo/Tabs1.razor
@@ -1,5 +1,5 @@
 ﻿<div>
-    <Card Title=@("Card title")>
+    <Card Title="TabbedCard">
         <Extra>
             <a>More</a>
         </Extra>
@@ -22,12 +22,15 @@
     </Card>
     <br />
     <br />
-    <Card>
+    <Card Title="Standalone Tabs">
         <Extra>
             <a>More</a>
         </Extra>
         <ChildContent>
-            <Tabs DefaultActiveKey="1">
+            <p>Card content</p>
+            <p>Card content</p>
+            <p>Card content</p>
+            <Tabs DefaultActiveKey="1" StandaloneInCard>
                 <TabPane Key="1">
                     <TabTemplate>Article</TabTemplate>
                     <ChildContent>Content of Tab Pane 1</ChildContent>


### PR DESCRIPTION
Introduce a new `StandaloneInCard` parameter to the `Tabs` component, enabling independent rendering within a `Card` to avoid content conflicts. Update component logic to incorporate the `IsTabbedCard` boolean for conditional rendering. Revise documentation and examples in `Tabs1.razor` and `Test.razor` to showcase the new functionality.

<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [x ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
fixed #4598
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
