### PR TITLE
Fix JsInvokeAsync: remove console output to prevent stack trace printing

### DIFF
--- a/components/core/Base/AntComponentBase.cs
+++ b/components/core/Base/AntComponentBase.cs
@@ -91,7 +91,7 @@ namespace AntDesign
             {
                 return await Js.InvokeAsync<T>(code, args);
             }
-            catch (Exception e)
+            catch
             {
                 throw;
             }
@@ -103,12 +103,13 @@ namespace AntDesign
             {
                 await Js.InvokeVoidAsync(code, args);
             }
-            catch (Exception e)
+            catch
             {
-                Console.WriteLine(e);
+                // Do not write to console
                 throw;
             }
         }
+
 
         /// <summary>
         /// Standard Focus. From Net5 uses Blazor extension method on ElementReference.


### PR DESCRIPTION
### 🤔 This is a ...

- [x] Bug fix

### 🔗 Related issue link

#4665

### 💡 Background and solution

The `AntComponentBase.JsInvokeAsync` method was printing exceptions to the console even when the exception might be handled.  
This caused unnecessary stack traces to appear during normal operation.  

**Solution:**  
- Removed `Console.WriteLine(e)` from the catch block in `JsInvokeAsync`.  
- Now exceptions will be propagated normally without logging to the console.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed JsInvokeAsync to stop printing exception stack traces to console. |
| 🇨🇳 Chinese | 修复 JsInvokeAsync 方法，不再向控制台打印异常堆栈信息。 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
