### PR TITLE
fix(breadcrumb): fix breadcrumb missing separator in AutoGenerate is …

### DIFF
--- a/components/breadcrumb/Breadcrumb.razor
+++ b/components/breadcrumb/Breadcrumb.razor
@@ -5,26 +5,27 @@
     <ol>
         <CascadingValue Value="this" IsFixed="@true">
             @ChildContent
-        </CascadingValue>
-        @if (AutoGenerate)
-        {
-            @foreach (var options in MenuService.GetBreadcrumbOptions())
+            @if (AutoGenerate)
             {
-                @if (_existingOptions.Any(x => x.RouterLink == options.RouterLink))
+                @foreach (var options in MenuService.GetBreadcrumbOptions())
                 {
-                    continue;
+                    @if (_existingOptions.Any(x => x.RouterLink == options.RouterLink))
+                    {
+                        continue;
+                    }
+
+                    <BreadcrumbItem Href="@options.RouterLink">
+                        @if (options.TitleTemplate != null)
+                        {
+                            @options.TitleTemplate
+                        }
+                        else
+                        {
+                            @options.Title
+                        }
+                    </BreadcrumbItem>
                 }
-                <BreadcrumbItem Href="@options.RouterLink">
-                    @if (options.TitleTemplate != null)
-                    {
-                        @options.TitleTemplate
-                    }
-                    else
-                    {
-                        @options.Title
-                    }
-                </BreadcrumbItem>
             }
-        }
+        </CascadingValue>
     </ol>
 </nav>


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 💡 Background and solution

The breadcrumb component does not have a separator when using autogenerate

### 📝 Changelog

Fixed an issue where breadcrumb components were missing separators when autogenerated

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
