### PR TITLE
IconThemeType added to the copied Component

### DIFF
--- a/site/AntDesign.Docs/Demos/Components/Icon/demo/List.razor
+++ b/site/AntDesign.Docs/Demos/Components/Icon/demo/List.razor
@@ -118,7 +118,7 @@ else
 
     private void OnCopyClick(IconThemeType theme, string iconName)
     {
-        string htmlIcon = $"<Icon Type=\"{iconName}\" Theme=\"{theme}\"/>";
+        string htmlIcon = $"<Icon Type=\"{iconName}\" Theme=\"{nameof(IconThemeType)}.{theme}\"/>";
         JsRuntime.InvokeAsync<object>(JSInteropConstants.Copy, htmlIcon);
 
         messageService.Success(htmlIcon+ "  copied 🎉!");


### PR DESCRIPTION
### 🤔 This is a refactor

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 💡 Background and solution

In demo page of `Icons` when user click on an icon to copy, something like below comes to the clipboard .
```cs
<Icon Type="fast-backward" Theme="Outline" />
```
And shows error for `Outline` , then when user clicks on `show potential fixes (ctrl+.) ` it become more confusing.

<img width="821" height="260" alt="image" src="https://github.com/user-attachments/assets/212c4674-c70a-413f-a60a-59972e9cb9db" />

After my changes it will be copied containing `IconThemeType` with no errors after pasting.
```cs
<Icon Type="step-forward" Theme="IconThemeType.Outline" />
```

### 📝 Changelog

There is no potential break changes or other risks.


### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
