### PR TITLE
fix(module: reuse-tabs): fix the exception with assembly scanning

### DIFF
--- a/components/tabs/Reuse/ReusePages.razor
+++ b/components/tabs/Reuse/ReusePages.razor
@@ -5,6 +5,7 @@
 
 @namespace AntDesign
 @using Microsoft.AspNetCore.Components.Routing
+@using System.Reflection
 
 
 <CascadingValue Name="AntDesign.InReusePageContent" Value="true" IsFixed>
@@ -47,7 +48,7 @@
         if (InReusePageContent)
             return;
         base.OnInitialized();
-        ReuseTabsService.Init(Reuse);
+        ReuseTabsService.Init(Reuse, GetDefaultScanAssemblies());
         ReuseTabsService.TrySetRouteData(RouteData, Reuse);
 
         NavigationManager.LocationChanged += OnLocationChanged;
@@ -71,4 +72,10 @@
     }
 
     protected override bool ShouldRender() => !InReusePageContent;
+
+    private Assembly[] GetDefaultScanAssemblies()
+    {
+        var assembly = RouteData?.PageType?.Assembly ?? Assembly.GetEntryAssembly();
+        return assembly is null ? Array.Empty<Assembly>() : new[] { assembly };
+    }
 }

--- a/components/tabs/Reuse/ReuseTabs.razor.cs
+++ b/components/tabs/Reuse/ReuseTabs.razor.cs
@@ -3,8 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
+using AntDesign.Core.Documentation;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Routing;
 
@@ -38,6 +41,20 @@ namespace AntDesign
         /// </summary>
         [Parameter]
         public ReuseTabsLocale Locale { get; set; } = LocaleProvider.CurrentLocale.ReuseTabs;
+
+        /// <summary>
+        /// Assemblies to scan for pinned pages.
+        /// If not set, the page assembly that contains this component is scanned by default.
+        /// Set to an empty array to disable pinned page scanning.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// <ReuseTabs ScanAssemblies="new[] { typeof(App).Assembly }" />
+        /// </code>
+        /// </example>
+        [Parameter]
+        [PublicApi("1.6.2")]
+        public Assembly[] ScanAssemblies { get; set; }
 
         /// <summary>
         /// Whether to hide the page display and keep only the title tab. Then you can use <see cref="ReusePages" /> to show the page conent.
@@ -87,7 +104,7 @@ namespace AntDesign
 
             Navmgr.LocationChanged += OnLocationChanged;
 
-            ReuseTabsService.Init(true);
+            ReuseTabsService.Init(true, ScanAssemblies ?? GetDefaultScanAssemblies());
             ReuseTabsService.OnStateHasChanged += OnStateHasChanged;
 
             LoadPage();
@@ -171,6 +188,12 @@ namespace AntDesign
             LoadPage();
 
             ActivatePane(ReuseTabsService.ActiveKey);
+        }
+
+        private IEnumerable<Assembly> GetDefaultScanAssemblies()
+        {
+            var assembly = ActualRouteData?.PageType?.Assembly ?? Assembly.GetEntryAssembly();
+            return assembly is null ? Array.Empty<Assembly>() : new[] { assembly };
         }
 
         private void OnStateHasChanged()

--- a/components/tabs/Reuse/ReuseTabsService.cs
+++ b/components/tabs/Reuse/ReuseTabsService.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using Microsoft.AspNetCore.Components;
@@ -239,12 +240,19 @@ namespace AntDesign
             OnStateHasChanged?.Invoke();
         }
 
-        internal void Init(bool reuse)
+        internal void Init(bool reuse, IEnumerable<Assembly> scanAssemblies = null)
         {
-            if (reuse)
+            if (!reuse)
             {
-                ScanPinnedPageAttribute();
+                return;
             }
+
+            if (scanAssemblies is null || !scanAssemblies.Any())
+            {
+                return;
+            }
+
+            ScanPinnedPageAttribute(scanAssemblies);
         }
 
         internal void TrySetRouteData(RouteData routeData, bool reuse)
@@ -353,24 +361,47 @@ namespace AntDesign
         }
 
         /// <summary>
-        /// Get all assembly
+        /// Get exported types from assembly
         /// </summary>
-        /// <returns></returns>
-        private static IEnumerable<Assembly> GetAllAssembly()
+        protected virtual Type[] GetExportedTypes(Assembly assembly)
         {
-            return AppDomain.CurrentDomain.GetAssemblies();
+            return assembly.ExportedTypes.ToArray();
         }
 
         /// <summary>
         /// Scan ReuseTabsPageAttribute
         /// </summary>
-        private void ScanPinnedPageAttribute()
+        private void ScanPinnedPageAttribute(IEnumerable<Assembly> scanAssemblies)
         {
-            var list = GetAllAssembly();
-
-            foreach (var item in list)
+            if (scanAssemblies is null || !scanAssemblies.Any())
             {
-                var allClass = item.ExportedTypes
+                return;
+            }
+
+            foreach (var item in scanAssemblies)
+            {
+                if (item.IsDynamic)
+                    continue;
+
+                Type[] exportedTypes;
+                try
+                {
+                    exportedTypes = GetExportedTypes(item);
+                }
+                catch (NotSupportedException)
+                {
+                    continue;
+                }
+                catch (FileNotFoundException)
+                {
+                    continue;
+                }
+                catch (ReflectionTypeLoadException ex)
+                {
+                    exportedTypes = ex.Types.Where(t => t != null).ToArray()!;
+                }
+
+                var allClass = exportedTypes
                     .Where(w => w.GetCustomAttribute<ReuseTabsPageAttribute>()?.Pin == true);
                 foreach (var pageType in allClass)
                 {

--- a/tests/AntDesign.Tests/tabs/ReuseTabsServiceTests.cs
+++ b/tests/AntDesign.Tests/tabs/ReuseTabsServiceTests.cs
@@ -1,0 +1,131 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Reflection.Emit;
+using Bunit;
+using FluentAssertions;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace AntDesign.Tests.Tabs
+{
+    public class ReuseTabsServiceTests : AntDesignTestBase
+    {
+        private ReuseTabsService CreateService()
+        {
+            return Services.GetRequiredService<ReuseTabsService>();
+        }
+
+        /// <summary>
+        /// Regression test for https://github.com/ant-design-blazor/ant-design-blazor/issues/4796
+        /// ScanPinnedPageAttribute should not throw when dynamic assemblies are present in AppDomain.
+        /// </summary>
+        [Fact]
+        public void Init_WithDynamicAssemblyInAppDomain_DoesNotThrow()
+        {
+            // Arrange: create a dynamic assembly so it appears in AppDomain.CurrentDomain.GetAssemblies()
+            var dynamicAssembly = AssemblyBuilder.DefineDynamicAssembly(
+                new AssemblyName("TestDynamicAssembly_" + System.Guid.NewGuid()),
+                AssemblyBuilderAccess.Run);
+
+            dynamicAssembly.IsDynamic.Should().BeTrue("the assembly should be dynamic");
+
+            var service = CreateService();
+
+            // Act & Assert: Init(true) calls ScanPinnedPageAttribute which iterates all assemblies
+            var act = () => service.Init(true);
+            act.Should().NotThrow<NotSupportedException>();
+            act.Should().NotThrow();
+        }
+
+        /// <summary>
+        /// ScanPinnedPageAttribute should not scan when no assembly list is provided.
+        /// </summary>
+        [Fact]
+        public void Init_WithNullScanAssemblies_DoesNotScanPinnedPages()
+        {
+            var service = CreateService();
+
+            service.Init(true);
+
+            service.Pages.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void ReuseTabs_DefaultScanAssemblies_UsesPageAssembly()
+        {
+            JSInterop.Mode = JSRuntimeMode.Loose;
+
+            var routeData = new RouteData(typeof(FakePinnedPage), new Dictionary<string, object?>());
+            RenderComponent<ReuseTabs>(parameters => parameters.AddCascadingValue(routeData));
+
+            var service = CreateService();
+
+            service.Pages.Should().Contain(p => p.Url == "/fake-pinned");
+        }
+
+        [Fact]
+        public void Init_WithEmptyScanAssemblies_DoesNotScanPinnedPages()
+        {
+            var service = CreateService();
+
+            // Act
+            service.Init(true, Array.Empty<Assembly>());
+
+            // Assert
+            service.Pages.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void Init_WithSpecifiedScanAssemblies_UsesProvidedAssemblyList()
+        {
+            var service = CreateService();
+            var targetAssembly = Assembly.GetExecutingAssembly();
+
+            // Act
+            service.Init(true, new[] { targetAssembly });
+
+            // Assert
+            service.Pages.Should().Contain(p => p.Url == "/fake-pinned");
+        }
+
+        /// <summary>
+        /// Regression test for a missing referenced assembly during ExportedTypes enumeration.
+        /// </summary>
+        [Fact]
+        public void Init_WithExportedTypesThrowFileNotFoundException_DoesNotThrow()
+        {
+            var service = new ReuseTabsServiceWithMissingDependencyExport(
+                Services.GetRequiredService<NavigationManager>(),
+                Services.GetRequiredService<MenuService>());
+
+            var act = () => service.Init(true, new[] { Assembly.GetExecutingAssembly() });
+            act.Should().NotThrow();
+        }
+
+        private class ReuseTabsServiceWithMissingDependencyExport : ReuseTabsService
+        {
+            public ReuseTabsServiceWithMissingDependencyExport(NavigationManager navmgr, MenuService menusService)
+                : base(navmgr, menusService)
+            {
+            }
+
+            protected override Type[] GetExportedTypes(Assembly assembly)
+            {
+                throw new FileNotFoundException("Could not load file or assembly 'SkiaSharp'.", "SkiaSharp, Version=3.119.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756");
+            }
+        }
+    }
+
+    [Route("/fake-pinned")]
+    [ReuseTabsPage(Pin = true, PinUrl = "/fake-pinned")]
+    public class FakePinnedPage : ComponentBase
+    {
+    }
+}


### PR DESCRIPTION
- Added ScanAssemblies parameter to ReuseTabs for custom assembly scanning.
- Updated ReuseTabsService.Init method to accept scan assemblies.
- Implemented GetDefaultScanAssemblies method for default behavior.
- Introduced unit tests for ReuseTabsService to validate new functionality.

<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

fixed #4798
fixed #4800 

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

break changes:
If the pinned page is not in the assembly where the current component resides, manual import is require

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    fixed the exception with assembly scanning       |
| 🇨🇳 Chinese |  修复 程序集扫描异常          |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
