### PR TITLE
fix(module: select): Fix the bug no initial tag is shown when the mode is set to `Multiple`.

### DIFF
--- a/components/select/SelectBase.razor.cs
+++ b/components/select/SelectBase.razor.cs
@@ -585,15 +585,14 @@ namespace AntDesign
                 return;
             }
 
-            //if (!SelectOptionItems.Any())
-            //{
-            //    return;
-            //}
-
             if (values == null)
             {
                 await ValuesChanged.InvokeAsync(default);
                 await OnSelectedItemsChanged.InvokeAsync(default);
+                return;
+            }
+            if (!SelectOptionItems.Any())
+            {
                 return;
             }
             _cachedOrderedSelectedItems = null;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

For example:

```
<Form Model="@model" LabelColSpan="8" WrapperColSpan="16">
    <FormItem Label="Fruits" Name="Fruits">
        <EnumSelect TEnum="Fruits" Mode="SelectMode.Multiple" />
    </FormItem>
</Form>

@code {
    [Flags]
    public enum Fruits
    {
        Apple = 1,

        Pear = 2,

        Orange = 4

    }
    public class Model
    {
		public Fruits Fruits { get; set; } = Fruits.Apple | Fruits.Pear;
    }

    private Model model = new Model();
}
```
