### PR TITLE
fix(module: menu): the inline collapsed state can't invoke correctly

### DIFF
--- a/components/menu/Menu.razor.cs
+++ b/components/menu/Menu.razor.cs
@@ -400,8 +400,6 @@ namespace AntDesign
             {
                 InternalMode = Mode;
             }
-
-            SetClass();
         }
 
         private void HandleOpenChange(string[] openKeys)

--- a/components/menu/MenuItem.razor
+++ b/components/menu/MenuItem.razor
@@ -5,7 +5,7 @@
 <CascadingValue Value="this" IsFixed>
     @if (ShowTooltip)
     {
-        <Tooltip TitleTemplate="@content" Placement="@Placement.Right" Disabled="TooltipDisabled">
+        <Tooltip @ref="_tooltip" TitleTemplate="@content" Placement="@Placement.Right" Disabled="TooltipDisabled">
             <Unbound Context="tooltip">
                 @MenuItemContent(tooltip)
             </Unbound>

--- a/components/menu/MenuItem.razor.cs
+++ b/components/menu/MenuItem.razor.cs
@@ -89,6 +89,8 @@ namespace AntDesign
         internal bool IsSelected { get; private set; }
         internal bool FirstRun { get; set; } = true;
         private string _key;
+        private Tooltip _tooltip;
+
         private bool TooltipDisabled => ParentMenu?.IsOpen == true || ParentMenu?._overlayVisible == true || RootMenu?.InlineCollapsed == false;
 
         private int Padding => RootMenu?.InternalMode == MenuMode.Inline ? ((ParentMenu?.Level ?? 0) + 1) * RootMenu?.InlineIndent ?? 0 : 0;
@@ -127,6 +129,8 @@ namespace AntDesign
 
             if (RootMenu?.SelectedKey(Key) == true && !IsSelected)
                 Select();
+
+            _tooltip?.SetShouldRender(true);
         }
 
         protected override void Dispose(bool disposing)


### PR DESCRIPTION
- Updated `Menu.razor.cs` to streamline internal state management by setting `InternalMode` and removing redundant calls.
- Modified `MenuItem.razor` to include a reference to `_tooltip` for improved tooltip manipulation.
- Introduced `_tooltip` field and `TooltipDisabled` property in `MenuItem.razor.cs` to enhance tooltip display logic based on menu state.
- Updated `OnParametersSet` to ensure tooltip rendering is responsive.
- Improved lifecycle management of tooltips within menu items for better performance.

<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
