### PR TITLE
feat(module: table): support for hiding the adding button for  `FieldType` filter with FilterMultiple=false.

### DIFF
--- a/components/table/Column.razor
+++ b/components/table/Column.razor
@@ -346,7 +346,7 @@ else if (IsBody && RowSpan != 0 && ColSpan != 0)
             <Button Size="@ButtonSize.Small" Type="@ButtonType.Link" OnClick="ResetFilters">
                 @Table?.Locale.FilterReset
             </Button>
-            @if (_columnFilterType == TableFilterType.FieldType)
+            @if (_columnFilterType == TableFilterType.FieldType && FilterMultiple)
             {
                 <Button Size="@ButtonSize.Small" Icon="plus" Type="@ButtonType.Primary" OnClick="AddFilter" />
             }


### PR DESCRIPTION
When `FilterMultiple` is `true`, show the `AddFilter` button, otherwise don't show it.

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
<!--
1. Describe the source of requirement, like related issue link.
-->
https://github.com/ant-design-blazor/ant-design-blazor/issues/2056

### 💡 Background and solution
Problem: when `FilterMultiple` is `false` in a `TableFilterType.FieldType` column (not a list), the user can add multiple filters (with the `AddFilter` button). 
Solution: don't show this button when `FilterMultiple` is `false`.
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
