### PR TITLE
fix(module: Overlay): fix dropdown hover menu auto close 

### DIFF
--- a/components/core/Component/Overlay/Overlay.razor
+++ b/components/core/Component/Overlay/Overlay.razor
@@ -10,8 +10,7 @@
          style="position: absolute; @display @Trigger.OverlayStyle @_overlayStyle"
          @ref="Ref"
          @onmouseenter="OnOverlayMouseEnter"
-         @onmouseleave="OnOverlayMouseLeave"
-		 @onmouseup="OnOverlayMouseUp"
+         @onmouseup="OnOverlayMouseUp"
          @onclick:stopPropagation>
 
         <CascadingValue Value="this" Name="Overlay" IsFixed>

--- a/components/core/Component/Overlay/Overlay.razor.cs
+++ b/components/core/Component/Overlay/Overlay.razor.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using AntDesign.Core.JsInterop.Modules.Components;
 using AntDesign.JsInterop;
 using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
 
 namespace AntDesign.Internal
 {
@@ -109,6 +110,7 @@ namespace AntDesign.Internal
 
         private bool _shouldRender = true;
         private bool _afterFirstRender = false;
+        private DotNetObjectReference<Overlay> _dotNetObjectReference;
 
         protected override bool ShouldRender()
         {
@@ -185,8 +187,19 @@ namespace AntDesign.Internal
                     await JsInvokeAsync(JSInteropConstants.OverlayComponentHelper.DeleteOverlayFromContainer, Ref.Id);
                 });
             }
+            else
+            {
+                _dotNetObjectReference?.Dispose();
+            }
             DomEventListener?.Dispose();
             base.Dispose(disposing);
+        }
+
+        [JSInvokable]
+        public async Task HandleOverlayMouseLeave()
+        {
+            //invoke by js only after the pointer leaves the entire overlay
+            await OnOverlayMouseLeave.InvokeAsync(null);
         }
 
         internal async Task Show(int? overlayLeft = null, int? overlayTop = null)
@@ -375,10 +388,11 @@ namespace AntDesign.Internal
                     return;
                 }
 
+                _dotNetObjectReference ??= DotNetObjectReference.Create(this);
                 _position = await JsInvokeAsync<OverlayPosition>(JSInteropConstants.OverlayComponentHelper.AddOverlayToContainer,
                     Ref.Id, Ref, Trigger.Ref, Trigger.PlacementWithRTL, Trigger.PopupContainerSelector,
                     Trigger.BoundaryAdjustMode, triggerIsWrappedInDiv, Trigger.PrefixCls,
-                    VerticalOffset, HorizontalOffset, ArrowPointAtCenter, overlayTop, overlayLeft);
+                    VerticalOffset, HorizontalOffset, ArrowPointAtCenter, _dotNetObjectReference, overlayTop, overlayLeft);
                 if (_position is null && _recurenceGuard <= 10) //up to 10 attempts
                 {
                     //Console.WriteLine($"Failed to add overlay to the container. Container: {Trigger.PopupContainerSelector}, trigger: {Trigger.Ref.Id}, overlay: {Ref.Id}. Awaiting and rerunning.");
@@ -508,10 +522,11 @@ namespace AntDesign.Internal
         {
             bool triggerIsWrappedInDiv = Trigger.Unbound is null;
 
+            _dotNetObjectReference ??= DotNetObjectReference.Create(this);
             _position = await JsInvokeAsync<OverlayPosition>(JSInteropConstants.OverlayComponentHelper.UpdateOverlayPosition,
                 Ref.Id, Ref, Trigger.Ref, Trigger.PlacementWithRTL, Trigger.PopupContainerSelector,
                 Trigger.BoundaryAdjustMode, triggerIsWrappedInDiv, Trigger.PrefixCls,
-                VerticalOffset, HorizontalOffset, ArrowPointAtCenter, overlayTop, overlayLeft);
+                VerticalOffset, HorizontalOffset, ArrowPointAtCenter, _dotNetObjectReference, overlayTop, overlayLeft);
             if (_position is not null)
             {
                 if (_position.Placement != Trigger.GetPlacementType().Placement)

--- a/components/core/JsInterop/modules/components/overlay.ts
+++ b/components/core/JsInterop/modules/components/overlay.ts
@@ -173,6 +173,15 @@ export class Overlay {
   private isContainerOverBody = false;
   private isTriggerFixed: boolean; //refers to trigger or any of its parent having "position:fixed"
   private lastScrollPosition: number; //used only if isTriggerFixed === true
+  private dotNetObjectReference;
+
+  //chromium can inject a false leave when moving from the overlay root into a child
+  //use relatedTarget to ignore mouseout events that only move between elements inside the overlay
+  private onOverlayMouseOut = (event: MouseEvent): void => {
+    if (!(event.relatedTarget instanceof window.Node) ||!this.overlay.contains(event.relatedTarget)) {
+      this.dotNetObjectReference?.invokeMethodAsync("HandleOverlayMouseLeave");
+    }
+  };
 
   private scrollbarSize: {
     horizontalHeight: number,
@@ -182,9 +191,11 @@ export class Overlay {
   constructor(blazorId: string,
     overlay: HTMLDivElement, container: HTMLElement, trigger: HTMLElement, placement: Placement, 
     triggerBoundyAdjustMode: TriggerBoundyAdjustMode, triggerIsWrappedInDiv: boolean, triggerPrefixCls: string,
-    overlayConstraints: overlayConstraints) {
+    overlayConstraints: overlayConstraints, dotNetObjectReference?) {
     this.blazorId = blazorId;
-    this.overlay = overlay;  
+    this.overlay = overlay;
+    this.dotNetObjectReference = dotNetObjectReference;
+    this.overlay.addEventListener("mouseout", this.onOverlayMouseOut);
     //containerInfo & scrollbars have to be obtained here, because after
     //removal of classes, the overlay goes to left: -9999 what causes artificial 
     //scrollbars and viewport dimensions are changing
@@ -484,6 +495,9 @@ export class Overlay {
   public dispose(): void {    
     resize.dispose(`container-${this.blazorId}`);
     mutation.dispose(`trigger-${this.blazorId}`);
+    //remove the custom leave handler and release its the dotnetobject callback reference
+    this.overlay.removeEventListener("mouseout", this.onOverlayMouseOut);
+    this.dotNetObjectReference?.dispose();
     if (this.container.contains(this.overlay)) {
       this.container.removeChild(this.overlay);
     }

--- a/components/core/JsInterop/modules/components/overlayHelper.ts
+++ b/components/core/JsInterop/modules/components/overlayHelper.ts
@@ -8,7 +8,8 @@ export class overlayHelper {
   static addOverlayToContainer(blazorId: string, 
     overlaySelector, triggerSelector, placement: Placement,  containerSelector: string,
     triggerBoundyAdjustMode: TriggerBoundyAdjustMode, triggerIsWrappedInDiv: boolean, triggerPrefixCls: string,
-    verticalOffset: number, horizontalOffset: number, arrowPointAtCenter: boolean,    
+    verticalOffset: number, horizontalOffset: number, arrowPointAtCenter: boolean,
+    dotNetObjectReference,
     overlayTop?: number, overlayLeft?: number
   ): overlayPosition {      
     const overlayElement = domInfoHelper.get(overlaySelector) as HTMLDivElement;    
@@ -35,7 +36,7 @@ export class overlayHelper {
       arrowPointAtCenter: arrowPointAtCenter
     };
 
-    const overlay = new Overlay(blazorId, overlayElement, containerElement, triggerElement, placement, triggerBoundyAdjustMode, triggerIsWrappedInDiv, triggerPrefixCls, overlayConstraints);   
+    const overlay = new Overlay(blazorId, overlayElement, containerElement, triggerElement, placement, triggerBoundyAdjustMode, triggerIsWrappedInDiv, triggerPrefixCls, overlayConstraints, dotNetObjectReference);
     //register object in store, so it can be retrieved during update/dispose
     this.overlayRegistry[blazorId] = overlay;
 
@@ -49,7 +50,8 @@ export class overlayHelper {
 
   static updateOverlayPosition(blazorId: string, overlaySelector, triggerSelector, placement: Placement,  containerSelector: string,
     triggerBoundyAdjustMode: TriggerBoundyAdjustMode, triggerIsWrappedInDiv: boolean, triggerPrefixCls: string,
-    verticalOffset: number, horizontalOffset: number, arrowPointAtCenter: boolean,  
+    verticalOffset: number, horizontalOffset: number, arrowPointAtCenter: boolean,
+    dotNetObjectReference,
     overlayTop?: number, overlayLeft?: number): overlayPosition {
     const overlay = this.overlayRegistry[blazorId];
     if (overlay){
@@ -67,7 +69,7 @@ export class overlayHelper {
       //blazor thinks it did happen. In such a case, when overlay object is not found, just try
       //to render it again.
       return overlayHelper.addOverlayToContainer(blazorId, overlaySelector, triggerSelector, placement,  containerSelector,triggerBoundyAdjustMode, triggerIsWrappedInDiv, triggerPrefixCls, 
-        verticalOffset, horizontalOffset, arrowPointAtCenter,  
+        verticalOffset, horizontalOffset, arrowPointAtCenter, dotNetObjectReference,
         overlayTop, overlayLeft);      
     }    
   }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
Dropdown overlay disappearing in MS Edge https://github.com/ant-design-blazor/ant-design-blazor/issues/4809

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

- Chromium: 149.x and above breaks the overlay for Dropdown. 

- Initial investigation by https://github.com/ant-design-blazor/ant-design-blazor/issues/4809 share similar test result that `Overlay.Hide` is invoked when it shouldnt be

- The rootcause was the new Chromium update causes `mouseleave` to fire when moving from the overlay container into its child menu. I cant pinpoint which changes in the chromium update causes it but this bug only exist from 149 and above.

https://github.com/user-attachments/assets/e9bae0c3-78e3-4ce7-8206-b954a2cd77c4

- The current fix is to handle `mouseout` in JS and close the overlay only when the mouse fully leaves the overlay
---
## Before

https://github.com/user-attachments/assets/c0f8acd2-e545-4598-a28d-2ba0592b89ea


## After

https://github.com/user-attachments/assets/cf7ed94f-0cf8-440a-9eb1-19bcc4021386


### 📝 Changelog
---
<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
