### PR TITLE
fix(module: slider): support touch dragging with pointer events

### DIFF
--- a/components/slider/Slider.razor
+++ b/components/slider/Slider.razor
@@ -5,7 +5,7 @@
 @using System.Globalization
 
 <div class="@ClassMapper.Class" style="user-select:none;@Style" id="@Id" @ref="Ref"
-     @onmousedown="(e) => OnMouseDown(e)">
+     @onpointerdown="(e) => OnPointerDown(e)">
     <div class="ant-slider-rail">
     </div>
     @if (Included)
@@ -28,22 +28,22 @@
         {
             <Tooltip Title="@TipFormatter(_leftValue)" Style="display: inline;" Visible="_tooltipLeftVisible" ArrowPointAtCenter="true" OverlayClassName="ant-slider-tooltip" Placement="@TooltipPlacement" @ref="_toolTipLeft">
                 <Unbound>
-                    <div tabindex="0" class="ant-slider-handle ant-slider-handle-1" role="slider" aria-disabled="@Disabled.ToString()" aria-valuenow=@(Math.Round(LeftValue, 2).ToString(CultureInfo.InvariantCulture)) aria-valuemin=@(Math.Round(Min, 2).ToString(CultureInfo.InvariantCulture)) aria-valuemax=@(Math.Round(Max, 2).ToString(CultureInfo.InvariantCulture)) style="@_leftHandleStyle" @ref="@context.Current" @onmousedown="(e) => OnMouseDownEdge(e, false)">
+                    <div tabindex="0" class="ant-slider-handle ant-slider-handle-1" role="slider" aria-disabled="@Disabled.ToString()" aria-valuenow=@(Math.Round(LeftValue, 2).ToString(CultureInfo.InvariantCulture)) aria-valuemin=@(Math.Round(Min, 2).ToString(CultureInfo.InvariantCulture)) aria-valuemax=@(Math.Round(Max, 2).ToString(CultureInfo.InvariantCulture)) style="@_leftHandleStyle" @ref="@context.Current" @onpointerdown="(e) => OnPointerDownEdge(e, false)">
                     </div>
                 </Unbound>
             </Tooltip>
             <Tooltip Title="@TipFormatter(_rightValue)" Style="display: inline;" Visible="_tooltipRightVisible" ArrowPointAtCenter="true" OverlayClassName="ant-slider-tooltip" Placement="@TooltipPlacement" @ref="_toolTipRight">
                 <Unbound>
-                    <div tabindex="0" class="ant-slider-handle ant-slider-handle-2" role="slider" aria-disabled="@Disabled.ToString()" aria-valuenow=@(Math.Round(RightValue, 2).ToString(CultureInfo.InvariantCulture)) aria-valuemin=@(Math.Round(Min, 2).ToString(CultureInfo.InvariantCulture)) aria-valuemax=@(Math.Round(Max, 2).ToString(CultureInfo.InvariantCulture)) style="@_rightHandleStyle" @ref="@context.Current" @onmousedown="(e) => OnMouseDownEdge(e, true)">
+                    <div tabindex="0" class="ant-slider-handle ant-slider-handle-2" role="slider" aria-disabled="@Disabled.ToString()" aria-valuenow=@(Math.Round(RightValue, 2).ToString(CultureInfo.InvariantCulture)) aria-valuemin=@(Math.Round(Min, 2).ToString(CultureInfo.InvariantCulture)) aria-valuemax=@(Math.Round(Max, 2).ToString(CultureInfo.InvariantCulture)) style="@_rightHandleStyle" @ref="@context.Current" @onpointerdown="(e) => OnPointerDownEdge(e, true)">
                     </div>
                 </Unbound>
             </Tooltip>
         }
         else
         {
-            <div tabindex="0" class="ant-slider-handle ant-slider-handle-1" role="slider" aria-disabled="@Disabled.ToString()" aria-valuenow=@(Math.Round(LeftValue, 2).ToString(CultureInfo.InvariantCulture)) aria-valuemin=@(Math.Round(Min, 2).ToString(CultureInfo.InvariantCulture)) aria-valuemax=@(Math.Round(Max, 2).ToString(CultureInfo.InvariantCulture)) style="@_leftHandleStyle" @ref="_leftHandle" @onmousedown="(e) => OnMouseDownEdge(e, false)">
+            <div tabindex="0" class="ant-slider-handle ant-slider-handle-1" role="slider" aria-disabled="@Disabled.ToString()" aria-valuenow=@(Math.Round(LeftValue, 2).ToString(CultureInfo.InvariantCulture)) aria-valuemin=@(Math.Round(Min, 2).ToString(CultureInfo.InvariantCulture)) aria-valuemax=@(Math.Round(Max, 2).ToString(CultureInfo.InvariantCulture)) style="@_leftHandleStyle" @ref="_leftHandle" @onpointerdown="(e) => OnPointerDownEdge(e, false)">
             </div>
-            <div tabindex="0" class="ant-slider-handle ant-slider-handle-2" role="slider" aria-disabled="@Disabled.ToString()" aria-valuenow=@(Math.Round(RightValue, 2).ToString(CultureInfo.InvariantCulture)) aria-valuemin=@(Math.Round(Min, 2).ToString(CultureInfo.InvariantCulture)) aria-valuemax=@(Math.Round(Max, 2).ToString(CultureInfo.InvariantCulture)) style="@_rightHandleStyle" @ref="_rightHandle" @onmousedown="(e) => OnMouseDownEdge(e, true)">
+            <div tabindex="0" class="ant-slider-handle ant-slider-handle-2" role="slider" aria-disabled="@Disabled.ToString()" aria-valuenow=@(Math.Round(RightValue, 2).ToString(CultureInfo.InvariantCulture)) aria-valuemin=@(Math.Round(Min, 2).ToString(CultureInfo.InvariantCulture)) aria-valuemax=@(Math.Round(Max, 2).ToString(CultureInfo.InvariantCulture)) style="@_rightHandleStyle" @ref="_rightHandle" @onpointerdown="(e) => OnPointerDownEdge(e, true)">
             </div>
         }
     }
@@ -53,14 +53,14 @@
         {
             <Tooltip Title="@TipFormatter(_rightValue)" Style="display: inline;" Visible="_tooltipRightVisible" ArrowPointAtCenter="true" OverlayClassName="ant-slider-tooltip" Placement="@TooltipPlacement" @ref="_toolTipRight">
                 <Unbound>
-                    <div tabindex="0" class="ant-slider-handle" role="slider" aria-disabled="@Disabled.ToString()" aria-valuenow=@(Math.Round(RightValue, 2).ToString(CultureInfo.InvariantCulture)) aria-valuemin=@(Math.Round(Min, 2).ToString(CultureInfo.InvariantCulture)) aria-valuemax=@(Math.Round(Max, 2).ToString(CultureInfo.InvariantCulture)) style="@_rightHandleStyle" @ref="@context.Current" @onmousedown="(e)=>OnMouseDownEdge(e,  true)">
+                    <div tabindex="0" class="ant-slider-handle" role="slider" aria-disabled="@Disabled.ToString()" aria-valuenow=@(Math.Round(RightValue, 2).ToString(CultureInfo.InvariantCulture)) aria-valuemin=@(Math.Round(Min, 2).ToString(CultureInfo.InvariantCulture)) aria-valuemax=@(Math.Round(Max, 2).ToString(CultureInfo.InvariantCulture)) style="@_rightHandleStyle" @ref="@context.Current" @onpointerdown="(e)=>OnPointerDownEdge(e, true)">
                     </div>
                 </Unbound>
             </Tooltip>
         }
         else
         {
-            <div tabindex="0" class="ant-slider-handle" role="slider" aria-disabled="@Disabled.ToString()" aria-valuenow=@(Math.Round(RightValue, 2).ToString(CultureInfo.InvariantCulture)) aria-valuemin=@(Math.Round(Min, 2).ToString(CultureInfo.InvariantCulture)) aria-valuemax=@(Math.Round(Max, 2).ToString(CultureInfo.InvariantCulture)) style="@_rightHandleStyle" @ref="_rightHandle" @onmousedown="(e)=>OnMouseDownEdge(e,  true)">
+            <div tabindex="0" class="ant-slider-handle" role="slider" aria-disabled="@Disabled.ToString()" aria-valuenow=@(Math.Round(RightValue, 2).ToString(CultureInfo.InvariantCulture)) aria-valuemin=@(Math.Round(Min, 2).ToString(CultureInfo.InvariantCulture)) aria-valuemax=@(Math.Round(Max, 2).ToString(CultureInfo.InvariantCulture)) style="@_rightHandleStyle" @ref="_rightHandle" @onpointerdown="(e)=>OnPointerDownEdge(e, true)">
                 </div>
         }
     }

--- a/components/slider/Slider.razor.cs
+++ b/components/slider/Slider.razor.cs
@@ -38,8 +38,7 @@ namespace AntDesign
         private string _leftHandleStyle = "left: 0%; right: auto; transform: translateX(-50%);";
         private string _rightHandleStyle = "left: 0%; right: auto; transform: translateX(-50%);";
         private string _trackStyle = "left: 0%; width: 0%; right: auto;";
-        private bool _mouseDown;
-        private bool _mouseMove;
+        private long? _activePointerId;
         private bool _right = true;
         private bool _initialized = false;
         private double _initialLeftValue;
@@ -351,7 +350,7 @@ namespace AntDesign
         public bool Vertical { get; set; }
 
         /// <summary>
-        /// Callback executed when onmouseup is fired.
+        /// Callback executed when pointerup is fired.
         /// </summary>
         [Parameter]
         public EventCallback<TValue> OnAfterChange { get; set; }
@@ -412,9 +411,9 @@ namespace AntDesign
                 if (_tooltipVisible != value)
                 {
                     _tooltipVisible = value;
-                    //ensure parameter loading is not happening because values are changing during mouse moving
-                    //otherwise the tooltip will be vanishing when mouse moves out of the edge
-                    if (!_mouseDown)
+                    //ensure parameter loading is not happening because values are changing during pointer moving
+                    //otherwise the tooltip will be vanishing when the pointer moves out of the edge
+                    if (!_activePointerId.HasValue)
                     {
                         _tooltipRightVisible = _tooltipVisible;
                         _tooltipLeftVisible = _tooltipVisible;
@@ -502,8 +501,9 @@ namespace AntDesign
         {
             if (firstRender)
             {
-                DomEventListener.AddShared<JsonElement>("window", "mousemove", OnMouseMove);
-                DomEventListener.AddShared<JsonElement>("window", "mouseup", OnMouseUp);
+                DomEventListener.AddShared<JsonElement>("window", "pointermove", OnPointerMove);
+                DomEventListener.AddShared<JsonElement>("window", "pointerup", OnPointerUp);
+                DomEventListener.AddShared<JsonElement>("window", "pointercancel", OnPointerCancel);
             }
 
             base.OnAfterRender(firstRender);
@@ -550,16 +550,21 @@ namespace AntDesign
             }
         }
 
-        private void OnMouseDown(MouseEventArgs args)
+        private void OnPointerDown(PointerEventArgs args)
         {
-            _mouseDown = !Disabled;
+            TryBeginPointer(args);
         }
 
         private double _trackedClientX;
         private double _trackedClientY;
 
-        private void OnMouseDownEdge(MouseEventArgs args, bool right)
+        private void OnPointerDownEdge(PointerEventArgs args, bool right)
         {
+            if (!TryBeginPointer(args))
+            {
+                return;
+            }
+
             _right = right;
             _initialLeftValue = _leftValue;
             _initialRightValue = _rightValue;
@@ -578,34 +583,60 @@ namespace AntDesign
             }
         }
 
+        private bool TryBeginPointer(PointerEventArgs args)
+        {
+            if (Disabled)
+            {
+                return false;
+            }
+
+            if (!_activePointerId.HasValue)
+            {
+                _activePointerId = args.PointerId;
+            }
+
+            return _activePointerId == args.PointerId;
+        }
+
+        private bool IsActivePointer(JsonElement jsonElement)
+        {
+            return _activePointerId == jsonElement.GetProperty("pointerId").GetInt64();
+        }
+
         private bool IsMoveInEdgeBoundary(JsonElement jsonElement)
         {
             double clientX = jsonElement.GetProperty("clientX").GetDouble();
             double clientY = jsonElement.GetProperty("clientY").GetDouble();
 
-            return (clientX == _trackedClientX && clientY == _trackedClientY);
+            return clientX == _trackedClientX && clientY == _trackedClientY;
         }
 
-        private async Task OnMouseMove(JsonElement jsonElement)
+        private async Task OnPointerMove(JsonElement jsonElement)
         {
-            if (_mouseDown)
+            if (!IsActivePointer(jsonElement))
             {
-                _trackedClientX = jsonElement.GetProperty("clientX").GetDouble();
-                _trackedClientY = jsonElement.GetProperty("clientY").GetDouble();
-                _mouseMove = true;
-                await CalculateValueAsync(Vertical ? jsonElement.GetProperty("pageY").GetDouble() : jsonElement.GetProperty("pageX").GetDouble());
-
-                if (OnChange.HasDelegate)
-                    await InvokeAsync(() => OnChange.InvokeAsync(CurrentValue));
+                return;
             }
+
+            _trackedClientX = jsonElement.GetProperty("clientX").GetDouble();
+            _trackedClientY = jsonElement.GetProperty("clientY").GetDouble();
+            await CalculateValueAsync(Vertical ? jsonElement.GetProperty("pageY").GetDouble() : jsonElement.GetProperty("pageX").GetDouble());
+
+            if (OnChange.HasDelegate)
+                await InvokeAsync(() => OnChange.InvokeAsync(CurrentValue));
         }
 
-        private async Task OnMouseUp(JsonElement jsonElement)
+        private async Task OnPointerUp(JsonElement jsonElement)
         {
-            bool isMoveInEdgeBoundary = IsMoveInEdgeBoundary(jsonElement);
-            if (_mouseDown)
+            if (!IsActivePointer(jsonElement))
             {
-                _mouseDown = false;
+                return;
+            }
+
+            bool isMoveInEdgeBoundary = IsMoveInEdgeBoundary(jsonElement);
+            _activePointerId = null;
+            try
+            {
                 if (!isMoveInEdgeBoundary)
                 {
                     await CalculateValueAsync(Vertical ? jsonElement.GetProperty("pageY").GetDouble() : jsonElement.GetProperty("pageX").GetDouble());
@@ -613,6 +644,26 @@ namespace AntDesign
                 if (OnAfterChange.HasDelegate)
                     await InvokeAsync(() => OnAfterChange.InvokeAsync(CurrentValue));
             }
+            finally
+            {
+                EndPointerInteraction();
+            }
+        }
+
+        private Task OnPointerCancel(JsonElement jsonElement)
+        {
+            if (IsActivePointer(jsonElement))
+            {
+                EndPointerInteraction();
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private void EndPointerInteraction()
+        {
+            _activePointerId = null;
+
             if (_toolTipRight != null)
             {
                 if (_tooltipRightVisible != TooltipVisible)
@@ -671,7 +722,7 @@ namespace AntDesign
                 if (rightV < LeftValue)
                 {
                     _right = false;
-                    if (_mouseDown)
+                    if (_activePointerId.HasValue)
                         RightValue = _initialLeftValue;
                     LeftValue = rightV;
                     await FocusAsync(_leftHandle);
@@ -718,7 +769,7 @@ namespace AntDesign
                 if (leftV > RightValue)
                 {
                     _right = true;
-                    if (_mouseDown)
+                    if (_activePointerId.HasValue)
                         LeftValue = _initialRightValue;
                     RightValue = leftV;
                     await FocusAsync(_rightHandle);

--- a/site/AntDesign.Docs/Demos/Components/Slider/demo/Event.md
+++ b/site/AntDesign.Docs/Demos/Components/Slider/demo/Event.md
@@ -6,8 +6,8 @@ title:
 ---
 
 ## zh-CN
-当 Slider 的值发生改变时，会触发 `onChange` 事件，并把改变后的值作为参数传入。在 `onmouseup` 时，会触发 `onAfterChange` 事件，并把当前值作为参数传入。
+当 Slider 的值发生改变时，会触发 `onChange` 事件，并把改变后的值作为参数传入。在 `pointerup` 时，会触发 `onAfterChange` 事件，并把当前值作为参数传入。
 
 
 ## en-US
-The `onChange` callback function will fire when the user changes the slider's value. The `onAfterChange` callback function will fire when `onmouseup` fired.
+The `onChange` callback function will fire when the user changes the slider's value. The `onAfterChange` callback function will fire when `pointerup` is fired.

--- a/site/AntDesign.Docs/Demos/Components/Slider/doc/index.en-US.md
+++ b/site/AntDesign.Docs/Demos/Components/Slider/doc/index.en-US.md
@@ -29,7 +29,7 @@ A Slider component for displaying current value and intervals in range.
 | Step | The granularity the slider can step through values. Must greater than 0, and be divided by (max - min) . When marks no null, step can be null.   | number        | -         |
 | Value | The value of slider. When range is false, use number, otherwise, use [number, number]         | number        | -         |
 | Vertical | If true, the slider will be vertical.                   | boolean        | -         |
-| OnAfterChange |Fire when onmouseup is fired.                        | function(e)        | -         |
+| OnAfterChange |Fire when pointerup is fired.                       | function(e)        | -         |
 | OnChange |Callback function that is fired when the user changes the slider's value.                          | function(e)        | -         |
 | HasTooltip |Will not render `Tooltip` if set to false | boolean | true |
 | TipFormatter |Slider will pass its value to `TipFormatter`, and display its value in `Tooltip`. | Func<double, string> | (d) => d.ToString() |

--- a/site/AntDesign.Docs/Demos/Components/Slider/doc/index.zh-CN.md
+++ b/site/AntDesign.Docs/Demos/Components/Slider/doc/index.zh-CN.md
@@ -30,7 +30,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/HZ3meFc6W/Silder.svg
 | step | 步长，取值必须大于 0，并且可被 (max - min) 整除。当 marks 不为空对象时，可以设置 step 为 null，此时 Slider 的可选值仅有 marks 标出来的部分。                            | number        | -         |
 | value | 设置当前取值。当 range 为 false 时，使用 number，否则用 [number, number]                          | number        | -         |
 | vertical | 	值为 true 时，Slider 为垂直方向                           | boolean        | -         |
-| onAfterChange | 与 onmouseup 触发时机一致，把当前值作为参数传入。                          | function(e)        | -         |
+| onAfterChange | 与 pointerup 触发时机一致，把当前值作为参数传入。                         | function(e)        | -         |
 | onChange | 	当 Slider 的值发生改变时，会触发 onChange 事件，并把改变后的值作为参数传入。                           | function(e)        | -         |
 | tooltipPlacement | 设置 Tooltip 展示位置。参考 Tooltip。                           | string        | -         |
 | tooltipVisible | 值为true时，Tooltip 将会始终显示；否则始终不显示，哪怕在拖拽及移入时。                           | boolean        | -         |

--- a/tests/AntDesign.Tests/Slider/SliderTests.cs
+++ b/tests/AntDesign.Tests/Slider/SliderTests.cs
@@ -5,9 +5,13 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
 using System.Threading.Tasks;
+using AntDesign.JsInterop;
 using Bunit;
 using FluentAssertions;
+using Microsoft.AspNetCore.Components.Web;
+using Moq;
 using Xunit;
 
 namespace AntDesign.Tests.Slider
@@ -196,7 +200,7 @@ namespace AntDesign.Tests.Slider
                 .Add(x => x.HasTooltip, true)
             );
 
-            systemUnderTest.Find(".ant-slider-handle").MouseDown();
+            systemUnderTest.Find(".ant-slider-handle").PointerDown(CreateTouchPointerEvent(1, 30));
 
             systemUnderTest.WaitForAssertion(() =>
             {
@@ -216,7 +220,7 @@ namespace AntDesign.Tests.Slider
                 .Add(x => x.HasTooltip, true)
             );
 
-            systemUnderTest.Find(".ant-slider-handle-1").MouseDown();
+            systemUnderTest.Find(".ant-slider-handle-1").PointerDown(CreateTouchPointerEvent(1, 10));
 
             systemUnderTest.WaitForAssertion(() =>
             {
@@ -237,7 +241,7 @@ namespace AntDesign.Tests.Slider
                 .Add(x => x.HasTooltip, true)
             );
 
-            systemUnderTest.Find(".ant-slider-handle-2").MouseDown();
+            systemUnderTest.Find(".ant-slider-handle-2").PointerDown(CreateTouchPointerEvent(1, 30));
 
             systemUnderTest.WaitForAssertion(() =>
             {
@@ -351,6 +355,97 @@ namespace AntDesign.Tests.Slider
             systemUnderTest.FindAll(".ant-slider-mark-text").Select(x => x.ClassName.Trim()).Should().BeEquivalentTo(expectedClassesInOrder, options => options.WithStrictOrdering());
 
             return Task.CompletedTask;
+        }
+
+        [Fact]
+        public async Task ItShouldDragWithTouchPointer()
+        {
+            Func<JsonElement, Task> pointerMove = null!;
+            Func<JsonElement, Task> pointerUp = null!;
+            Func<JsonElement, Task> pointerCancel = null!;
+
+            MockedDomEventListener
+                .Setup(x => x.AddShared<JsonElement>("window", "pointermove", It.IsAny<Func<JsonElement, Task>>(), false))
+                .Callback<object, string, Func<JsonElement, Task>, bool>((_, _, callback, _) => pointerMove = callback);
+            MockedDomEventListener
+                .Setup(x => x.AddShared<JsonElement>("window", "pointerup", It.IsAny<Func<JsonElement, Task>>(), false))
+                .Callback<object, string, Func<JsonElement, Task>, bool>((_, _, callback, _) => pointerUp = callback);
+            MockedDomEventListener
+                .Setup(x => x.AddShared<JsonElement>("window", "pointercancel", It.IsAny<Func<JsonElement, Task>>(), false))
+                .Callback<object, string, Func<JsonElement, Task>, bool>((_, _, callback, _) => pointerCancel = callback);
+
+            JSInterop.Setup<HtmlElement>(JSInteropConstants.GetDomInfo, _ => true)
+                .SetResult(new HtmlElement { AbsoluteLeft = 0, ClientWidth = 100 });
+
+            double changedValue = -1;
+            double committedValue = -1;
+            int commitCount = 0;
+            var systemUnderTest = RenderComponent<Slider<double>>(parameters => parameters
+                .Add(x => x.DefaultValue, 30)
+                .Add(x => x.HasTooltip, false)
+                .Add(x => x.OnChange, value => changedValue = value)
+                .Add(x => x.OnAfterChange, value =>
+                {
+                    committedValue = value;
+                    commitCount++;
+                })
+            );
+
+            pointerMove.Should().NotBeNull();
+            pointerUp.Should().NotBeNull();
+            pointerCancel.Should().NotBeNull();
+
+            systemUnderTest.Find(".ant-slider-handle").PointerDown(CreateTouchPointerEvent(1, 30));
+
+            await systemUnderTest.InvokeAsync(() => pointerMove(CreateTouchPointerJson(2, 80)));
+            changedValue.Should().Be(-1);
+            await systemUnderTest.InvokeAsync(() => pointerUp(CreateTouchPointerJson(2, 80)));
+            committedValue.Should().Be(-1);
+
+            await systemUnderTest.InvokeAsync(() => pointerMove(CreateTouchPointerJson(1, 60)));
+            changedValue.Should().Be(60);
+            systemUnderTest.Find(".ant-slider-handle").GetAttribute("aria-valuenow").Should().Be("60");
+
+            await systemUnderTest.InvokeAsync(() => pointerUp(CreateTouchPointerJson(1, 60)));
+            committedValue.Should().Be(60);
+            commitCount.Should().Be(1);
+
+            systemUnderTest.Find(".ant-slider-handle").PointerDown(CreateTouchPointerEvent(3, 60));
+            await systemUnderTest.InvokeAsync(() => pointerCancel(CreateTouchPointerJson(3, 60)));
+            await systemUnderTest.InvokeAsync(() => pointerMove(CreateTouchPointerJson(3, 80)));
+
+            changedValue.Should().Be(60);
+            committedValue.Should().Be(60);
+            commitCount.Should().Be(1);
+        }
+
+        private static PointerEventArgs CreateTouchPointerEvent(long pointerId, double position)
+        {
+            return new PointerEventArgs
+            {
+                PointerId = pointerId,
+                PointerType = "touch",
+                IsPrimary = true,
+                Button = 0,
+                Buttons = 1,
+                ClientX = position,
+            };
+        }
+
+        private static JsonElement CreateTouchPointerJson(long pointerId, double position)
+        {
+            return JsonSerializer.SerializeToElement(new
+            {
+                pointerId,
+                pointerType = "touch",
+                isPrimary = true,
+                button = 0,
+                buttons = 1,
+                clientX = position,
+                clientY = 0,
+                pageX = position,
+                pageY = 0,
+            });
         }
     }
 }


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [x] Site / documentation update
- [x] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

Closes #3388

### 💡 Background and solution

Slider currently listens to mouse-specific events for its drag lifecycle, so touch and pen input cannot reliably drag the control.

This change uses Pointer Events for the existing interaction path, tracks the active pointer ID so unrelated pointers are ignored, and resets the interaction on `pointercancel`. The shared window callbacks remain `JsonElement`-based because all supported target frameworks provide the required page coordinates through that path, while older `PointerEventArgs` versions do not expose `PageX` and `PageY`.

There are no public API or visual style changes. Touch dragging was manually verified in a Blazor application consuming a locally built package. Because the appearance is unchanged, no screenshot is included.

### ✅ Validation

- `npm run lint`
- Slider tests: 27 passed on net6
- Full .NET tests with coverage: 3,020 passed on each of net6, net8, net9, and net10.0
- JavaScript tests with coverage: 70 passed
- Full solution build with .NET SDK 10.0.400: 0 errors after the test-only baseline workaround described below

Current `master` (`11397d04`) has four pre-existing `CS1503` errors in `TreeNodeTitle.razor` under the current .NET 10 SDK. The same errors reproduce in a detached, unmodified `master` worktree and in recent upstream PR checks. For local validation only, I parenthesized those four existing Razor directive expressions, ran the build and tests above, and then reverted that file. This PR contains no Tree changes.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Slider now supports dragging with touch and pen input in addition to mouse input. |
| 🇨🇳 Chinese | Slider 现在除鼠标外，也支持通过触摸和触控笔进行拖动。 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed