### PR TITLE
Redundant ant-input-group-wrapper has been removed

### DIFF
--- a/components/input/Search.razor.cs
+++ b/components/input/Search.razor.cs
@@ -144,7 +144,7 @@ namespace AntDesign
             }
 
             AffixWrapperClass = string.Join(" ", AffixWrapperClass, $"{PrefixCls}-search");
-            GroupWrapperClass = string.Join(" ", GroupWrapperClass, $"{PrefixCls}-search ant-input-group-wrapper");
+            GroupWrapperClass = string.Join(" ", GroupWrapperClass, $"{PrefixCls}-search");
             GroupWrapperClass = string.Join(" ", GroupWrapperClass, $"{PrefixCls}-search-enter-button");
         }
 


### PR DESCRIPTION
### 🤔 This is a minor fix
Since in the initialize of **GroupWrapperClass** there is `$"{PrefixCls}-group-wrapper";`
```CS
protected const string PrefixCls = "ant-input";
protected string GroupWrapperClass { get; set; } = $"{PrefixCls}-group-wrapper";
```
In `SetClasses()` there is no need to add it again, not to mention that **PrefixCls** is not used and directly written with **ant-input**.
```CS
GroupWrapperClass = string.Join(" ", GroupWrapperClass, $"{PrefixCls}-search ant-input-group-wrapper");
```
As the picture attached this class is mentioned twice :
<img width="1082" height="647" alt="ant-input-group-wrapper" src="https://github.com/user-attachments/assets/81c4e607-4e50-431d-8468-0d96778bc34d" />

Thus I removed the redundant one.


- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [x] Performance optimization
- [ ] Refactoring
- [x] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
