### PR TITLE
fix(module: tabs): avoid rerendering on tab was close

### DIFF
--- a/components/tabs/Tabs.razor
+++ b/components/tabs/Tabs.razor
@@ -102,7 +102,7 @@
             <div class="@_contentClassMapper.Class">
                 @foreach (var tab in _tabs)
                 {
-                    __builder.AddContent(tab.GetHashCode(), tab.RenderPane);
+					__builder.AddContent(tab.TabIndex, tab.RenderPane);
                 }
             </div>
         </div>     

--- a/components/tabs/Tabs.razor.cs
+++ b/components/tabs/Tabs.razor.cs
@@ -423,13 +423,10 @@ namespace AntDesign
             if (IsDisposed)
                 return;
 
-            // reorder tabs
-            _tabs.OrderBy(x => x.TabIndex).ForEach((x, i) => x.SetIndex(i));
-
             // if it is active, need to activiate the previous tab, or the next one if no previous
             if (_activeKey == tab.Key)
             {
-                if (tab.TabIndex > 0)
+                if (_tabs.IndexOf(tab) > 0)
                 {
                     Previous();
                 }


### PR DESCRIPTION
Refactor `Tabs.razor` to use `tab.TabIndex` instead of `tab.GetHashCode()` for rendering content, ensuring proper tab order.

Remove manual reordering of `_tabs` in `Tabs.razor.cs`, as tabs are now rendered in the correct order directly.

Update the condition for activating the previous tab to use `_tabs.IndexOf(tab)` instead of `tab.TabIndex`, improving reliability and alignment with the collection's natural order.

These changes improve maintainability and address potential issues with tab ordering and activation.

<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
