### PR TITLE
fix(module: Space): SpaceItem RTL Fixed

### DIFF
--- a/components/space/Space.razor
+++ b/components/space/Space.razor
@@ -5,7 +5,7 @@
     SpaceItemCount = 0;
 }
 <CascadingValue Value="this" IsFixed="@true">
-    <div class="@ClassMapper.Class" style="@Style @InnerStyle" id="@Id" @ref="@Ref">
+    <div class="@ClassMapper.Class" style="@Style @InnerStyle @_gapStyle" id="@Id" @ref="@Ref">
         @ChildContent
     </div>
 </CascadingValue>

--- a/components/space/Space.razor.cs
+++ b/components/space/Space.razor.cs
@@ -45,6 +45,7 @@ namespace AntDesign
             set
             {
                 _size = value;
+                ChangeSize();
             }
         }
 
@@ -79,6 +80,8 @@ namespace AntDesign
 
         private string InnerStyle => Wrap && Direction == SpaceDirection.Horizontal ? "flex-wrap: wrap;" : "";
 
+        private string _gapStyle = "";
+
         private readonly static Dictionary<SpaceAlign, string> _alignMap = new()
         {
             [SpaceAlign.Start] = "start",
@@ -97,9 +100,52 @@ namespace AntDesign
                 .If($"{PrefixCls}-rtl", () => RTL);
         }
 
+        private void ChangeSize()
+        {
+            Size.Switch(
+                singleSize =>
+                {
+                    _gapStyle = $"column-gap:{GetSize(singleSize)};row-gap:{GetSize(singleSize)}";
+                },
+                singleSize =>
+                {
+                    _gapStyle = $"column-gap:{GetSize(singleSize)};row-gap:{GetSize(singleSize)}";
+                },
+                arraySize =>
+                {
+                    _gapStyle = $"column-gap:{GetSize(arraySize.Item1)};row-gap:{GetSize(arraySize.Item2)};";
+                }
+            );
+        }
+
+        private static readonly Dictionary<SpaceSize, string> _spaceSize = new()
+        {
+            [SpaceSize.Small] = "8",
+            [SpaceSize.Middle] = "16",
+            [SpaceSize.Large] = "24"
+        };
+
+        private CssSizeLength GetSize(SpaceSize size)
+        {
+            var originalSize = _spaceSize[size];
+
+            return GetSize(originalSize);
+        }
+
+        private CssSizeLength GetSize(string size)
+        {
+            if (Split != null)
+            {
+                return ((CssSizeLength)size).Value / 2;
+            }
+
+            return size;
+        }
+
         protected override void OnInitialized()
         {
             SetClass();
+            ChangeSize();
             base.OnInitialized();
         }
     }

--- a/components/space/SpaceItem.razor
+++ b/components/space/SpaceItem.razor
@@ -1,7 +1,6 @@
 ﻿@namespace AntDesign
 @inherits AntDomComponentBase
 
-@{ ChangeSize(); }
 @if (Parent?.Split != null && _index != 0)
 {
     <span class="ant-space-item-split" style="margin-right: 4px;">
@@ -9,6 +8,6 @@
     </span>
 }
 
-<div class="@ClassMapper.Class" style="@Style @_marginStyle" @ref="Ref" id="@Id">
+<div class="@ClassMapper.Class" style="@Style" @ref="Ref" id="@Id">
     @ChildContent
 </div>

--- a/components/space/SpaceItem.razor.cs
+++ b/components/space/SpaceItem.razor.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
 using Microsoft.AspNetCore.Components;
 
 namespace AntDesign
@@ -21,14 +20,6 @@ namespace AntDesign
         [Parameter]
         public RenderFragment ChildContent { get; set; }
 
-        private static readonly Dictionary<SpaceSize, string> _spaceSize = new()
-        {
-            [SpaceSize.Small] = "8",
-            [SpaceSize.Middle] = "16",
-            [SpaceSize.Large] = "24"
-        };
-
-        private string _marginStyle = "";
         private int _index;
 
         protected override void OnInitialized()
@@ -42,42 +33,6 @@ namespace AntDesign
         {
             _index = Parent.SpaceItemCount++;
             base.OnParametersSet();
-        }
-
-        private void ChangeSize()
-        {
-            var size = Parent.Size;
-            var direction = Parent.Direction;
-
-            size.Switch(singleSize =>
-            {
-                _marginStyle = direction == SpaceDirection.Horizontal ? (_index != Parent.SpaceItemCount - 1 ? $"margin-right:{GetSize(singleSize)};" : "") : $"margin-bottom:{GetSize(singleSize)};";
-            },
-            singleSize =>
-            {
-                _marginStyle = direction == SpaceDirection.Horizontal ? (_index != Parent.SpaceItemCount - 1 ? $"margin-right:{GetSize(singleSize)};" : "") : $"margin-bottom:{GetSize(singleSize)};";
-            },
-            arraySize =>
-            {
-                _marginStyle = (_index != Parent.SpaceItemCount - 1 ? $"margin-right:{GetSize(arraySize.Item1)};" : "") + $"margin-bottom:{GetSize(arraySize.Item2)};";
-            });
-        }
-
-        private CssSizeLength GetSize(SpaceSize size)
-        {
-            var originalSize = _spaceSize[size];
-
-            return GetSize(originalSize);
-        }
-
-        private CssSizeLength GetSize(string size)
-        {
-            if (Parent?.Split != null)
-            {
-                return ((CssSizeLength)size).Value / 2;
-            }
-
-            return size;
         }
     }
 }


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 💡 Background and solution

In **Space** component **Space Items** does not shows properly in **RTL** mode, It acts like **LTR** and add a right margin.

This is **LTR** with **right** margin
<img width="403" height="66" alt="LTR" src="https://github.com/user-attachments/assets/68206532-a449-4abf-a0d2-67ae504353a2" />

This is (current) **RTL**  with **right** margin which does not behaves as expected :
<img width="373" height="49" alt="RTLErr" src="https://github.com/user-attachments/assets/c088d4e3-86aa-4c1d-9868-95205bf1e1da" />

This is **RTL** that is expected with **left** margin :
<img width="381" height="46" alt="image" src="https://github.com/user-attachments/assets/fe7c94d8-58cb-43a9-a72b-e7da0e81b61c" />

In addition of current issue I've also added SetClass to build **PrefixCls-rtl** class — it’s not strictly necessary, just there for consistency and it can help RTL developers to play with CSS better. If you’d prefer, I can remove it; just let me know.
```
        private void SetClass()
        {
            ClassMapper
                .Add(PrefixCls)
                .If($"{PrefixCls}-rtl", () => RTL);
        }
```

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is not needed
- [x] Demo is updated
- [x] Changelog is not needed
