### PR TITLE
feat(module: modal): support KeepOnRouteChange for service-created di…

### DIFF
--- a/components/modal/config/DialogOptionsBase.cs
+++ b/components/modal/config/DialogOptionsBase.cs
@@ -151,6 +151,11 @@ namespace AntDesign
         /// </summary>
         public bool Rtl { get; set; } = false;
 
+        /// <summary>
+        /// Whether to keep the dialog open when the route changes
+        /// </summary>
+        public bool KeepOnRouteChange { get; set; }
+
         internal bool CreateByService { get; set; }
     }
 }

--- a/components/modal/confirmDialog/ComfirmContainer.razor.cs
+++ b/components/modal/confirmDialog/ComfirmContainer.razor.cs
@@ -43,7 +43,7 @@ namespace AntDesign
 
         private void OnLocationChanged(object sender, EventArgs e)
         {
-            _confirmRefs.Clear();
+            _confirmRefs.RemoveAll(x => !x.Config.KeepOnRouteChange);
             InvokeStateHasChanged();
         }
 

--- a/components/modal/modalDialog/ModalContainer.razor.cs
+++ b/components/modal/modalDialog/ModalContainer.razor.cs
@@ -30,7 +30,7 @@ namespace AntDesign
 
         private void OnLocationChanged(object sender, EventArgs e)
         {
-            _modalRefs.Clear();
+            _modalRefs.RemoveAll(x => !x.Config.KeepOnRouteChange);
             InvokeStateHasChanged();
         }
 

--- a/site/AntDesign.Docs/Demos/Components/Modal/doc/index.en-US.md
+++ b/site/AntDesign.Docs/Demos/Components/Modal/doc/index.en-US.md
@@ -116,6 +116,7 @@ There are some ways to display the information based on the content's nature:
 | Button1Props | the props of the leftmost button in LTR layout  | ButtonProps | Type = ButtonType.Primary, ChildContent is in the same order as ConfirmButtons |
 | Button2Props | the props of the second button on the left is in the LTR layout  | ButtonProps |  ChildContent is in the same order as ConfirmButtons|
 | Button3Props | the props of the rightmost button in LTR layout | ButtonProps | ChildContent is in the same order as ConfirmButtons |
+| KeepOnRouteChange | Whether to keep the dialog open when the route changes | bool | false |
 
 All the `ModalService.Method`s will return a reference, and then we can update and close the modal dialog by the reference.
 

--- a/site/AntDesign.Docs/Demos/Components/Modal/doc/index.zh-CN.md
+++ b/site/AntDesign.Docs/Demos/Components/Modal/doc/index.zh-CN.md
@@ -118,6 +118,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/3StSdUlSH/Modal.svg
 | Button1Props | 在LTR模式中最左侧按钮的属性 | ButtonProps | Type = ButtonType.Primary, ChildContent 与 ConfirmButtons 顺序相同 |
 | Button2Props | 在LTR模式中左边第二个按钮的属性 | ButtonProps |  ChildContent 与 ConfirmButtons 顺序相同|
 | Button3Props | 在LTR模式中左边第三个按钮的属性 | ButtonProps |  ChildContent 与 ConfirmButtons 顺序相同 |
+| KeepOnRouteChange | 路由切换时是否保留弹窗 | bool | false |
 
 以上函数调用后，会返回一个引用，可以通过该引用更新和关闭弹窗。
 

--- a/tests/AntDesign.Tests/Modal/ModalContainerTests.cs
+++ b/tests/AntDesign.Tests/Modal/ModalContainerTests.cs
@@ -1,0 +1,85 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Bunit;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace AntDesign.Tests.Modal
+{
+    public class ModalContainerTests : AntDesignTestBase
+    {
+        public ModalContainerTests()
+        {
+            JSInterop.Mode = JSRuntimeMode.Loose;
+        }
+
+        [Fact]
+        public void ItShouldDestroyServiceModalOnRouteChangeByDefault()
+        {
+            var cut = RenderComponent<AntDesign.ModalContainer>();
+            var modalService = Services.GetRequiredService<AntDesign.ModalService>();
+
+            modalService.CreateModal(new AntDesign.ModalOptions
+            {
+                Content = builder => builder.AddContent(0, "modal content")
+            });
+
+            cut.WaitForAssertion(() => cut.FindAll(".ant-modal").Should().HaveCount(1));
+            NavigationManager.NavigateTo("http://localhost/next");
+            cut.WaitForAssertion(() => cut.FindAll(".ant-modal").Should().BeEmpty());
+        }
+
+        [Fact]
+        public void ItShouldKeepServiceModalOnRouteChangeWhenKeepOnRouteChange()
+        {
+            var cut = RenderComponent<AntDesign.ModalContainer>();
+            var modalService = Services.GetRequiredService<AntDesign.ModalService>();
+
+            modalService.CreateModal(new AntDesign.ModalOptions
+            {
+                Content = builder => builder.AddContent(0, "modal content"),
+                KeepOnRouteChange = true
+            });
+
+            cut.WaitForAssertion(() => cut.FindAll(".ant-modal").Should().HaveCount(1));
+            NavigationManager.NavigateTo("http://localhost/next");
+            cut.WaitForAssertion(() => cut.FindAll(".ant-modal").Should().HaveCount(1));
+        }
+
+        [Fact]
+        public void ItShouldDestroyConfirmOnRouteChangeByDefault()
+        {
+            var cut = RenderComponent<AntDesign.ComfirmContainer>();
+            var modalService = Services.GetRequiredService<AntDesign.ModalService>();
+
+            modalService.Confirm(new AntDesign.ConfirmOptions
+            {
+                Content = "confirm content"
+            });
+
+            cut.WaitForAssertion(() => cut.FindAll(".ant-modal-confirm").Should().HaveCount(1));
+            NavigationManager.NavigateTo("http://localhost/next");
+            cut.WaitForAssertion(() => cut.FindAll(".ant-modal-confirm").Should().BeEmpty());
+        }
+
+        [Fact]
+        public void ItShouldKeepConfirmOnRouteChangeWhenKeepOnRouteChange()
+        {
+            var cut = RenderComponent<AntDesign.ComfirmContainer>();
+            var modalService = Services.GetRequiredService<AntDesign.ModalService>();
+
+            modalService.Confirm(new AntDesign.ConfirmOptions
+            {
+                Content = "confirm content",
+                KeepOnRouteChange = true
+            });
+
+            cut.WaitForAssertion(() => cut.FindAll(".ant-modal-confirm").Should().HaveCount(1));
+            NavigationManager.NavigateTo("http://localhost/next");
+            cut.WaitForAssertion(() => cut.FindAll(".ant-modal-confirm").Should().HaveCount(1));
+        }
+    }
+}


### PR DESCRIPTION
### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

None.

### 💡 Background and solution

Service-created dialogs (`ModalService.CreateModal`, `ModalService.Confirm`, `ConfirmService`) are destroyed on every route change because `ModalContainer` and `ComfirmContainer` clear all dialog refs in their `NavigationManager.LocationChanged` handler.

This PR adds a `KeepOnRouteChange` option (default `false`) to `DialogOptionsBase`, which is inherited by `ModalOptions` and `ConfirmOptions`. When set to `true`, the dialog survives route changes and can still be closed normally through its reference.

```csharp
var modalRef = ModalService.CreateModal(new ModalOptions
{
    Title = "Keep me",
    KeepOnRouteChange = true
});