### PR TITLE
Fix installation command for AntDesign.Templates

### DIFF
--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -85,7 +85,7 @@ WebAssembly 静态托管页面示例
 - 安装模板
 
   ```bash
-  $ dotnet new --install AntDesign.Templates
+  $ dotnet new install AntDesign.Templates
   ```
 
 - 从模板创建 Ant Design Blazor Pro 项目

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ We have provided the `dotnet new` template to create a [Boilerplate](https://git
 - Install the template
 
   ```bash
-  $ dotnet new --install AntDesign.Templates
+  $ dotnet new install AntDesign.Templates
   ```
 
 - Create the Boilerplate project with the template

--- a/docs/introduce.en-US.md
+++ b/docs/introduce.en-US.md
@@ -79,7 +79,7 @@ We have provided the `dotnet new` template to create a [Boilerplate](https://git
 - Install the template
 
   ```bash
-  $ dotnet new --install AntDesign.Templates
+  $ dotnet new install AntDesign.Templates
   ```
 
 - Create the Boilerplate project with the template

--- a/docs/introduce.zh-CN.md
+++ b/docs/introduce.zh-CN.md
@@ -76,7 +76,7 @@ title: Ant Design of Blazor
 - 安装模板
 
   ```bash
-  $ dotnet new --install AntDesign.Templates
+  $ dotnet new install AntDesign.Templates
   ```
 
 - 从模板创建 Ant Design Blazor Pro 项目


### PR DESCRIPTION
从 .NET 7 开始，官方已经淘汰了--install，使用了更简洁的install

<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/ant-design-blazor/ant-design-blazor/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

None. (Or link to the issue if there is one)

### 💡 Background and solution

**Background:**
Since .NET 7, the `dotnet new --install` command has been deprecated and replaced by the cleaner `dotnet new install` subcommand. The current documentation/code still uses the obsolete `--install` flag.

**Solution:**
Updated the obsolete `dotnet new --install` command to the modern `dotnet new install` syntax to avoid confusion and deprecation warnings for users.

---

**背景：**
从 .NET 7 开始，官方已经淘汰了 `dotnet new --install` 命令，改用更简洁的 `dotnet new install` 子命令。目前文档/代码中仍残留有旧版命令。

**解决方案：**
将过时的 `dotnet new --install` 命令更新为现代的 `dotnet new install` 语法，避免对用户造成误导或触发弃用警告。

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Update obsolete `dotnet new --install` command to `dotnet new install`. |
| 🇨🇳 Chinese | 将已过时的 `dotnet new --install` 命令更新为 `dotnet new install`。 |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed