### PR TITLE
Fix the problem that the autofocus of input in the pop-up window is invalid. It is a temporary solution.

### DIFF
--- a/components/input/Input.cs
+++ b/components/input/Input.cs
@@ -106,6 +106,11 @@ namespace AntDesign
                     IsFocused = _autoFocus;
             }
         }
+        /// <summary>
+        /// Delay of auto focus
+        /// </summary>
+        [Parameter]
+        public int AutoFocusDelay { get; set; }
 
         /// <summary>
         /// Whether has border style
@@ -641,6 +646,8 @@ namespace AntDesign
                 if (this.AutoFocus)
                 {
                     IsFocused = true;
+                    if(AutoFocusDelay>0)
+                        await Task.Delay(AutoFocusDelay);
                     await this.FocusAsync(Ref);
                 }
 

--- a/site/AntDesign.Docs/Demos/Components/Modal/demo/FormInModal.razor
+++ b/site/AntDesign.Docs/Demos/Components/Modal/demo/FormInModal.razor
@@ -28,7 +28,7 @@
               OnFinishFailed="OnFinishFailed"
               @ref="@_form">
             <FormItem Label="Username">
-                <Input @bind-Value="@context.Username" />
+                <Input @bind-Value="@context.Username" AutoFocus AutoFocusDelay="700" />
             </FormItem>
             <FormItem Label="Password">
                 <InputPassword @bind-Value="@context.Password" />


### PR DESCRIPTION


### 🤔 this is a
Bug fix

### 🔗 Related issue link
[Input in modal can not be focused automatically](https://github.com/ant-design-blazor/ant-design-blazor/issues/4059)

### 💡 Background and solution

When an Input component is placed inside a Dialog/Modal component, the AutoFocus feature of the Input does not work as expected. The suspected cause is the popup animation.

A complete solution is difficult, because the Input can be placed inside any type of container, which involves interaction between the container component and the slotted inner component.

The current workaround is to add an AutoFocusDelay parameter. When the Input is rendered for the first time, it waits for AutoFocusDelay milliseconds before setting focus on the input box. In testing, this works reasonably well for Inputs inside a modal:
'''<Input @bind-Value="@context.Username" AutoFocus AutoFocusDelay="700" />'''

Note: By default, when the modal is closed, the DOM is not destroyed. Therefore, when reopening the modal, the Input still cannot be focused automatically, because it only auto-focuses on the first render.

As mentioned, a thorough fix is difficult. For now, you can try referencing the Input component via @ref, and then call the Input’s Focus method inside the modal’s VisibleChanged event. This approach has not been tested.
or 
set modalOptions.DestroyOnClose=true

### 📝 Changelog
When Dialog/Modal is displayed for the first time, AutoFocus of Input will work as expected.

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ √] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
