### PR TITLE
fix(module: Sider): Sider Trigger RTL Fixed

### DIFF
--- a/components/layout/Sider.razor.cs
+++ b/components/layout/Sider.razor.cs
@@ -40,7 +40,7 @@ namespace AntDesign
         [Parameter]
         public bool NoTrigger { get; set; }
 
-        [CascadingParameter] 
+        [CascadingParameter]
         public Layout Parent { get; set; }
 
         /// <summary>
@@ -136,7 +136,9 @@ namespace AntDesign
         private RenderFragment DefaultTrigger => builder =>
         {
             builder.OpenComponent<Icon>(1);
-            builder.AddAttribute(2, "Type", _isCollapsed ? IconType.Outline.Right : IconType.Outline.Left);
+            var collapsedIcon = RTL ? IconType.Outline.Left : IconType.Outline.Right;
+            var expandedIcon = RTL ? IconType.Outline.Right : IconType.Outline.Left;
+            builder.AddAttribute(2, "Type", _isCollapsed ? collapsedIcon : expandedIcon);
             builder.AddAttribute(3, "Theme", IconThemeType.Outline);
             builder.CloseComponent();
         };


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)


### 💡 Background and solution

As you know, the `Layout` component can contain a `Sider`.
In **LTR** mode, everything works as expected. When the `Sider` is **expanded** or **collapsed**, the bottom **trigger arrow** is displayed in the **correct direction**:
<img width="708" height="391" alt="image" src="https://github.com/user-attachments/assets/66a082ed-9610-4d22-96e5-3bc1dd8f57f0" />

However, in **RTL** languages, the arrow is displayed in the **opposite direction**, as if the layout were still using **LTR** mode:
<img width="750" height="396" alt="image" src="https://github.com/user-attachments/assets/42e8a8ff-d6f5-4332-88f5-374c0ef83e1d" />

I have updated the code so that the trigger arrow is displayed **correctly** in both **LTR** and **RTL** modes.
<img width="750" height="395" alt="RTL Right" src="https://github.com/user-attachments/assets/45280f82-ba2d-4d57-b003-e0135448958f" />

Please note that because the following line exists in the **components.en-US.json** file:
```"Iframe": 360```
The `Layout` component on the demo page does not inherit the `<ConfigProvider />` settings from `AntDomComponentBase`. Therefore, it has not `ant-layout-rtl` class and the fix will not be visible on the **demo** page.
However, I have tested the changes in a production environment, and the component works as expected.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
