### PR TITLE
fix(module: tabs): Ensure OnTabClick is fired correctly when tabs are clicked

### DIFF
--- a/components/tabs/Tabs.razor.cs
+++ b/components/tabs/Tabs.razor.cs
@@ -449,13 +449,13 @@ namespace AntDesign
 
         internal async Task HandleTabClick(TabPane tabPane)
         {
-            if (tabPane.IsActive)
-                return;
-
             if (OnTabClick.HasDelegate)
             {
                 await OnTabClick.InvokeAsync(tabPane.Key);
             }
+
+            if (tabPane.IsActive)
+                return;
 
             ActivatePane(tabPane.Key);
         }

--- a/tests/AntDesign.Tests/tabs/TabsTests.razor
+++ b/tests/AntDesign.Tests/tabs/TabsTests.razor
@@ -125,4 +125,27 @@
         var paneElements = cut.FindAll(".ant-tabs-nav");
             paneElements[0].Attributes["class"]?.Value.Should().Be($"ant-tabs-nav {classList}");
     }
+
+    [Fact]
+    public void Should_fire_OnTabClick_when_tab_is_clicked()
+    {
+        string clickedKey = null;
+        Action<string> onTabClick = key => clickedKey = key;
+
+        var cut = Context.Render(
+            @<Tabs OnTabClick="onTabClick">
+                <TabPane Key="tab1" Tab="Tab 1"></TabPane>
+                <TabPane Key="tab2" Tab="Tab 2"></TabPane>
+            </Tabs>
+        );
+
+        // Click on the first tab (already active)
+        cut.FindAll("div.ant-tabs-tab")[0].Click();
+        clickedKey.Should().Be("tab1");
+
+        // Click on the second tab (not active)
+        clickedKey = null;
+        cut.FindAll("div.ant-tabs-tab")[1].Click();
+        clickedKey.Should().Be("tab2");
+    }
 }


### PR DESCRIPTION
- Moved the check for active tab after the OnTabClick invocation to ensure the event is fired correctly for both active and inactive tabs.
- Added a new unit test to verify that OnTabClick is triggered when a tab is clicked, regardless of its active state.

<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

fixed #4584

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
