### PR TITLE
fix(module: datepicker): fix for net10 bug on DatePicker

### DIFF
--- a/components/core/Component/Overlay/Overlay.razor.cs
+++ b/components/core/Component/Overlay/Overlay.razor.cs
@@ -403,6 +403,14 @@ namespace AntDesign.Internal
         }
 
         /// <summary>
+        /// Refresh the state of the component
+        /// </summary>
+        /// <remarks>
+        /// Call to StateHasChanged()
+        /// </remarks>
+        internal void RefreshComponentState() => StateHasChanged();
+
+        /// <summary>
         /// Will probe a check predicate every given milliseconds until predicate is true or until
         /// runs out of number of probings.
         /// </summary>

--- a/components/date-picker/internal/DatePickerBase.cs
+++ b/components/date-picker/internal/DatePickerBase.cs
@@ -552,8 +552,8 @@ namespace AntDesign
                 {
                     _activeBarStyle = "display: none";
                 }
-
-                StateHasChanged();
+                
+                RefreshComponentState();
             }
 
             _needRefresh = false;
@@ -916,7 +916,18 @@ namespace AntDesign
 
         protected virtual void InvokeOnChange()
         {
+        }
 
+        /// <summary>
+        /// Refresh the state of the component
+        /// </summary>
+        /// <remarks>
+        /// Call to StateHasChanged() for the overlay
+        /// </remarks>
+        protected void RefreshComponentState()
+        {
+            _dropDown.GetOverlayComponent().RefreshComponentState();
+            StateHasChanged(); // needed?
         }
 
         /// <summary>
@@ -957,7 +968,7 @@ namespace AntDesign
         {
             _placeholders[index] = placeholder;
 
-            StateHasChanged();
+            RefreshComponentState();
         }
 
         protected void ResetPlaceholder(int rangePickerIndex = -1)
@@ -1088,7 +1099,7 @@ namespace AntDesign
 
             InvokeOnPanelChange(date);
 
-            StateHasChanged();
+            RefreshComponentState();
         }
 
         internal void ChangePickerType(DatePickerType type)
@@ -1103,7 +1114,7 @@ namespace AntDesign
 
             InvokeOnPanelChange(PickerValues[index]);
 
-            StateHasChanged();
+            RefreshComponentState();
         }
 
         /// <summary>


### PR DESCRIPTION
On a .NET 10 (rc1) project, the DatePicker has bugs: for example, the year and month top buttons are useless (nothing on click).

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

This is a problem with StateHasChanged -> on DatePickerBase, the call to StateHasChanged don't resfresh the overlay component.
I don't know if this is due to CascadingValue behavior in .NET 10...

This workaround/fix will work for the DatePicker bug, but I suspect that other components that use Overlay (and OverlayTrigger) are also bugged if they use StateHasChanged...

If someone has an idea to better fix this, it will be very useful for the .Net 10 compatibility!

Notes :
 - this fix is useless for other versions of .Net (tested with .Net 9), but it will also work.
 - not needed to compile AntDesign package on .Net 10 (AntDesign components on .Net 9 with project on .Net 10 will work with this fix).
 
### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
