### PR TITLE
fix(module: table): resolve header column initialization issue

### DIFF
--- a/components/table/ColumnContext.cs
+++ b/components/table/ColumnContext.cs
@@ -17,6 +17,8 @@ namespace AntDesign
         private int CurrentColIndex { get; set; }
 
         private int[] ColIndexOccupied { get; set; }
+        
+        private bool _headerColumnsInitialized;
 
         private ITable _table;
 
@@ -64,6 +66,11 @@ namespace AntDesign
 
             column.ColIndex = CurrentColIndex;
             HeaderColumns.Add(column);
+            if (HeaderColumns.Count == Columns.Count)
+            {
+                _headerColumnsInitialized = true;
+            }
+
             CurrentColIndex += columnSpan - 1;
 
             if (column.RowSpan > 1)
@@ -159,7 +166,7 @@ namespace AntDesign
 
         internal void HeaderColumnInitialized(IColumn column)
         {
-            if (column.ColIndex == Columns.Count - 1)
+            if (_headerColumnsInitialized)
             {
                 // Header columns have all been initialized, then we can invoke the first change.
                 _table.OnColumnInitialized();


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

#4667 

### 💡 Background and solution

**Header column initialization improvements:**

* Added a private `_headerColumnsInitialized` flag to track when all header columns have been initialized (`ColumnContext.cs`).
* Set `_headerColumnsInitialized` to `true` in `AddHeaderColumn` when the number of header columns matches the number of total columns (`ColumnContext.cs`).
* Updated `HeaderColumnInitialized` to use the `_headerColumnsInitialized` flag instead of relying on the column index, ensuring `OnColumnInitialized` is only called after all header columns are initialized (`ColumnContext.cs`).

### 📝 Changelog

fix Table rendering fails when HeaderColSpan exceeds remaining column count

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
