### PR TITLE
fix(module:date-picker): accept date-only input when ShowTime is enabled

### DIFF
--- a/components/date-picker/internal/DatePickerBase.cs
+++ b/components/date-picker/internal/DatePickerBase.cs
@@ -204,6 +204,22 @@ namespace AntDesign
             }
         }
 
+        private TimeSpan? _defaultTime;
+
+        /// <summary>
+        /// Time of day used to fill the time portion when the user types only a date
+        /// (e.g. <c>01.01.2024</c>) into a picker whose format includes time
+        /// (e.g. <c>dd.MM.yyyy HH:mm</c>). Defaults to <see cref="TimeSpan.Zero"/>
+        /// (00:00:00) when <c>null</c>.
+        /// </summary>
+        /// <default value="null"/>
+        [Parameter]
+        public TimeSpan? DefaultTime
+        {
+            get => _defaultTime;
+            set => _defaultTime = value;
+        }
+
         /// <summary>
         /// Allow clearing the selected value or not
         /// </summary>
@@ -654,10 +670,81 @@ namespace AntDesign
                     ChangeValue(parsedValue, index);
                 }
             }
+            else if (hasMask && TryParseDateWithDefaultTime(newValue, Mask, out DateTime dateWithDefaultTime))
+            {
+                // The user typed a value that matches only the date portion of the mask
+                // (e.g. "01.01.2024" against "dd.MM.yyyy HH:mm"). Fill the time with
+                // DefaultTime (00:00:00 by default) and treat the input as a full pick.
+                if (IsDisabledDate(dateWithDefaultTime))
+                {
+                    return;
+                }
+
+                _pickerStatus[index].SelectedValue = InternalConvert.SetKind<TValue>(dateWithDefaultTime);
+                ChangePickerValue(dateWithDefaultTime, index);
+                ChangeValue(dateWithDefaultTime, index);
+            }
             else
             {
                 _pickerStatus[index].SelectedValue = null;
             }
+        }
+
+        /// <summary>
+        /// Attempts to parse <paramref name="value"/> using only the date portion of
+        /// <paramref name="mask"/> and combine it with <see cref="DefaultTime"/>.
+        /// Used as a fallback when the full mask does not match but the user typed a
+        /// complete date (e.g. <c>01.01.2024</c> against mask <c>dd.MM.yyyy HH:mm</c>).
+        /// </summary>
+        private bool TryParseDateWithDefaultTime(string value, string mask, out DateTime result)
+        {
+            result = default;
+
+            if (string.IsNullOrEmpty(mask) || string.IsNullOrEmpty(value))
+            {
+                return false;
+            }
+
+            var dateOnlyFormat = FormatAnalyzer.GetDateOnlyFormat(mask);
+            if (string.IsNullOrEmpty(dateOnlyFormat))
+            {
+                return false;
+            }
+
+            // Only accept inputs whose length exactly matches the date portion
+            // (plus, optionally, a single trailing separator that belongs to the mask
+            // boundary between date and time, like the space in "dd.MM.yyyy HH:mm").
+            // This avoids mis-firing on partial time inputs like "01.01.2024 1".
+            var maskDateLength = dateOnlyFormat.Length;
+            var accepted = value.Length == maskDateLength
+                || (value.Length == maskDateLength + 1 && mask.Length > maskDateLength && mask[maskDateLength] == value[maskDateLength]);
+            if (!accepted)
+            {
+                return false;
+            }
+
+            // Trim the boundary separator before passing to the date-only analyzer
+            // so it does not bleed into the year partial ("2024 " has length 5
+            // which violates the yyyy max width).
+            var valueForDateParse = value.Length > maskDateLength ? value.Substring(0, maskDateLength) : value;
+
+            var dateAnalyzer = new FormatAnalyzer(dateOnlyFormat, Picker, Locale, CultureInfo);
+            if (!dateAnalyzer.TryPickerStringConvert(valueForDateParse, out DateTime parsedDate))
+            {
+                return false;
+            }
+
+            var time = _defaultTime ?? TimeSpan.Zero;
+            result = new DateTime(
+                parsedDate.Year,
+                parsedDate.Month,
+                parsedDate.Day,
+                time.Hours,
+                time.Minutes,
+                time.Seconds,
+                parsedDate.Millisecond,
+                parsedDate.Kind);
+            return true;
         }
 
         protected virtual void GetIfNotNull(TValue value, int index, Action<DateTime> notNullAction)

--- a/components/date-picker/locale/FormatAnalyzer.cs
+++ b/components/date-picker/locale/FormatAnalyzer.cs
@@ -378,6 +378,51 @@ namespace AntDesign.Datepicker.Locale
             return true;
         }
 
+        /// <summary>
+        /// Returns the part of <paramref name="format"/> that contains only date
+        /// partials and their separators (everything before the first time-related
+        /// character: <c>h</c>, <c>H</c>, <c>m</c>, <c>s</c>, <c>t</c>). Trailing
+        /// separators between the date and time parts are trimmed so the result is
+        /// a valid standalone date format.
+        /// </summary>
+        /// <remarks>
+        /// Used to build a date-only <see cref="FormatAnalyzer"/> so we can parse
+        /// partial inputs that only contain a date (e.g. when a user types
+        /// <c>01.01.2024</c> into a field with format <c>dd.MM.yyyy HH:mm</c>).
+        /// Returns <c>null</c> if the format is null or empty, or contains no date
+        /// partials.
+        /// </remarks>
+        public static string GetDateOnlyFormat(string format)
+        {
+            if (string.IsNullOrEmpty(format))
+                return null;
+
+            var inDate = false;
+            var cutIndex = format.Length;
+            for (var i = 0; i < format.Length; i++)
+            {
+                var c = format[i];
+                if (c == 'h' || c == 'H' || c == 'm' || c == 's' || c == 't')
+                {
+                    cutIndex = i;
+                    break;
+                }
+
+                if (c == 'd' || c == 'M' || c == 'y')
+                {
+                    inDate = true;
+                }
+            }
+
+            if (!inDate)
+            {
+                return null;
+            }
+
+            var datePortion = format.Substring(0, cutIndex);
+            return datePortion.TrimEnd();
+        }
+
         public (bool, DateTime) TryParseYear(string pickerString)
         {
             if (IsFullString(pickerString))

--- a/tests/AntDesign.Tests/DatePicker/DatePickerKeyboardInputTests.razor
+++ b/tests/AntDesign.Tests/DatePicker/DatePickerKeyboardInputTests.razor
@@ -195,4 +195,92 @@
         cut.Instance.Value.Should().Be(newValue);
         newValue.Offset.Should().Be(value.Offset);
     }
+
+    [Fact]
+    public void Typing_date_only_with_showTime_and_mask_uses_DefaultTime_zero()
+    {
+        //Arrange
+        JSInterop.SetupVoid(JSInteropConstants.AddPreventKeys, _ => true);
+        JSInterop.SetupVoid(JSInteropConstants.Focus, _ => true);
+
+        DateTime? value = null;
+        const string mask = "dd.MM.yyyy HH:mm";
+        var cut = Render<AntDesign.DatePicker<DateTime?>>(
+			@<DatePicker @bind-Value="value" TValue="DateTime?" ShowTime="true" Mask="@mask" />);
+
+        //Act - type only the date part, then press Enter to commit.
+        var input = cut.Find("input");
+        input.Input("01.03.2024");
+        input.KeyDown("Enter");
+
+        //Assert - date is accepted and time defaults to 00:00.
+        cut.Instance.Value.Should().Be(new DateTime(2024, 3, 1, 0, 0, 0));
+        value.Should().Be(new DateTime(2024, 3, 1, 0, 0, 0));
+    }
+
+    [Fact]
+    public void Typing_date_only_with_DefaultTime_uses_provided_time()
+    {
+        //Arrange
+        JSInterop.SetupVoid(JSInteropConstants.AddPreventKeys, _ => true);
+        JSInterop.SetupVoid(JSInteropConstants.Focus, _ => true);
+
+        DateTime? value = null;
+        const string mask = "dd.MM.yyyy HH:mm";
+        var defaultTime = new TimeSpan(9, 30, 0);
+        var cut = Render<AntDesign.DatePicker<DateTime?>>(
+			@<DatePicker @bind-Value="value" TValue="DateTime?" ShowTime="true" Mask="@mask" DefaultTime="defaultTime" />);
+
+        //Act
+        var input = cut.Find("input");
+        input.Input("15.07.2024");
+        input.KeyDown("Enter");
+
+        //Assert
+        cut.Instance.Value.Should().Be(new DateTime(2024, 7, 15, 9, 30, 0));
+        value.Should().Be(new DateTime(2024, 7, 15, 9, 30, 0));
+    }
+
+    [Fact]
+    public void Typing_partial_time_input_does_not_replace_existing_value_on_blur()
+    {
+        //Arrange
+        JSInterop.SetupVoid(JSInteropConstants.AddPreventKeys, _ => true);
+
+        DateTime value = new DateTime(2020, 5, 10, 12, 0, 0);
+        const string mask = "dd.MM.yyyy HH:mm";
+        var cut = Render<AntDesign.DatePicker<DateTime>>(
+			@<DatePicker @bind-Value="value" ShowTime="true" Mask="@mask" />);
+
+        //Act - type something that does not match the date portion of the mask; blur should keep the original value.
+        var input = cut.Find("input");
+        input.Input("32");  // invalid day, does not satisfy the date portion
+        input.Blur();
+
+        //Assert
+        cut.Instance.Value.Should().Be(new DateTime(2020, 5, 10, 12, 0, 0));
+        value.Should().Be(new DateTime(2020, 5, 10, 12, 0, 0));
+    }
+
+    [Fact]
+    public void DateOnly_input_with_showTime_and_mask_does_not_clear_value_on_blur()
+    {
+        //Regression test for the original bug report: with
+        //ShowTime="true", Format="dd.MM.yyyy HH:mm", Mask="dd.MM.yyyy HH:mm",
+        //typing a date without time used to clear the field instead of accepting
+        //the date with default 00:00 time.
+        JSInterop.SetupVoid(JSInteropConstants.AddPreventKeys, _ => true);
+
+        DateTime? value = null;
+        const string mask = "dd.MM.yyyy HH:mm";
+        var cut = Render<AntDesign.DatePicker<DateTime?>>(
+			@<DatePicker @bind-Value="value" TValue="DateTime?" ShowTime="true" Format="@mask" Mask="@mask" />);
+
+        var input = cut.Find("input");
+        input.Input("05.06.2024");
+        input.Blur();
+
+        cut.Instance.Value.Should().Be(new DateTime(2024, 6, 5, 0, 0, 0));
+        value.Should().Be(new DateTime(2024, 6, 5, 0, 0, 0));
+    }
 }

--- a/tests/AntDesign.Tests/DatePicker/locale/FormatAnalyzerTests.cs
+++ b/tests/AntDesign.Tests/DatePicker/locale/FormatAnalyzerTests.cs
@@ -402,5 +402,21 @@ namespace AntDesign.Tests.DatePicker.Locale
             new object[] { "yyyy", "yyyy-Q0","2020/Q1", false, null!},
             new object[] { "yyyy", "yyyy-Q0", "2020 Q1", false, null!},
         };
+
+        [Theory]
+        [InlineData("dd.MM.yyyy HH:mm", "dd.MM.yyyy")]
+        [InlineData("yyyy-MM-dd HH:mm:ss", "yyyy-MM-dd")]
+        [InlineData("dd.MM.yyyy", "dd.MM.yyyy")]
+        [InlineData("yyyyMMdd", "yyyyMMdd")]
+        [InlineData("M/yyyy/d H:mm:s", "M/yyyy/d")]
+        [InlineData("yyyy年M月d日 HH时mm分ss秒", "yyyy年M月d日")]
+        [InlineData("", null)]
+        [InlineData(null, null)]
+        [InlineData("HH:mm", null)]
+        public void GetDateOnlyFormat_ShouldReturnDatePortion(string fullFormat, string expected)
+        {
+            var actual = FormatAnalyzer.GetDateOnlyFormat(fullFormat);
+            Assert.Equal(expected, actual);
+        }
     }
 }


### PR DESCRIPTION
### 🤔 This is a ...

- [x] Bug fix

### 🔗 Related issue link

_No upstream issue filed by the reporter; surfaced from a user report._

### 💡 Background and solution

**Reproduction**

```razor
<DatePicker TValue="DateTime?"
            ShowTime="@true"
            Format="dd.MM.yyyy HH:mm"
            Mask="dd.MM.yyyy HH:mm"
            @bind-Value="date" />
```

1. Type a date into the input without time, e.g. `01.01.2024`.
2. Blur / press Enter.
3. The field clears instead of keeping the date with `00:00`.
4. Open the dropdown — the calendar is on the default date, not on `01.01.2024`.

**Root cause**

`DatePickerBase.OnInput` calls `FormatAnalyzer.TryPickerStringConvert` which
rejects any input whose length is shorter than the full format (`dd.MM.yyyy HH:mm`
= 16 chars). For a mask-converted value of `01.01.2024 ` (11 chars) the parse
fails, `_pickerStatus.SelectedValue` is set to `null`, and neither
`ChangePickerValue` nor `ChangeValue` runs. On blur the field is rebuilt from
the (still-null) value, and the calendar stays on the default.

**Fix**

In `DatePickerBase.OnInput`, when the full mask parse fails, try to parse just
the date portion of the mask and combine it with a new `DefaultTime` parameter
(defaults to `TimeSpan.Zero` = `00:00:00`). On success, run the same
`SelectedValue` → `ChangePickerValue` → `ChangeValue` path as a complete input,
so the field keeps the date and the calendar syncs to it.

The `DefaultTime` parameter is exposed publicly so callers can pick a different
fallback time:

```razor
<DatePicker ShowTime="true"
            Format="dd.MM.yyyy HH:mm"
            Mask="dd.MM.yyyy HH:mm"
            DefaultTime="@(new TimeSpan(9, 0, 0))"
            @bind-Value="date" />
```

`FormatAnalyzer.GetDateOnlyFormat(string)` is a new public helper that returns
the date portion of a format (everything before the first `h/H/m/s/t`, with
trailing separators trimmed). It is reused internally by the fallback but is
also available for any future caller that needs the same extraction.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | `DatePicker`: typing a date without time no longer clears the field when `ShowTime` is enabled together with a `Format`/`Mask` that includes time. The missing time portion is now filled with the new `DefaultTime` parameter (default `00:00:00`). The calendar also syncs with the typed date. |
| 🇨🇳 Chinese | `DatePicker`: 在 `ShowTime` 与含时间的 `Format`/`Mask` 组合下，只输入日期不再清空字段，未填的时间部分将使用新增的 `DefaultTime` 参数（默认 `00:00:00`）填充。日历也会同步到所输入的日期。 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed _(the parameter is self-documented via XML doc; a demo update can be added if the maintainers want it)_
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
